### PR TITLE
chore: upgrade AWS SDK to 2.44.4 for Spark integration

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -31,7 +31,7 @@ ext {
     mockitoVersion = '4.11.0'
     postgresqlVersion = '42.7.9'
     testcontainersVersion = '1.21.4'
-    awssdkVersion = '2.42.25'
+    awssdkVersion = '2.44.4'
     configurableTestConfig = [
             sparkConfFile: project.findProperty('spark.conf.file') ?: System.getProperty('spark.conf.file'),
             hostDir      : project.findProperty('host.dir') ?: System.getProperty('host.dir'),

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -42,7 +42,7 @@ ext {
     postgresqlVersion = "42.7.9"
     sqlLiteVersion = "3.51.1.0"
     testcontainersVersion = "1.19.3"
-    awsSdkVersion = '2.42.25'
+    awsSdkVersion = '2.44.4'
 
     sparkVersion = project.findProperty("shared.spark.version")
     sparkSeries = sparkVersion.substring(0, 3)


### PR DESCRIPTION
- Updated awsSdkVersion from 2.42.25 to 2.44.4
- Affects integration/spark/shared and integration/spark/app modules
- Ensures latest AWS SDK features and security fixes

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->


### Checklist
- [ ] AI was used in creating this PR
