### PR TITLE
fix: upgrade netty to 4.2.13.Final to fix CVE-2026-41417

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -59,6 +59,7 @@ ext {
     lombokVersion = '1.18.46'
     mockitoVersion = '5.23.0'
     micrometerVersion = '1.16.5'
+    nettyVersion = '4.2.13.Final'
     isReleaseVersion = !version.endsWith('SNAPSHOT')
     guavaVersion = '33.6.0-jre'
 }
@@ -109,6 +110,11 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
         exclude group: 'org.mock-server.mockserver-client-java'
     }
+    
+    // Force netty version to fix CVE-2026-41417
+    testImplementation "io.netty:netty-codec:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http2:${nettyVersion}"
 }
 
 configurations {

--- a/integration/hive/hive-openlineage-hook/build.gradle
+++ b/integration/hive/hive-openlineage-hook/build.gradle
@@ -32,6 +32,7 @@ ext {
     jupiterVersion = '5.11.3'
     jacksonVersion = '2.18.1'
     mockitoVersion = '4.11.0'
+    nettyVersion = '4.2.13.Final'
     hiveVersion = '3.1.3'
     hadoopVersion = '2.10.2'
     postgresqlVersion = '42.7.5'
@@ -96,6 +97,11 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
         exclude group: 'org.mock-server.mockserver-client-java'
     }
+    
+    // Force netty version to fix CVE-2026-41417
+    testImplementation "io.netty:netty-codec:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http2:${nettyVersion}"
 
     testImplementation 'org.datanucleus:datanucleus-rdbms:4.1.19'
     testImplementation 'org.datanucleus:datanucleus-api-jdo:4.2.4'

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -29,6 +29,7 @@ ext {
     bigqueryVersion = '0.42.2'
     junit5Version = '5.11.4'
     mockitoVersion = '4.11.0'
+    nettyVersion = '4.2.13.Final'
     postgresqlVersion = '42.7.9'
     testcontainersVersion = '1.21.4'
     awssdkVersion = '2.42.25'
@@ -150,6 +151,12 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
         exclude group: 'org.mock-server.mockserver-client-java'
     }
+    
+    // Force netty version to fix CVE-2026-41417
+    testImplementation "io.netty:netty-codec:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http2:${nettyVersion}"
+    
     testImplementation("io.micrometer:micrometer-core:${micrometerVersion}")
     testImplementation("io.micrometer:micrometer-registry-statsd:${micrometerVersion}")
     testImplementation('net.javacrumbs.json-unit:json-unit-assertj:2.38.0')

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -39,6 +39,7 @@ ext {
     micrometerVersion = '1.16.2'
     mockitoVersion = "4.11.0"
     mockserverVersion = "5.14.0"
+    nettyVersion = "4.2.13.Final"
     postgresqlVersion = "42.7.9"
     sqlLiteVersion = "3.51.1.0"
     testcontainersVersion = "1.19.3"
@@ -94,6 +95,12 @@ dependencies {
         exclude(group: "com.fasterxml.jackson.dataformat")
     }
     testFixturesApi("org.mock-server:mockserver-netty:${mockserverVersion}:shaded")
+    
+    // Force netty version to fix CVE-2026-41417
+    testFixturesApi("io.netty:netty-codec:${nettyVersion}")
+    testFixturesApi("io.netty:netty-codec-http:${nettyVersion}")
+    testFixturesApi("io.netty:netty-codec-http2:${nettyVersion}")
+    
     testFixturesApi("org.awaitility:awaitility:${awaitilityVersion}")
     testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
     testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")

--- a/integration/spark/vendor/gcp/build.gradle
+++ b/integration/spark/vendor/gcp/build.gradle
@@ -17,6 +17,7 @@ ext {
     lombokVersion = '1.18.30'
     micrometerVersion = '1.14.1'
     mockserverVersion = "5.14.0"
+    nettyVersion = '4.2.13.Final'
 
     sparkProp = project.findProperty('spark.version').toString()
     // compile for unsupported iceberg versions
@@ -41,6 +42,12 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("org.assertj:assertj-core:${assertjVersion}")
     testImplementation("org.mock-server:mockserver-netty:${mockserverVersion}:shaded")
+    
+    // Force netty version to fix CVE-2026-41417
+    testImplementation "io.netty:netty-codec:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http:${nettyVersion}"
+    testImplementation "io.netty:netty-codec-http2:${nettyVersion}"
+    
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("org.mockito:mockito-inline:${mockitoVersion}")
     testImplementation("org.mockito:mockito-junit-jupiter:${mockitoVersion}")


### PR DESCRIPTION
- Added netty version 4.2.13.Final constraint in all build.gradle files
- Forces upgrade of netty-codec, netty-codec-http, and netty-codec-http2
- Affects client/java, integration/spark, and integration/hive modules
- Verified dependency resolution shows all netty deps at 4.2.13.Final

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->


### Checklist
- [ ] AI was used in creating this PR
