### PR TITLE
spark: stabilize three flaky integration tests on main

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/HiveMetastoreIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/HiveMetastoreIntegrationTest.java
@@ -68,7 +68,6 @@ class HiveMetastoreIntegrationTest {
   @BeforeEach
   void beforeEach() throws IOException {
     FileUtils.deleteDirectory(new File("/tmp/hive-metastore/"));
-    MockServerUtils.clearRequests(mockServer);
     spark =
         SparkSession.builder()
             .master("local[*]")
@@ -86,6 +85,11 @@ class HiveMetastoreIntegrationTest {
                 "http://localhost:" + MOCKSERVER_PORT + "/api/v1/lineage")
             .enableHiveSupport()
             .getOrCreate();
+    // The Hive metastore container is shared across tests, so table definitions persist even after
+    // the warehouse directory is wiped. Drop the database so CREATE TABLE IF NOT EXISTS statements
+    // actually execute (and emit events) instead of becoming no-ops for an already-existing table.
+    spark.sql("DROP DATABASE IF EXISTS hive3 CASCADE");
+    MockServerUtils.clearRequests(mockServer);
   }
 
   @Test

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MockServerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MockServerUtils.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -157,6 +158,29 @@ public class MockServerUtils {
                     .map(r -> OpenLineageClientUtils.runEventFromJson(r.getBodyAsString()))
                     .findAny()
                     .isPresent());
+
+    return Arrays.stream(mockServer.retrieveRecordedRequests(request().withPath("/api/v1/lineage")))
+        .map(r -> OpenLineageClientUtils.runEventFromJson(r.getBodyAsString()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Wait for at least one recorded event that matches the given predicate, then return all events
+   * currently recorded. Use this instead of {@link #getEventsEmitted(ClientAndServer)} when the
+   * caller depends on a specific event (e.g. the COMPLETE event for a specific output) that may
+   * arrive after other events, to avoid races where the predicate-matching event has not yet been
+   * delivered when the assertion runs.
+   */
+  public static List<RunEvent> getEventsEmitted(
+      ClientAndServer mockServer, Predicate<RunEvent> predicate) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .until(
+            () ->
+                Arrays.stream(
+                        mockServer.retrieveRecordedRequests(request().withPath("/api/v1/lineage")))
+                    .map(r -> OpenLineageClientUtils.runEventFromJson(r.getBodyAsString()))
+                    .anyMatch(predicate));
 
     return Arrays.stream(mockServer.retrieveRecordedRequests(request().withPath("/api/v1/lineage")))
         .map(r -> OpenLineageClientUtils.runEventFromJson(r.getBodyAsString()))

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkSqlGenericIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkSqlGenericIntegrationTest.java
@@ -113,7 +113,16 @@ class SparkSqlGenericIntegrationTest {
     spark.sql(
         "CREATE TABLE test_output AS SELECT * FROM test_input1 UNION ALL SELECT * FROM test_input2");
     spark.stop();
-    List<RunEvent> events = getEventsEmitted(mockServer);
+    // Wait for the COMPLETE event for test_output specifically: events are delivered via the async
+    // HTTP transport and SparkSession.stop() does not guarantee they have all been received by the
+    // mock server when it returns.
+    List<RunEvent> events =
+        getEventsEmitted(
+            mockServer,
+            e ->
+                e.getEventType() == RunEvent.EventType.COMPLETE
+                    && e.getOutputs() != null
+                    && e.getOutputs().stream().anyMatch(o -> o.getName().endsWith("test_output")));
 
     // verify output statistics facet
     Optional<OutputStatisticsOutputDatasetFacet> outputStatistics =

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -622,13 +622,21 @@ class SparkReadWriteIntegTest {
 
     String sparkVersion = System.getProperty(SPARK_VERSION);
     String scalaBinaryVersion = System.getProperty("scala.binary.version");
+    // Append a unique run id so that concurrent CI runs (and re-runs of the same Spark/Scala
+    // version) do not write to the same S3 keys. Sharing keys causes `mode("overwrite")` from one
+    // run to delete files that another run's FileOutputCommitter is about to rename, which
+    // surfaces as a NoSuchKey error during commit.
+    String runId = UUID.randomUUID().toString().substring(0, 8);
 
     String aDatasetName =
-        String.format("rdd_a_%s_%s", sparkVersion, scalaBinaryVersion).replace(".", "_");
+        String.format("rdd_a_%s_%s_%s", sparkVersion, scalaBinaryVersion, runId)
+            .replace(".", "_");
     String bDatasetName =
-        String.format("rdd_b_%s_%s", sparkVersion, scalaBinaryVersion).replace(".", "_");
+        String.format("rdd_b_%s_%s_%s", sparkVersion, scalaBinaryVersion, runId)
+            .replace(".", "_");
     String cDatasetName =
-        String.format("rdd_c_%s_%s", sparkVersion, scalaBinaryVersion).replace(".", "_");
+        String.format("rdd_c_%s_%s_%s", sparkVersion, scalaBinaryVersion, runId)
+            .replace(".", "_");
 
     String bucketUrl = System.getenv("S3_BUCKET");
 


### PR DESCRIPTION
## Summary

The CircleCI job `integration-test-integration-spark-java:8-spark:3.3.4-scala:2.12-full-tests` on `main` has been intermittently failing with three independent flakes (latest occurrence: pipeline [18812](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/18812) on `d32b78b58`). Each has a distinct root cause — fixed all three so they cannot recur.

### 1. `HiveMetastoreIntegrationTest.testCreateHiveTableAsSelect` — MockServer timeout
The `@Container` Hive metastore is `static`, so table definitions persist across `@Test` methods even though `@BeforeEach` wipes the warehouse directory on disk. When `testSaveAsTable` runs before `testCreateHiveTableAsSelect`, the `hive3.table2` it created still lives in the metastore — so `CREATE TABLE IF NOT EXISTS hive3.table2 …` becomes a no-op, no `CreateHiveTableAsSelectCommand` events are emitted, and `MockServer`'s 30s `verifyEvents` await times out.

**Fix:** drop `hive3` cascade in `@BeforeEach` after the SparkSession is built and before MockServer requests are cleared.

### 2. `SparkSqlGenericIntegrationTest.sparkSqlQueryEmitsInputAndOutputStatistics` — Optional empty
`getEventsEmitted()` only waits until *any* event lands at the mock server, even though the assertion needs the COMPLETE event for `test_output`. `SparkSession.stop()` does not guarantee the async HTTP transport has delivered every event before returning, so the COMPLETE event carrying the `OutputStatisticsOutputDatasetFacet` could still be in-flight when the assertion ran.

**Fix:** add a predicate-based `getEventsEmitted(mockServer, predicate)` variant and wait for the COMPLETE event whose outputs include `test_output`.

### 3. `SparkReadWriteIntegTest.testExternalRDDWithS3Bucket` — `NoSuchKey` race on S3 commit
The test wrote to S3 keys derived only from Spark + Scala version (e.g. `rdd_a_3_3_4_2_12`), which are stable across CI runs. Concurrent or sequential runs on the same versions raced on the same key — one run's `mode("overwrite")` could delete files that another run's `FileOutputCommitter` was about to rename, surfacing as `S3AFileSystem.copyFile … NoSuchKey` during commit.

**Fix:** append a per-execution UUID suffix to the dataset names. Assertions already reference the variables, so no other changes are needed.

## Test plan
- [ ] `integration-test-integration-spark-java:8-spark:3.3.4-scala:2.12-full-tests` passes on CI
- [ ] Other Spark/Scala/Java variants of the same job still pass
- [ ] No regressions in `HiveMetastoreIntegrationTest`, `SparkSqlGenericIntegrationTest`, `SparkReadWriteIntegTest` other tests