### PR TITLE
Fix Spark listener deadlock by building the extension-visitor wrapper once

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.api.naming.JobNameBuilder;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.Optional;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.MethodUtils;
@@ -36,6 +37,19 @@ public class ContextFactory {
   @Getter private final SparkOpenLineageConfig config;
   private final OpenLineageEventHandlerFactory handlerFactory;
 
+  /**
+   * Built once and shared across all execution contexts. Its constructor walks the classpath
+   * (ServiceLoader, Thread.getAllStackTraces, reflective defineClass) to discover
+   * OpenLineageExtensionProvider implementations. Doing that on every SQL execution start ran on
+   * the Spark listener thread and, when classpath JARs live on S3, could deadlock against the
+   * driver thread over the AWS HTTP connection-pool lock and the app classloader's URLClassPath
+   * monitor. The discovered providers are static for the JVM lifetime, so a single immutable
+   * instance is built here (at ContextFactory construction, i.e. application start) and reused
+   * everywhere.
+   */
+  @Getter(AccessLevel.PACKAGE)
+  private final SparkOpenLineageExtensionVisitorWrapper visitorWrapper;
+
   public ContextFactory(
       EventEmitter openLineageEventEmitter,
       MeterRegistry meterRegistry,
@@ -44,6 +58,7 @@ public class ContextFactory {
     this.meterRegistry = meterRegistry;
     this.config = config;
     handlerFactory = new InternalEventHandlerFactory();
+    this.visitorWrapper = new SparkOpenLineageExtensionVisitorWrapper(config);
   }
 
   public ExecutionContext createSparkApplicationExecutionContext(SparkContext sparkContext) {
@@ -59,7 +74,7 @@ public class ContextFactory {
             .vendors(Vendors.getVendors())
             .meterRegistry(meterRegistry)
             .openLineageConfig(config)
-            .sparkExtensionVisitorWrapper(new SparkOpenLineageExtensionVisitorWrapper(config))
+            .sparkExtensionVisitorWrapper(visitorWrapper)
             .build();
 
     String resolvedAppName = JobNameBuilder.buildApplicationName(olContext);
@@ -83,7 +98,7 @@ public class ContextFactory {
             .vendors(Vendors.getVendors())
             .meterRegistry(meterRegistry)
             .openLineageConfig(config)
-            .sparkExtensionVisitorWrapper(new SparkOpenLineageExtensionVisitorWrapper(config))
+            .sparkExtensionVisitorWrapper(visitorWrapper)
             .build();
 
     OpenLineageRunEventBuilder runEventBuilder =
@@ -112,7 +127,7 @@ public class ContextFactory {
             .vendors(Vendors.getVendors())
             .meterRegistry(meterRegistry)
             .openLineageConfig(config)
-            .sparkExtensionVisitorWrapper(new SparkOpenLineageExtensionVisitorWrapper(config))
+            .sparkExtensionVisitorWrapper(visitorWrapper)
             .build();
     OpenLineageRunEventBuilder runEventBuilder =
         new OpenLineageRunEventBuilder(olContext, handlerFactory);
@@ -140,8 +155,7 @@ public class ContextFactory {
                       .vendors(Vendors.getVendors())
                       .meterRegistry(meterRegistry)
                       .openLineageConfig(config)
-                      .sparkExtensionVisitorWrapper(
-                          new SparkOpenLineageExtensionVisitorWrapper(config))
+                      .sparkExtensionVisitorWrapper(visitorWrapper)
                       .build();
               OpenLineageRunEventBuilder runEventBuilder =
                   new OpenLineageRunEventBuilder(olContext, handlerFactory);

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/ContextFactoryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/ContextFactoryTest.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,5 +39,32 @@ class ContextFactoryTest {
     factory.createSparkApplicationExecutionContext(sparkContext);
 
     verify(emitter).setApplicationJobName("test_app");
+  }
+
+  @Test
+  void testVisitorWrapperIsBuiltOnceAndReusedAcrossExecutionContexts() {
+    EventEmitter emitter = mock(EventEmitter.class);
+    when(emitter.getApplicationRunId()).thenReturn(UUID.randomUUID());
+    when(emitter.getCustomEnvironmentVariables()).thenReturn(Optional.of(Collections.emptyList()));
+
+    SparkContext sparkContext = mock(SparkContext.class);
+    SparkConf sparkConf = new SparkConf().set("spark.app.name", "test-app");
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.appName()).thenReturn("test-app");
+
+    ContextFactory factory =
+        new ContextFactory(emitter, new SimpleMeterRegistry(), new SparkOpenLineageConfig());
+
+    // The wrapper performs an expensive classpath scan in its constructor; it must be built exactly
+    // once (here, at ContextFactory construction) and shared, never rebuilt per execution context.
+    SparkOpenLineageExtensionVisitorWrapper wrapper = factory.getVisitorWrapper();
+    assertThat(wrapper).isNotNull();
+
+    factory.createSparkApplicationExecutionContext(sparkContext);
+    factory.createRddExecutionContext(0);
+
+    // Same instance after creating contexts guards against regressing to a per-execution
+    // `new SparkOpenLineageExtensionVisitorWrapper(config)` (the source of the listener deadlock).
+    assertThat(factory.getVisitorWrapper()).isSameAs(wrapper);
   }
 }


### PR DESCRIPTION
When a Spark job's classpath JARs live on S3 (`--jars`/`ADD JAR s3://…`), the OpenLineage listener could deadlock the driver. `ContextFactory` rebuilt a `SparkOpenLineageExtensionVisitorWrapper` on every SQL execution start, and its constructor scans the classpath (`ServiceLoader`, `Thread.getAllStackTraces`, reflective `defineClass`) on the listener thread. 

With S3 JARs that scan takes the classloader's `URLClassPath` lock and then needs the AWS S3 connection-pool lock — the opposite order to the driver thread running `ADD JAR s3://…`, which holds the pool lock and then wants `URLClassPath`. 

This PR builds the wrapper only once, in the `ContextFactory` constructor, and reuses that single instance everywhere. The discovered providers don't change during the JVM's lifetime, so the per-query rescan was both the deadlock trigger and wasted work. The only tradeoff is that a provider added on a new classloader after startup is no longer picked up, which is fine since such connectors are already on the startup classpath.

### Checklist
- [x] AI was used in creating this PR
