### PR TITLE
spark: add Lakehouse Hive Catalog handling

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -48,6 +48,7 @@ public class AlterTableRenameCommandVisitor
             .dataset(di)
             .schema(table.schema())
             .lifecycleStateChange(LifecycleStateChange.RENAME, previousName, di.getNamespace())
+            .catalog(table.identifier())
             .build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
@@ -8,7 +8,7 @@ package io.openlineage.spark.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -29,7 +29,7 @@ public class InsertIntoDataSourceDirVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoDataSourceDirCommand command = (InsertIntoDataSourceDirCommand) x;
     // URI is required by the InsertIntoDataSourceDirCommand
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> builder =
         outputDataset()
             .sparkDatasetBuilder()
             .dataset(command.storage().locationUri().get())

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
@@ -13,7 +13,7 @@ import io.openlineage.spark.agent.util.OpenLineageAbstractPartialFunction;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkOutputDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkOutputDatasetBuilder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -53,8 +53,7 @@ public class InsertIntoDataSourceVisitor
               ds.getFacets().getAdditionalProperties().putAll(facetsMap.build());
               if (command.overwrite()) {
                 // rebuild whole dataset with a LifecycleStateChange facet added
-                SparkOutputDatasetCompositeFacetsBuilder builder =
-                    new SparkOutputDatasetCompositeFacetsBuilder(context);
+                SparkOutputDatasetBuilder builder = new SparkOutputDatasetBuilder(context);
                 return builder
                     .fromBuilder(DatasetFacetsUtils.copyToBuilder(context, ds.getFacets()))
                     .lifecycleStateChange(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
@@ -9,7 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +36,7 @@ public class InsertIntoDirVisitor
     return optionalUri
         .map(
             uri -> {
-              SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+              SparkDatasetBuilder<OpenLineage.OutputDataset> builder =
                   outputDataset().sparkDatasetBuilder().dataset(uri).schema(cmd.child().schema());
               if (cmd.overwrite()) {
                 builder.lifecycleStateChange(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -10,7 +10,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +36,7 @@ public class InsertIntoHadoopFsRelationVisitor
     return getDatasetIdentifier(command)
         .map(
             di -> {
-              SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+              SparkDatasetBuilder<OpenLineage.OutputDataset> builder =
                   outputDataset()
                       .sparkDatasetBuilder()
                       .dataset(di)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
@@ -11,7 +11,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +38,7 @@ public class InsertIntoHiveDirVisitor
     return optionalUri
         .map(
             uri -> {
-              SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+              SparkDatasetBuilder<OpenLineage.OutputDataset> builder =
                   outputDataset()
                       .sparkDatasetBuilder()
                       .dataset(uri)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
@@ -9,7 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class InsertIntoHiveTableVisitor
 
     InsertIntoHiveTable cmd = (InsertIntoHiveTable) x;
     CatalogTable table = cmd.table();
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> builder =
         outputDataset().sparkDatasetBuilder().dataset(table).schema(table.schema()).catalog();
     if (cmd.overwrite()) {
       builder.lifecycleStateChange(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -18,7 +18,7 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -136,7 +136,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
     DatasetIdentifier di =
         PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get());
 
-    SparkDatasetCompositeFacetsBuilder<D> sparkBuilder =
+    SparkDatasetBuilder<D> sparkBuilder =
         datasetFactory.sparkDatasetBuilder().dataset(di).schema(logRel.schema());
     DatasetCompositeFacetsBuilder datasetFacetsBuilder = sparkBuilder.getInner();
 
@@ -258,7 +258,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
       HadoopFsRelation relation,
       Optional<OpenLineage.DatasetVersionDatasetFacet> datasetVersion,
       Optional<OpenLineage.InputStatisticsInputDatasetFacet> inputStats) {
-    SparkDatasetCompositeFacetsBuilder<D> b =
+    SparkDatasetBuilder<D> b =
         datasetFactory.sparkDatasetBuilder().dataset(uri).schema(relation.schema());
     datasetVersion.ifPresent(b::version);
     inputStats.ifPresent(s -> b.getInner().getInputFacets().inputStatistics(s));

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
@@ -11,7 +11,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.SaveMode;
@@ -64,7 +64,7 @@ public class OptimizedCreateHiveTableAsSelectCommandVisitor
         PathUtils.fromCatalogTable(table, context.getSparkSession().get());
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
 
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> builder =
         outputDataset().sparkDatasetBuilder().dataset(datasetIdentifier).schema(schema);
     if ((SaveMode.Overwrite == command.mode())) {
       builder.lifecycleStateChange(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -8,11 +8,23 @@ package io.openlineage.spark.agent.util;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.NoSuchElementException;
 import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.spark.SparkConf;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
+import org.apache.spark.sql.hive.HiveSessionCatalog;
+import scala.Option;
 
+@Slf4j
 public class CatalogDatasetFacetUtils {
 
   public static Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacetForHive(
@@ -21,27 +33,94 @@ public class CatalogDatasetFacetUtils {
         .getSparkContext()
         .flatMap(
             sparkContext -> {
-              SparkConf sparkConf = sparkContext.getConf();
-              Configuration hadoopConf = sparkContext.hadoopConfiguration();
-              return PathUtils.getWarehouseLocation(sparkConf, hadoopConf)
-                  .map(FilesystemDatasetUtils::fromLocation)
-                  .map(FilesystemDatasetUtils::toLocation)
-                  .map(location -> Pair.of(sparkContext, location));
-            })
-        .map(
-            pair -> {
               OpenLineage.CatalogDatasetFacetBuilder builder =
                   context
                       .getOpenLineage()
                       .newCatalogDatasetFacetBuilder()
-                      .name("default")
                       .framework("hive")
-                      .type("hive")
                       .source("spark");
-              PathUtils.getMetastoreUri(pair.getLeft())
-                  .map(PathUtils::prepareHiveUri)
-                  .ifPresent(uri -> builder.metadataUri(uri.toString()));
-              return builder.warehouseUri(pair.getRight().toString()).build();
+              Optional<URI> warehouseUri;
+              if (GoogleCloudPlatformUtils.isBigLakeHiveCatalog(sparkContext.conf())) {
+                Option<String> catalogName =
+                    sparkContext.getConf().getOption("spark.hive.metastore.blms.catalog.default");
+                if (!catalogName.isDefined()) {
+                  log.warn(
+                      "Big Lake Hive Catalog detected, but no default catalog configured. Please set spark.hive.metastore.blms.catalog.default to enable catalog dataset facets");
+                  return Optional.empty();
+                }
+                warehouseUri =
+                    SparkConfUtils.findHadoopConfigKey(
+                            sparkContext.hadoopConfiguration(), "hive.metastore.warehouse.dir")
+                        .map(URI::create);
+                builder.name(catalogName.get()).type("gcp_lakehouse");
+                sparkContext
+                    .getConf()
+                    .getOption("spark.hive.metastore.blms.project.id")
+                    .foreach(
+                        projectId ->
+                            builder.catalogProperties(
+                                context
+                                    .getOpenLineage()
+                                    .newCatalogDatasetFacetCatalogPropertiesBuilder()
+                                    .put("gcp_project_id", projectId)
+                                    .build()));
+              } else {
+                warehouseUri =
+                    PathUtils.getWarehouseLocation(
+                        sparkContext.getConf(), sparkContext.hadoopConfiguration());
+                builder.name("default").type("hive");
+                PathUtils.getMetastoreUri(sparkContext)
+                    .map(PathUtils::prepareHiveUri)
+                    .ifPresent(uri -> builder.metadataUri(uri.toString()));
+              }
+
+              if (!warehouseUri.isPresent()) {
+                log.warn(
+                    "Unable to determine warehouse URI for Hive catalog, skipping catalog dataset facet");
+              }
+              return warehouseUri
+                  .map(FilesystemDatasetUtils::fromLocation)
+                  .map(FilesystemDatasetUtils::toLocation)
+                  .map(location -> builder.warehouseUri(location.toString()).build());
             });
+  }
+
+  public static boolean isHiveCatalog(SparkSession session, TableIdentifier identifier) {
+    return getCatalogPlugin(session, identifier)
+        .map(catalogPlugin -> isHiveCatalog(session.sparkContext(), catalogPlugin))
+        .orElse(false);
+  }
+
+  @SuppressWarnings("PMD")
+  public static boolean isHiveCatalog(SparkContext context, CatalogPlugin catalogPlugin) {
+    if ("hive".equals(context.conf().get("spark.sql.catalogImplementation", ""))
+        && catalogPlugin instanceof V2SessionCatalog) {
+
+      V2SessionCatalog v2Catalog = ((V2SessionCatalog) catalogPlugin);
+      Field catalog = FieldUtils.getField(V2SessionCatalog.class, "catalog", true);
+      catalog.setAccessible(true);
+      try {
+        return catalog.get(v2Catalog) instanceof HiveSessionCatalog;
+      } catch (IllegalAccessException e) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  public static Optional<CatalogPlugin> getCatalogPlugin(
+      SparkSession session, TableIdentifier identifier) {
+    try {
+      //noinspection unchecked
+      return Optional.ofNullable(
+              ((Option<String>) MethodUtils.invokeMethod(identifier, "catalog")).get())
+          .map(catalogName -> session.sessionState().catalogManager().catalog(catalogName));
+    } catch (NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchElementException e) {
+      //            log.debug("No catalog name, cannot add catalog/storage facets");
+      return Optional.empty();
+    }
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -86,7 +86,8 @@ public class CatalogDatasetFacetUtils {
   }
 
   public static boolean isHiveCatalog(SparkSession session, TableIdentifier identifier) {
-    return "hive".equals(session.sparkContext().conf().get("spark.sql.catalogImplementation", ""))
+    return "hive"
+            .equals(session.sparkContext().getConf().get("spark.sql.catalogImplementation", ""))
         && getCatalogPlugin(session, identifier)
             .map(catalogPlugin -> isHiveCatalog(session.sparkContext(), catalogPlugin))
             .orElse(false);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -86,16 +86,15 @@ public class CatalogDatasetFacetUtils {
   }
 
   public static boolean isHiveCatalog(SparkSession session, TableIdentifier identifier) {
-    return getCatalogPlugin(session, identifier)
-        .map(catalogPlugin -> isHiveCatalog(session.sparkContext(), catalogPlugin))
-        .orElse(false);
+    return "hive".equals(session.sparkContext().conf().get("spark.sql.catalogImplementation", ""))
+        && getCatalogPlugin(session, identifier)
+            .map(catalogPlugin -> isHiveCatalog(session.sparkContext(), catalogPlugin))
+            .orElse(false);
   }
 
   @SuppressWarnings("PMD")
-  public static boolean isHiveCatalog(SparkContext context, CatalogPlugin catalogPlugin) {
-    if ("hive".equals(context.conf().get("spark.sql.catalogImplementation", ""))
-        && catalogPlugin instanceof V2SessionCatalog) {
-
+  private static boolean isHiveCatalog(SparkContext context, CatalogPlugin catalogPlugin) {
+    if (catalogPlugin instanceof V2SessionCatalog) {
       V2SessionCatalog v2Catalog = ((V2SessionCatalog) catalogPlugin);
       Field catalog = FieldUtils.getField(V2SessionCatalog.class, "catalog", true);
       catalog.setAccessible(true);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtils.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.spark.SparkConf;
+
+@Slf4j
+public class GoogleCloudPlatformUtils {
+  public static boolean isBigLakeHiveCatalog(SparkConf conf) {
+    try {
+      // To use Big Lake Hive Catalog you have to use custom implementation of HiveConf that
+      // contains this enum
+      // if the enum is present, you can set the custom client factory
+      String name = HiveConf.ConfVars.valueOf("spark.hive.metastore.client.factory.class").name();
+      return conf.getOption(name)
+          .exists("com.google.cloud.spark.biglake.hive.BigLakeHiveClientFactory"::equals);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -20,7 +20,6 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
-import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.internal.StaticSQLConf;
 
 @Slf4j
@@ -59,20 +58,21 @@ public class PathUtils {
   @SneakyThrows
   public static DatasetIdentifier fromCatalogTable(
       CatalogTable catalogTable, SparkSession sparkSession, URI location) {
-
-    return fromTableIdentifier(
-        catalogTable.identifier(),
-        sparkSession.sparkContext(),
-        location,
-        CatalogDatasetFacetUtils.getCatalogPlugin(sparkSession, catalogTable.identifier()));
+    SparkContext sparkContext = sparkSession.sparkContext();
+    if (CatalogDatasetFacetUtils.isHiveCatalog(sparkSession, catalogTable.identifier())
+        && GoogleCloudPlatformUtils.isBigLakeHiveCatalog(sparkContext.getConf())) {
+      return fromURI(location)
+          .withSymlink(
+              nameFromTableIdentifier(catalogTable.identifier()),
+              "gcp_lakehouse",
+              DatasetIdentifier.SymlinkType.TABLE);
+    }
+    return fromTableIdentifier(catalogTable.identifier(), sparkContext, location);
   }
 
   @SneakyThrows
   public static DatasetIdentifier fromTableIdentifier(
-      TableIdentifier identifier,
-      SparkContext sparkContext,
-      URI location,
-      Optional<CatalogPlugin> catalogPlugin) {
+      TableIdentifier identifier, SparkContext sparkContext, URI location) {
     // perform URL normalization
     DatasetIdentifier locationDataset = fromURI(location);
     URI locationUri = FilesystemDatasetUtils.toLocation(locationDataset);
@@ -90,11 +90,6 @@ public class PathUtils {
       String tableName = nameFromTableIdentifier(identifier, "/");
       symlinkDataset =
           Optional.of(new DatasetIdentifier(GLUE_TABLE_PREFIX + tableName, glueArn.get()));
-    } else if (catalogPlugin.isPresent()
-        && CatalogDatasetFacetUtils.isHiveCatalog(sparkContext, catalogPlugin.get())
-        && GoogleCloudPlatformUtils.isBigLakeHiveCatalog(sparkContext.getConf())) {
-      String tableName = nameFromTableIdentifier(identifier);
-      symlinkDataset = Optional.of(new DatasetIdentifier(tableName, "gcp_lakehouse"));
     } else if (metastoreUri.isPresent()) {
       // dealing with Hive tables
       URI hiveUri = prepareHiveUri(metastoreUri.get());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -20,6 +20,7 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.internal.StaticSQLConf;
 
 @Slf4j
@@ -58,12 +59,20 @@ public class PathUtils {
   @SneakyThrows
   public static DatasetIdentifier fromCatalogTable(
       CatalogTable catalogTable, SparkSession sparkSession, URI location) {
-    return fromTableIdentifier(catalogTable.identifier(), sparkSession.sparkContext(), location);
+
+    return fromTableIdentifier(
+        catalogTable.identifier(),
+        sparkSession.sparkContext(),
+        location,
+        CatalogDatasetFacetUtils.getCatalogPlugin(sparkSession, catalogTable.identifier()));
   }
 
   @SneakyThrows
   public static DatasetIdentifier fromTableIdentifier(
-      TableIdentifier identifier, SparkContext sparkContext, URI location) {
+      TableIdentifier identifier,
+      SparkContext sparkContext,
+      URI location,
+      Optional<CatalogPlugin> catalogPlugin) {
     // perform URL normalization
     DatasetIdentifier locationDataset = fromURI(location);
     URI locationUri = FilesystemDatasetUtils.toLocation(locationDataset);
@@ -75,13 +84,17 @@ public class PathUtils {
 
     Optional<URI> metastoreUri = getMetastoreUri(sparkContext);
     Optional<String> glueArn = AwsUtils.getGlueArn(sparkConf, hadoopConf);
-
     if (glueArn.isPresent()) {
       // Even if glue catalog is used, it will have a hive metastore URI
       // Use ARN format 'arn:aws:glue:{region}:{account_id}:table/{database}/{table}'
       String tableName = nameFromTableIdentifier(identifier, "/");
       symlinkDataset =
           Optional.of(new DatasetIdentifier(GLUE_TABLE_PREFIX + tableName, glueArn.get()));
+    } else if (catalogPlugin.isPresent()
+        && CatalogDatasetFacetUtils.isHiveCatalog(sparkContext, catalogPlugin.get())
+        && GoogleCloudPlatformUtils.isBigLakeHiveCatalog(sparkContext.getConf())) {
+      String tableName = nameFromTableIdentifier(identifier);
+      symlinkDataset = Optional.of(new DatasetIdentifier(tableName, "gcp_lakehouse"));
     } else if (metastoreUri.isPresent()) {
       // dealing with Hive tables
       URI hiveUri = prepareHiveUri(metastoreUri.get());
@@ -111,12 +124,12 @@ public class PathUtils {
       }
     }
 
-    if (symlinkDataset.isPresent()) {
-      locationDataset.withSymlink(
-          symlinkDataset.get().getName(),
-          symlinkDataset.get().getNamespace(),
-          DatasetIdentifier.SymlinkType.TABLE);
-    }
+    symlinkDataset.ifPresent(
+        datasetIdentifier ->
+            locationDataset.withSymlink(
+                datasetIdentifier.getName(),
+                datasetIdentifier.getNamespace(),
+                DatasetIdentifier.SymlinkType.TABLE));
 
     return locationDataset;
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -42,10 +42,9 @@ public abstract class DatasetFactory<D extends Dataset> {
     this.namespaceResolver = new DatasetNamespaceCombinedResolver(context.getOpenLineageConfig());
   }
 
-  public abstract SparkDatasetCompositeFacetsBuilder<D> sparkDatasetBuilder();
+  public abstract SparkDatasetBuilder<D> sparkDatasetBuilder();
 
-  public abstract SparkDatasetCompositeFacetsBuilder<D> sparkDatasetBuilder(
-      DatasetCompositeFacetsBuilder inner);
+  public abstract SparkDatasetBuilder<D> sparkDatasetBuilder(DatasetCompositeFacetsBuilder inner);
 
   public abstract void buildVersionFacets(
       DatasetCompositeFacetsBuilder facetsBuilder, String version);
@@ -65,14 +64,14 @@ public abstract class DatasetFactory<D extends Dataset> {
       }
 
       @Override
-      public SparkDatasetCompositeFacetsBuilder<InputDataset> sparkDatasetBuilder() {
-        return new SparkInputDatasetCompositeFacetsBuilder(context);
+      public SparkDatasetBuilder<InputDataset> sparkDatasetBuilder() {
+        return new SparkInputDatasetBuilder(context);
       }
 
       @Override
-      public SparkDatasetCompositeFacetsBuilder<InputDataset> sparkDatasetBuilder(
+      public SparkDatasetBuilder<InputDataset> sparkDatasetBuilder(
           DatasetCompositeFacetsBuilder inner) {
-        return new SparkInputDatasetCompositeFacetsBuilder(context, inner);
+        return new SparkInputDatasetBuilder(context, inner);
       }
     };
   }
@@ -92,14 +91,14 @@ public abstract class DatasetFactory<D extends Dataset> {
       }
 
       @Override
-      public SparkDatasetCompositeFacetsBuilder<OutputDataset> sparkDatasetBuilder() {
-        return new SparkOutputDatasetCompositeFacetsBuilder(context);
+      public SparkDatasetBuilder<OutputDataset> sparkDatasetBuilder() {
+        return new SparkOutputDatasetBuilder(context);
       }
 
       @Override
-      public SparkDatasetCompositeFacetsBuilder<OutputDataset> sparkDatasetBuilder(
+      public SparkDatasetBuilder<OutputDataset> sparkDatasetBuilder(
           DatasetCompositeFacetsBuilder inner) {
-        return new SparkOutputDatasetCompositeFacetsBuilder(context, inner);
+        return new SparkOutputDatasetBuilder(context, inner);
       }
     };
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkDatasetBuilder.java
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.StructType;
  * DatasetCompositeFacetsBuilder} is accessible via {@link #getInner()} for passing to existing APIs
  * that still require it.
  */
-public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.Dataset> {
+public abstract class SparkDatasetBuilder<T extends OpenLineage.Dataset> {
 
   protected final OpenLineageContext context;
   protected final DatasetNamespaceCombinedResolver namespaceResolver;
@@ -49,18 +49,17 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
   @Getter protected String name;
   @Getter protected String namespace;
 
-  public SparkDatasetCompositeFacetsBuilder(OpenLineageContext context) {
+  public SparkDatasetBuilder(OpenLineageContext context) {
     this(context, new DatasetCompositeFacetsBuilder(context.getOpenLineage()));
   }
 
-  public SparkDatasetCompositeFacetsBuilder(
-      OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
+  public SparkDatasetBuilder(OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
     this.context = context;
     this.namespaceResolver = new DatasetNamespaceCombinedResolver(context.getOpenLineageConfig());
     this.inner = inner;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataset(DatasetIdentifier datasetIdentifier) {
+  public SparkDatasetBuilder<T> dataset(DatasetIdentifier datasetIdentifier) {
     this.name = datasetIdentifier.getName();
     this.namespace = datasetIdentifier.getNamespace();
     dataSource(datasetIdentifier.getNamespace());
@@ -68,19 +67,19 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataset(String name, String namespace) {
+  public SparkDatasetBuilder<T> dataset(String name, String namespace) {
     return dataset(new DatasetIdentifier(name, namespace));
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataset(String name, URI outputPath) {
+  public SparkDatasetBuilder<T> dataset(String name, URI outputPath) {
     return dataset(new DatasetIdentifier(name, PlanUtils.namespaceUri(outputPath)));
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataset(URI outputPath) {
+  public SparkDatasetBuilder<T> dataset(URI outputPath) {
     return dataset(PathUtils.fromURI(outputPath));
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataset(CatalogTable catalogTable) {
+  public SparkDatasetBuilder<T> dataset(CatalogTable catalogTable) {
     if (context.getSparkSession().isPresent()) {
       dataset(PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()));
       catalog(catalogTable.identifier());
@@ -88,12 +87,12 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> symlink(SymlinksDatasetFacet symlinksFacet) {
+  public SparkDatasetBuilder<T> symlink(SymlinksDatasetFacet symlinksFacet) {
     inner.getFacets().symlinks(symlinksFacet);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> symlink(List<DatasetIdentifier.Symlink> symlinks) {
+  public SparkDatasetBuilder<T> symlink(List<DatasetIdentifier.Symlink> symlinks) {
     if (!symlinks.isEmpty()) {
       List<OpenLineage.SymlinksDatasetFacetIdentifiers> symlinkIdentifiers =
           symlinks.stream()
@@ -117,31 +116,31 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> schema(SchemaDatasetFacet schemaFacet) {
+  public SparkDatasetBuilder<T> schema(SchemaDatasetFacet schemaFacet) {
     inner.getFacets().schema(schemaFacet);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> schema(StructType schema) {
+  public SparkDatasetBuilder<T> schema(StructType schema) {
     return schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema));
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataSource(DatasourceDatasetFacet datasourceFacet) {
+  public SparkDatasetBuilder<T> dataSource(DatasourceDatasetFacet datasourceFacet) {
     inner.getFacets().dataSource(datasourceFacet);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> dataSource(String namespace) {
+  public SparkDatasetBuilder<T> dataSource(String namespace) {
     return dataSource(
         PlanUtils.datasourceFacet(context.getOpenLineage(), namespaceResolver.resolve(namespace)));
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> catalog(CatalogDatasetFacet catalogFacet) {
+  public SparkDatasetBuilder<T> catalog(CatalogDatasetFacet catalogFacet) {
     inner.getFacets().catalog(catalogFacet);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> catalog(TableIdentifier identifier) {
+  public SparkDatasetBuilder<T> catalog(TableIdentifier identifier) {
     if (context.getSparkSession().isPresent()) {
       if (CatalogDatasetFacetUtils.isHiveCatalog(context.getSparkSession().get(), identifier)) {
         catalog();
@@ -150,28 +149,27 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> catalog() {
+  public SparkDatasetBuilder<T> catalog() {
     CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context).ifPresent(this::catalog);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> symlinks(SymlinksDatasetFacet symlinksFacet) {
+  public SparkDatasetBuilder<T> symlinks(SymlinksDatasetFacet symlinksFacet) {
     inner.getFacets().symlinks(symlinksFacet);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+  public SparkDatasetBuilder<T> lifecycleStateChange(
       LifecycleStateChangeDatasetFacet lifecycleFacet) {
     inner.getFacets().lifecycleStateChange(lifecycleFacet);
     return this;
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
-      LifecycleStateChange lifecycleStateChange) {
+  public SparkDatasetBuilder<T> lifecycleStateChange(LifecycleStateChange lifecycleStateChange) {
     return lifecycleStateChange(lifecycleStateChange, null);
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+  public SparkDatasetBuilder<T> lifecycleStateChange(
       LifecycleStateChange lifecycleStateChange, String previousName, String previousNamespace) {
     return lifecycleStateChange(
         lifecycleStateChange,
@@ -183,7 +181,7 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
             .build());
   }
 
-  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+  public SparkDatasetBuilder<T> lifecycleStateChange(
       LifecycleStateChange lifecycleStateChange,
       OpenLineage.LifecycleStateChangeDatasetFacetPreviousIdentifier previousIdentifier) {
     return lifecycleStateChange(
@@ -199,19 +197,19 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
    * Sets the dataset version facet. For output datasets, also triggers vendor-specific output facet
    * builders (e.g. Iceberg snapshot facets). Subclasses may override to provide richer behaviour.
    */
-  public SparkDatasetCompositeFacetsBuilder<T> version(String version) {
+  public SparkDatasetBuilder<T> version(String version) {
     DatasetVersionUtils.buildVersionFacets(context, inner, version);
     return this;
   }
 
   /** Sets a pre-built {@link DatasetVersionDatasetFacet} directly on the facets builder. */
-  public SparkDatasetCompositeFacetsBuilder<T> version(DatasetVersionDatasetFacet versionFacet) {
+  public SparkDatasetBuilder<T> version(DatasetVersionDatasetFacet versionFacet) {
     inner.getFacets().version(versionFacet);
     return this;
   }
 
   public abstract T build();
 
-  public abstract SparkDatasetCompositeFacetsBuilder<T> fromBuilder(
+  public abstract SparkDatasetBuilder<T> fromBuilder(
       OpenLineage.DatasetFacetsBuilder facetsBuilder);
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkDatasetCompositeFacetsBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkDatasetCompositeFacetsBuilder.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.types.StructType;
 
@@ -82,6 +83,7 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
   public SparkDatasetCompositeFacetsBuilder<T> dataset(CatalogTable catalogTable) {
     if (context.getSparkSession().isPresent()) {
       dataset(PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()));
+      catalog(catalogTable.identifier());
     }
     return this;
   }
@@ -136,6 +138,15 @@ public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.D
 
   public SparkDatasetCompositeFacetsBuilder<T> catalog(CatalogDatasetFacet catalogFacet) {
     inner.getFacets().catalog(catalogFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> catalog(TableIdentifier identifier) {
+    if (context.getSparkSession().isPresent()) {
+      if (CatalogDatasetFacetUtils.isHiveCatalog(context.getSparkSession().get(), identifier)) {
+        catalog();
+      }
+    }
     return this;
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkInputDatasetBuilder.java
@@ -8,15 +8,13 @@ package io.openlineage.spark.api;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 
-public class SparkInputDatasetCompositeFacetsBuilder
-    extends SparkDatasetCompositeFacetsBuilder<OpenLineage.InputDataset> {
+public class SparkInputDatasetBuilder extends SparkDatasetBuilder<OpenLineage.InputDataset> {
 
-  public SparkInputDatasetCompositeFacetsBuilder(OpenLineageContext context) {
+  public SparkInputDatasetBuilder(OpenLineageContext context) {
     super(context);
   }
 
-  public SparkInputDatasetCompositeFacetsBuilder(
-      OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
+  public SparkInputDatasetBuilder(OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
     super(context, inner);
   }
 
@@ -33,7 +31,7 @@ public class SparkInputDatasetCompositeFacetsBuilder
   }
 
   @Override
-  public SparkDatasetCompositeFacetsBuilder<OpenLineage.InputDataset> fromBuilder(
+  public SparkDatasetBuilder<OpenLineage.InputDataset> fromBuilder(
       OpenLineage.DatasetFacetsBuilder facetsBuilder) {
     inner.setFacets(facetsBuilder);
     return this;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOutputDatasetBuilder.java
@@ -9,21 +9,20 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.agent.util.DatasetVersionUtils;
 
-public class SparkOutputDatasetCompositeFacetsBuilder
-    extends SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> {
+public class SparkOutputDatasetBuilder extends SparkDatasetBuilder<OpenLineage.OutputDataset> {
 
-  public SparkOutputDatasetCompositeFacetsBuilder(OpenLineageContext context) {
+  public SparkOutputDatasetBuilder(OpenLineageContext context) {
     super(context);
   }
 
-  public SparkOutputDatasetCompositeFacetsBuilder(
+  public SparkOutputDatasetBuilder(
       OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
     super(context, inner);
   }
 
   /** Overrides to also trigger vendor-specific output facet builders (e.g. Iceberg). */
   @Override
-  public SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> version(String version) {
+  public SparkDatasetBuilder<OpenLineage.OutputDataset> version(String version) {
     DatasetVersionUtils.buildVersionOutputFacets(context, inner, version);
     return this;
   }
@@ -41,7 +40,7 @@ public class SparkOutputDatasetCompositeFacetsBuilder
   }
 
   @Override
-  public SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> fromBuilder(
+  public SparkDatasetBuilder<OpenLineage.OutputDataset> fromBuilder(
       OpenLineage.DatasetFacetsBuilder facetsBuilder) {
     inner.setFacets(facetsBuilder);
     return this;

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,7 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.GoogleCloudPlatformUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -48,6 +50,7 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
   private static final String HIVE_FRAMEWORK = "hive";
   private static final String HIVE_METASTORE_URI = "hive://localhost:9083";
   private static final String HIVE_SYMLINK_NAME = "test_db.test_table";
+  private static final String GCP_LAKEHOUSE = "gcp_lakehouse";
 
   private SparkSession session;
   private OpenLineageContext context;
@@ -97,6 +100,9 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
 
       DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
       pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(false);
 
       List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
 
@@ -114,11 +120,53 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
 
       DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
       pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(false);
 
       List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
 
       assertThat(datasets).hasSize(1);
       assertThat(datasets.get(0).getFacets().getCatalog()).isNull();
+    }
+  }
+
+  @Test
+  void testApplyWithHiveCatalogIncludesCatalogFacet() {
+    OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    OpenLineage.CatalogDatasetFacet expectedFacet =
+        ol.newCatalogDatasetFacetBuilder()
+            .framework(HIVE_FRAMEWORK)
+            .source("spark")
+            .name("default")
+            .type(HIVE_FRAMEWORK)
+            .metadataUri(HIVE_METASTORE_URI)
+            .warehouseUri("file:/tmp/warehouse")
+            .build();
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(true);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+          .thenReturn(Optional.of(expectedFacet));
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      OpenLineage.CatalogDatasetFacet catalog = datasets.get(0).getFacets().getCatalog();
+      assertThat(catalog).isNotNull();
+      assertThat(catalog.getName()).isEqualTo("default");
+      assertThat(catalog.getFramework()).isEqualTo(HIVE_FRAMEWORK);
+      assertThat(catalog.getType()).isEqualTo(HIVE_FRAMEWORK);
+      assertThat(catalog.getMetadataUri()).isEqualTo(HIVE_METASTORE_URI);
+      assertThat(catalog.getWarehouseUri()).isEqualTo("file:/tmp/warehouse");
     }
   }
 
@@ -147,7 +195,9 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
       pathUtils
           .when(() -> PathUtils.fromCatalogTable(catalogTable, session))
           .thenReturn(diWithSymlink);
-
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(true);
       catalogUtils
           .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
           .thenReturn(Optional.of(hiveFacet));
@@ -162,6 +212,73 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
       assertThat(symlinks.getIdentifiers().get(0).getNamespace()).isEqualTo(HIVE_METASTORE_URI);
       assertThat(symlinks.getIdentifiers().get(0).getType())
           .isEqualTo(DatasetIdentifier.SymlinkType.TABLE.toString());
+    }
+  }
+
+  @Test
+  void testApplyWithBigLakeCatalogIncludesBigLakeFacetAndSymlink() {
+    OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    // Catalog facet as returned by getCatalogDatasetFacetForHive when BigLake is detected —
+    // mocking HiveConf.ConfVars.valueOf via mockStatic(GoogleCloudPlatformUtils.class) so
+    // the BigLake-specific HiveConf enum is not required on the test classpath.
+    OpenLineage.CatalogDatasetFacet bigLakeFacet =
+        ol.newCatalogDatasetFacetBuilder()
+            .framework(HIVE_FRAMEWORK)
+            .source("spark")
+            .name("my_biglake_catalog")
+            .type(GCP_LAKEHOUSE)
+            .warehouseUri("gs://my-bucket/warehouse")
+            .catalogProperties(
+                ol.newCatalogDatasetFacetCatalogPropertiesBuilder()
+                    .put("gcp_project_id", "my-gcp-project")
+                    .build())
+            .build();
+
+    // DatasetIdentifier with gcp_lakehouse symlink, as PathUtils produces for BigLake tables
+    DatasetIdentifier diWithBigLakeSymlink = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+    diWithBigLakeSymlink.withSymlink(
+        HIVE_SYMLINK_NAME, GCP_LAKEHOUSE, DatasetIdentifier.SymlinkType.TABLE);
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class);
+        // Mock GoogleCloudPlatformUtils so that BigLake detection does not require the
+        // BigLake-extended HiveConf (with SPARK_HIVE_METASTORE_CLIENT_FACTORY_CLASS ConfVar)
+        // to be present on the test classpath.
+        MockedStatic<GoogleCloudPlatformUtils> gcpUtils =
+            mockStatic(GoogleCloudPlatformUtils.class)) {
+
+      pathUtils
+          .when(() -> PathUtils.fromCatalogTable(catalogTable, session))
+          .thenReturn(diWithBigLakeSymlink);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(true);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+          .thenReturn(Optional.of(bigLakeFacet));
+      gcpUtils
+          .when(() -> GoogleCloudPlatformUtils.isBigLakeHiveCatalog(any(SparkConf.class)))
+          .thenReturn(true);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      OpenLineage.OutputDataset ds = datasets.get(0);
+
+      OpenLineage.CatalogDatasetFacet catalog = ds.getFacets().getCatalog();
+      assertThat(catalog).isNotNull();
+      assertThat(catalog.getName()).isEqualTo("my_biglake_catalog");
+      assertThat(catalog.getType()).isEqualTo(GCP_LAKEHOUSE);
+      assertThat(catalog.getWarehouseUri()).isEqualTo("gs://my-bucket/warehouse");
+      assertThat(catalog.getCatalogProperties().getAdditionalProperties())
+          .containsEntry("gcp_project_id", "my-gcp-project");
+
+      OpenLineage.SymlinksDatasetFacet symlinks = ds.getFacets().getSymlinks();
+      assertThat(symlinks).isNotNull();
+      assertThat(symlinks.getIdentifiers()).hasSize(1);
+      assertThat(symlinks.getIdentifiers().get(0).getNamespace()).isEqualTo(GCP_LAKEHOUSE);
+      assertThat(symlinks.getIdentifiers().get(0).getName()).isEqualTo(HIVE_SYMLINK_NAME);
     }
   }
 
@@ -187,6 +304,10 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
 
       DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
       pathUtils.when(() -> PathUtils.fromCatalogTable(emptySchemaTable, session)).thenReturn(di);
+      catalogUtils
+          .when(
+              () -> CatalogDatasetFacetUtils.isHiveCatalog(session, emptySchemaTable.identifier()))
+          .thenReturn(false);
 
       List<OpenLineage.OutputDataset> datasets = visitor.apply(cmd);
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -17,10 +18,12 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.GoogleCloudPlatformUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.List;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -39,6 +42,10 @@ class CreateDataSourceTableCommandVisitorTest {
   private static final String TABLE = "test_table";
   private static final String WAREHOUSE_PATH = "/warehouse/test_db/test_table";
   private static final String FILE_SCHEME = "file";
+  private static final String HIVE_FRAMEWORK = "hive";
+  private static final String HIVE_METASTORE_URI = "hive://localhost:9083";
+  private static final String HIVE_SYMLINK_NAME = "test_db.test_table";
+  private static final String GCP_LAKEHOUSE = "gcp_lakehouse";
 
   private SparkSession session;
   private OpenLineageContext context;
@@ -80,6 +87,9 @@ class CreateDataSourceTableCommandVisitorTest {
 
       DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
       pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(false);
 
       List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
 
@@ -97,11 +107,157 @@ class CreateDataSourceTableCommandVisitorTest {
 
       DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
       pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(false);
 
       List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
 
       assertThat(datasets).hasSize(1);
       assertThat(datasets.get(0).getFacets().getCatalog()).isNull();
+    }
+  }
+
+  @Test
+  void testApplyWithHiveCatalogIncludesCatalogFacet() {
+    OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    OpenLineage.CatalogDatasetFacet expectedFacet =
+        ol.newCatalogDatasetFacetBuilder()
+            .framework(HIVE_FRAMEWORK)
+            .source("spark")
+            .name("default")
+            .type(HIVE_FRAMEWORK)
+            .metadataUri(HIVE_METASTORE_URI)
+            .warehouseUri("file:/tmp/warehouse")
+            .build();
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(true);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+          .thenReturn(Optional.of(expectedFacet));
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      OpenLineage.CatalogDatasetFacet catalog = datasets.get(0).getFacets().getCatalog();
+      assertThat(catalog).isNotNull();
+      assertThat(catalog.getName()).isEqualTo("default");
+      assertThat(catalog.getFramework()).isEqualTo(HIVE_FRAMEWORK);
+      assertThat(catalog.getType()).isEqualTo(HIVE_FRAMEWORK);
+      assertThat(catalog.getMetadataUri()).isEqualTo(HIVE_METASTORE_URI);
+      assertThat(catalog.getWarehouseUri()).isEqualTo("file:/tmp/warehouse");
+    }
+  }
+
+  @Test
+  void testApplyWithBigLakeCatalogIncludesBigLakeFacetAndSymlink() {
+    OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    // Facet returned by getCatalogDatasetFacetForHive when BigLake is active —
+    // GoogleCloudPlatformUtils is mocked so BigLake-extended HiveConf is not needed on classpath.
+    OpenLineage.CatalogDatasetFacet bigLakeFacet =
+        ol.newCatalogDatasetFacetBuilder()
+            .framework(HIVE_FRAMEWORK)
+            .source("spark")
+            .name("my_biglake_catalog")
+            .type(GCP_LAKEHOUSE)
+            .warehouseUri("gs://my-bucket/warehouse")
+            .catalogProperties(
+                ol.newCatalogDatasetFacetCatalogPropertiesBuilder()
+                    .put("gcp_project_id", "my-gcp-project")
+                    .build())
+            .build();
+
+    DatasetIdentifier diWithBigLakeSymlink = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+    diWithBigLakeSymlink.withSymlink(
+        HIVE_SYMLINK_NAME, GCP_LAKEHOUSE, DatasetIdentifier.SymlinkType.TABLE);
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class);
+        MockedStatic<GoogleCloudPlatformUtils> gcpUtils =
+            mockStatic(GoogleCloudPlatformUtils.class)) {
+
+      pathUtils
+          .when(() -> PathUtils.fromCatalogTable(catalogTable, session))
+          .thenReturn(diWithBigLakeSymlink);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(true);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+          .thenReturn(Optional.of(bigLakeFacet));
+      gcpUtils
+          .when(() -> GoogleCloudPlatformUtils.isBigLakeHiveCatalog(any(SparkConf.class)))
+          .thenReturn(true);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      OpenLineage.OutputDataset ds = datasets.get(0);
+
+      OpenLineage.CatalogDatasetFacet catalog = ds.getFacets().getCatalog();
+      assertThat(catalog).isNotNull();
+      assertThat(catalog.getName()).isEqualTo("my_biglake_catalog");
+      assertThat(catalog.getType()).isEqualTo(GCP_LAKEHOUSE);
+      assertThat(catalog.getWarehouseUri()).isEqualTo("gs://my-bucket/warehouse");
+      assertThat(catalog.getCatalogProperties().getAdditionalProperties())
+          .containsEntry("gcp_project_id", "my-gcp-project");
+
+      OpenLineage.SymlinksDatasetFacet symlinks = ds.getFacets().getSymlinks();
+      assertThat(symlinks).isNotNull();
+      assertThat(symlinks.getIdentifiers()).hasSize(1);
+      assertThat(symlinks.getIdentifiers().get(0).getNamespace()).isEqualTo(GCP_LAKEHOUSE);
+      assertThat(symlinks.getIdentifiers().get(0).getName()).isEqualTo(HIVE_SYMLINK_NAME);
+    }
+  }
+
+  @Test
+  void testApplyWithHiveCatalogIncludesSymlinkFacet() {
+    OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    OpenLineage.CatalogDatasetFacet hiveFacet =
+        ol.newCatalogDatasetFacetBuilder()
+            .framework(HIVE_FRAMEWORK)
+            .source("spark")
+            .name("default")
+            .type(HIVE_FRAMEWORK)
+            .metadataUri(HIVE_METASTORE_URI)
+            .warehouseUri("file:/tmp/warehouse")
+            .build();
+
+    DatasetIdentifier diWithSymlink = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+    diWithSymlink.withSymlink(
+        HIVE_SYMLINK_NAME, HIVE_METASTORE_URI, DatasetIdentifier.SymlinkType.TABLE);
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      pathUtils
+          .when(() -> PathUtils.fromCatalogTable(catalogTable, session))
+          .thenReturn(diWithSymlink);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(session, catalogTable.identifier()))
+          .thenReturn(true);
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+          .thenReturn(Optional.of(hiveFacet));
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      OpenLineage.SymlinksDatasetFacet symlinks = datasets.get(0).getFacets().getSymlinks();
+      assertThat(symlinks).isNotNull();
+      assertThat(symlinks.getIdentifiers()).hasSize(1);
+      assertThat(symlinks.getIdentifiers().get(0).getName()).isEqualTo(HIVE_SYMLINK_NAME);
+      assertThat(symlinks.getIdentifiers().get(0).getNamespace()).isEqualTo(HIVE_METASTORE_URI);
     }
   }
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtilsTest.java
@@ -6,7 +6,9 @@
 package io.openlineage.spark.agent.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -20,10 +22,12 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class CatalogDatasetFacetUtilsTest {
 
   private static final String HIVE_TYPE = "hive";
+  private static final String BIGLAKE_CATALOG_NAME = "my_biglake_catalog";
 
   private SparkContext sparkContext;
   private OpenLineageContext context;
@@ -84,5 +88,93 @@ class CatalogDatasetFacetUtilsTest {
         CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
 
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  void testGetCatalogDatasetFacetForBigLakeReturnsBigLakeFacetWithProjectId() {
+    // BigLake path with project ID configured: expects gcp_project_id in catalogProperties.
+    SparkConf sparkConf =
+        new SparkConf()
+            .set("spark.hive.metastore.blms.catalog.default", BIGLAKE_CATALOG_NAME)
+            .set("spark.hive.metastore.blms.project.id", "my-gcp-project");
+    Configuration hadoopConf = new Configuration();
+    hadoopConf.set("hive.metastore.warehouse.dir", "gs://my-bucket/warehouse");
+
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+
+    try (MockedStatic<GoogleCloudPlatformUtils> gcpUtils =
+        mockStatic(GoogleCloudPlatformUtils.class)) {
+      gcpUtils
+          .when(() -> GoogleCloudPlatformUtils.isBigLakeHiveCatalog(any(SparkConf.class)))
+          .thenReturn(true);
+
+      Optional<OpenLineage.CatalogDatasetFacet> result =
+          CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
+
+      assertThat(result).isPresent();
+      OpenLineage.CatalogDatasetFacet facet = result.get();
+      assertThat(facet.getName()).isEqualTo(BIGLAKE_CATALOG_NAME);
+      assertThat(facet.getType()).isEqualTo("gcp_lakehouse");
+      assertThat(facet.getFramework()).isEqualTo(HIVE_TYPE);
+      assertThat(facet.getSource()).isEqualTo("spark");
+      assertThat(facet.getWarehouseUri()).contains("my-bucket/warehouse");
+      assertThat(facet.getCatalogProperties()).isNotNull();
+      assertThat(facet.getCatalogProperties().getAdditionalProperties())
+          .containsEntry("gcp_project_id", "my-gcp-project");
+    }
+  }
+
+  @Test
+  void testGetCatalogDatasetFacetForBigLakeReturnsBigLakeFacetWithoutProjectIdWhenNotConfigured() {
+    // BigLake path without project ID: catalogProperties should be null / absent.
+    SparkConf sparkConf =
+        new SparkConf().set("spark.hive.metastore.blms.catalog.default", BIGLAKE_CATALOG_NAME);
+    Configuration hadoopConf = new Configuration();
+    hadoopConf.set("hive.metastore.warehouse.dir", "gs://my-bucket/warehouse");
+
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+
+    try (MockedStatic<GoogleCloudPlatformUtils> gcpUtils =
+        mockStatic(GoogleCloudPlatformUtils.class)) {
+      gcpUtils
+          .when(() -> GoogleCloudPlatformUtils.isBigLakeHiveCatalog(any(SparkConf.class)))
+          .thenReturn(true);
+
+      Optional<OpenLineage.CatalogDatasetFacet> result =
+          CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
+
+      assertThat(result).isPresent();
+      OpenLineage.CatalogDatasetFacet facet = result.get();
+      assertThat(facet.getName()).isEqualTo(BIGLAKE_CATALOG_NAME);
+      assertThat(facet.getType()).isEqualTo("gcp_lakehouse");
+      assertThat(facet.getCatalogProperties()).isNull();
+    }
+  }
+
+  @Test
+  void testGetCatalogDatasetFacetForBigLakeReturnsEmptyWhenCatalogNameNotConfigured() {
+    // BigLake detected but spark.hive.metastore.blms.catalog.default not set → returns empty.
+    SparkConf sparkConf = new SparkConf(); // no blms.catalog.default
+    Configuration hadoopConf = new Configuration();
+
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+
+    try (MockedStatic<GoogleCloudPlatformUtils> gcpUtils =
+        mockStatic(GoogleCloudPlatformUtils.class)) {
+      gcpUtils
+          .when(() -> GoogleCloudPlatformUtils.isBigLakeHiveCatalog(any(SparkConf.class)))
+          .thenReturn(true);
+
+      Optional<OpenLineage.CatalogDatasetFacet> result =
+          CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
+
+      assertThat(result).isEmpty();
+    }
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -11,7 +11,7 @@ import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -104,7 +104,7 @@ public class CreateReplaceDatasetBuilder
       return Collections.emptyList();
     }
 
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
         outputDataset()
             .sparkDatasetBuilder()
             .dataset(di.get())

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -66,6 +66,7 @@ public class CreateTableLikeCommandVisitor
                       .sparkDatasetBuilder()
                       .dataset(di)
                       .schema(source.schema())
+                      .catalog(source.identifier())
                       .lifecycleStateChange(
                           OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE)
                       .build());

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -9,7 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
@@ -98,7 +98,7 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
         PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
 
     if (di.isPresent()) {
-      SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+      SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
           outputDataset()
               .sparkDatasetBuilder()
               .dataset(di.get())
@@ -147,7 +147,7 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
           PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
 
       if (di.isPresent()) {
-        SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
             outputDataset()
                 .sparkDatasetBuilder()
                 .dataset(di.get())

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -10,6 +10,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -104,6 +105,8 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
               .schema(resolvedTable.schema())
               .lifecycleStateChange(
                   OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
+      CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
+          .ifPresent(cf -> sparkBuilder.catalog(cf.getCatalogDatasetFacet()));
       return Collections.singletonList(sparkBuilder.build());
     } else {
       return Collections.emptyList();
@@ -151,6 +154,8 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
                 .schema(schema)
                 .lifecycleStateChange(
                     OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
+        CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
+            .ifPresent(cf -> sparkBuilder.catalog(cf.getCatalogDatasetFacet()));
         return Collections.singletonList(sparkBuilder.build());
       } else {
         return Collections.emptyList();

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -19,6 +19,7 @@ import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
 import lombok.SneakyThrows;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -59,8 +60,10 @@ class CreateTableLikeCommandVisitorTest {
   @SneakyThrows
   void testCreateTableLikeCommand() {
     CatalogTable sourceCatalogTable = mock(CatalogTable.class);
+    SparkContext sparkContext = mock(SparkContext.class);
 
-    when(sparkSession.sparkContext()).thenReturn(mock(SparkContext.class));
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
     when(sparkSession.sessionState()).thenReturn(sessionState);
     when(sessionState.catalog()).thenReturn(sessionCatalog);
     when(sessionCatalog.getTempViewOrPermanentTableMetadata(sourceTableIdentifier))

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -21,7 +21,7 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
 import java.net.URI;
@@ -100,8 +100,7 @@ class DataSourceV2RelationDatasetExtractorTest {
                 openLineageContext, tableCatalog, identifier, tableProperties))
             .thenReturn(di);
 
-        SparkDatasetCompositeFacetsBuilder sparkBuilder =
-            mock(SparkDatasetCompositeFacetsBuilder.class);
+        SparkDatasetBuilder sparkBuilder = mock(SparkDatasetBuilder.class);
         when(datasetFactory.sparkDatasetBuilder(datasetFacetsBuilder)).thenReturn(sparkBuilder);
         when(sparkBuilder.dataset(any(DatasetIdentifier.class))).thenReturn(sparkBuilder);
         when(sparkBuilder.build()).thenReturn(dataset);

--- a/integration/spark/spark31/src/main/java/io/openlineage/spark31/agent/lifecycle/plan/AlterTableDatasetBuilder.java
+++ b/integration/spark/spark31/src/main/java/io/openlineage/spark31/agent/lifecycle/plan/AlterTableDatasetBuilder.java
@@ -9,7 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -48,7 +48,7 @@ public class AlterTableDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
             context, alterTable.catalog(), alterTable.ident(), table.properties());
 
     if (di.isPresent()) {
-      SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+      SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
           outputDataset().sparkDatasetBuilder().dataset(di.get()).schema(table.schema());
 
       if (includeDatasetVersion(event)) {

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -9,7 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -83,7 +83,7 @@ public class AlterTableCommandDatasetBuilder
       return Collections.emptyList();
     }
 
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
         outputDataset()
             .sparkDatasetBuilder()
             .dataset(di.get())

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/RepairTableCommandVisitor.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/RepairTableCommandVisitor.java
@@ -37,6 +37,7 @@ public class RepairTableCommandVisitor
                         .schema(catalogTable.schema())
                         .lifecycleStateChange(
                             OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
+                        .catalog(catalogTable.identifier())
                         .build()))
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -11,7 +11,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractOnCompleteOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
@@ -153,7 +153,7 @@ public class CreateReplaceDatasetBuilder
       return Collections.emptyList();
     }
 
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
         outputDataset()
             .sparkDatasetBuilder()
             .dataset(di.get())

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
@@ -18,7 +18,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.List;
 import org.apache.spark.SparkContext;
@@ -141,8 +141,7 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.apply(catalogTable));
 
     @SuppressWarnings("unchecked")
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
-        mock(SparkDatasetCompositeFacetsBuilder.class);
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mock(SparkDatasetBuilder.class);
     when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
     when(sparkBuilder.dataset(catalogTable)).thenReturn(sparkBuilder);
     when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -11,7 +11,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
@@ -161,7 +161,7 @@ public class CreateReplaceOutputDatasetBuilder
       return Collections.emptyList();
     }
 
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
         outputDataset()
             .sparkDatasetBuilder()
             .dataset(di.get())

--- a/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -9,7 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -82,7 +82,7 @@ public class AlterTableCommandDatasetBuilder
       return Collections.emptyList();
     }
 
-    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder =
         outputDataset()
             .sparkDatasetBuilder()
             .dataset(di.get())

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/util/SparkInputPartitionExtractor.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/util/SparkInputPartitionExtractor.java
@@ -83,8 +83,7 @@ public class SparkInputPartitionExtractor implements InputPartitionExtractor {
         tableLocation.map(
             location ->
                 tableIdentifier.isPresent()
-                    ? PathUtils.fromTableIdentifier(
-                        tableIdentifier.get(), sparkContext, location, Optional.empty())
+                    ? PathUtils.fromTableIdentifier(tableIdentifier.get(), sparkContext, location)
                     : PathUtils.fromURI(location));
     return di.map(Collections::singletonList).orElse(Collections.emptyList());
   }

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/util/SparkInputPartitionExtractor.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/util/SparkInputPartitionExtractor.java
@@ -83,7 +83,8 @@ public class SparkInputPartitionExtractor implements InputPartitionExtractor {
         tableLocation.map(
             location ->
                 tableIdentifier.isPresent()
-                    ? PathUtils.fromTableIdentifier(tableIdentifier.get(), sparkContext, location)
+                    ? PathUtils.fromTableIdentifier(
+                        tableIdentifier.get(), sparkContext, location, Optional.empty())
                     : PathUtils.fromURI(location));
     return di.map(Collections::singletonList).orElse(Collections.emptyList());
   }


### PR DESCRIPTION
### One-line summary for changelog:
Add handling for Lakehouse Hive Catalog 


### Meaningful description
Spark jobs on Managed Spark (fromerly Dataproc) can use Lakehouse (formerly BigLake) with Hive Catalog. This requires custom implementation of Hive libraries. The code checks if the custom changes are present and if the appropriate properties are set. If so the catalog facet is added along with specific symlink.

Aside from that, mechanism to check if V2 sources use `HiveSessionCatalog` was added to increase coverage.

A lot of visitors didn't have any tests so there is crapload of added test lines

### Checklist
- [X] AI was used in creating this PR
