### PR TITLE
refactor of builder

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
@@ -8,8 +8,6 @@ package io.openlineage.spark.agent.lifecycle.plan;
 import static io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -98,7 +96,6 @@ class SaveIntoDataSourceCommandVisitorTest {
     when(command.query()).thenReturn(localRelation);
     when(localRelation.output())
         .thenReturn(ScalaConversionUtils.fromList(Arrays.asList(attr1, attr2)).toSeq());
-    when(datasetFactory.getDataset(any(), any(), eq(OVERWRITE))).thenReturn(dataset);
 
     List<OpenLineage.OutputDataset> datasets =
         visitor.apply(mock(SparkListenerEvent.class), command);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
@@ -45,8 +45,8 @@ public abstract class AbstractRDDNodeVisitor<T extends LogicalPlan, D extends Op
         .map(
             di ->
                 schema != null
-                    ? datasetFactory.getDataset(di, schema)
-                    : datasetFactory.getDataset(di))
+                    ? datasetFactory.sparkDatasetBuilder().dataset(di).schema(schema).build()
+                    : datasetFactory.sparkDatasetBuilder().dataset(di).build())
         .collect(Collectors.toList());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
@@ -41,9 +40,12 @@ public class AlterTableAddColumnsCommandVisitor
     if (tableColumns.containsAll(addedColumns)) {
       return Collections.singletonList(
           outputDataset()
-              .getDataset(
-                  PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
-                  catalogTable.schema()));
+              .sparkDatasetBuilder()
+              .dataset(catalogTable)
+              .schema(catalogTable.schema())
+              .lifecycleStateChange(
+                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
+              .build());
     } else {
       // apply triggered before applying the change - do not send an event
       return Collections.emptyList();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -39,8 +38,11 @@ public class AlterTableAddPartitionCommandVisitor
     // The generated datasets will not include partition nor location information
     return Collections.singletonList(
         outputDataset()
-            .getDataset(
-                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
-                catalogTable.schema()));
+            .sparkDatasetBuilder()
+            .dataset(catalogTable)
+            .schema(catalogTable.schema())
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
+            .build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -6,11 +6,9 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -41,36 +39,15 @@ public class AlterTableRenameCommandVisitor
 
     DatasetIdentifier di = PathUtils.fromCatalogTable(table, context.getSparkSession().get());
 
-    AlterTableRenameCommand alterTableRenameCommand = (AlterTableRenameCommand) x;
-    String previousName =
-        di.getName()
-            .replace(
-                alterTableRenameCommand.newName().table(),
-                alterTableRenameCommand.oldName().table());
+    AlterTableRenameCommand cmd = (AlterTableRenameCommand) x;
+    String previousName = di.getName().replace(cmd.newName().table(), cmd.oldName().table());
 
-    OpenLineage.LifecycleStateChangeDatasetFacet lifecycleStateChangeDatasetFacet =
-        context
-            .getOpenLineage()
-            .newLifecycleStateChangeDatasetFacetBuilder()
-            .lifecycleStateChange(
-                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.RENAME)
-            .previousIdentifier(
-                new OpenLineage.LifecycleStateChangeDatasetFacetPreviousIdentifierBuilder()
-                    .name(previousName)
-                    .namespace(di.getNamespace()) // namespace renaming is not allowed in
-                    // AlterTableRenameCommand
-                    .build())
-            .build();
-
-    DatasetFactory<OpenLineage.OutputDataset> factory = outputDataset();
-
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
-    datasetFacetsBuilder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), table.schema()))
-        .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()))
-        .lifecycleStateChange(lifecycleStateChangeDatasetFacet);
-
-    return Collections.singletonList(factory.getDataset(di, datasetFacetsBuilder));
+    return Collections.singletonList(
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di)
+            .schema(table.schema())
+            .lifecycleStateChange(LifecycleStateChange.RENAME, previousName, di.getNamespace())
+            .build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -39,8 +38,11 @@ public class AlterTableSetLocationCommandVisitor
     // The generated datasets will not include partition nor location information
     return Collections.singletonList(
         outputDataset()
-            .getDataset(
-                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
-                catalogTable.schema()));
+            .sparkDatasetBuilder()
+            .dataset(catalogTable)
+            .schema(catalogTable.schema())
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
+            .build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java
@@ -77,8 +77,11 @@ public class BigQueryNodeInputVisitor
                 }
               }
               return Collections.singletonList(
-                  factory.getDataset(
-                      getBigQueryTableName(relation).get(), BIGQUERY_NAMESPACE, relation.schema()));
+                  factory
+                      .sparkDatasetBuilder()
+                      .dataset(getBigQueryTableName(relation).get(), BIGQUERY_NAMESPACE)
+                      .schema(relation.schema())
+                      .build());
             })
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeOutputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeOutputVisitor.java
@@ -90,14 +90,17 @@ public class BigQueryNodeOutputVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan plan) {
     SaveIntoDataSourceCommand saveCommand = (SaveIntoDataSourceCommand) plan;
     Optional<SparkSession> session = SparkSessionUtils.activeSession();
-    if (session.isPresent()) {
-      return Collections.singletonList(
-          factory.getDataset(
-              getFromSaveIntoDataSourceCommand(saveCommand, session.get()),
-              BIGQUERY_NAMESPACE,
-              saveCommand.schema()));
-    } else {
-      return Collections.emptyList();
-    }
+    return session
+        .map(
+            sparkSession ->
+                Collections.singletonList(
+                    factory
+                        .sparkDatasetBuilder()
+                        .dataset(
+                            getFromSaveIntoDataSourceCommand(saveCommand, sparkSession),
+                            BIGQUERY_NAMESPACE)
+                        .schema(saveCommand.schema())
+                        .build()))
+        .orElse(Collections.emptyList());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
@@ -6,17 +6,19 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand;
 import org.apache.spark.sql.types.StructType;
 
+@Slf4j
 /**
  * {@link LogicalPlan} visitor that matches an {@link CreateDataSourceTableAsSelectCommand} and
  * extracts the output {@link OpenLineage.Dataset} being written.
@@ -30,24 +32,31 @@ public class CreateDataSourceTableAsSelectCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
-    if (!context.getSparkSession().isPresent()) {
-      return Collections.emptyList();
-    }
+    return context
+        .getSparkSession()
+        .map(
+            session -> {
+              CreateDataSourceTableAsSelectCommand command =
+                  (CreateDataSourceTableAsSelectCommand) x;
+              CatalogTable catalogTable = command.table();
 
-    CreateDataSourceTableAsSelectCommand command = (CreateDataSourceTableAsSelectCommand) x;
-    CatalogTable catalogTable = command.table();
-
-    // Sometimes the schema is missing from the catalog (e.g., when the table doesn't yet exist)
-    StructType schema = catalogTable.schema();
-    if (schema.fields().length == 0 && command.query().schema().fields().length > 0) {
-      schema = command.query().schema();
-    }
-    return Collections.singletonList(
-        outputDataset()
-            .getDataset(
-                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
-                schema,
-                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE));
+              // Sometimes the schema is missing from the catalog (e.g., when the table doesn't yet
+              // exist). Use the catalog schema if it has fields, otherwise fall back to the query
+              // schema.
+              StructType querySchema = command.query().schema();
+              StructType schema =
+                  Optional.of(catalogTable.schema())
+                      .filter(s -> s.fields().length > 0)
+                      .orElse(querySchema);
+              return Collections.singletonList(
+                  outputDataset()
+                      .sparkDatasetBuilder()
+                      .dataset(catalogTable)
+                      .schema(schema)
+                      .lifecycleStateChange(LifecycleStateChange.CREATE)
+                      .build());
+            })
+        .orElse(Collections.emptyList());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -35,13 +34,14 @@ public class CreateDataSourceTableCommandVisitor
 
     CreateDataSourceTableCommand command = (CreateDataSourceTableCommand) x;
     CatalogTable catalogTable = command.table();
-
     return Collections.singletonList(
         outputDataset()
-            .getDataset(
-                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
-                catalogTable.schema(),
-                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE));
+            .sparkDatasetBuilder()
+            .dataset(catalogTable)
+            .schema(catalogTable.schema())
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE)
+            .build());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
@@ -7,7 +7,6 @@ package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -55,24 +54,15 @@ public class CreateHiveTableAsSelectCommandVisitor
             index ->
                 schemaAttributes.add(
                     attributes.get(index).withName(command.outputColumnNames().apply(index))));
-
     return Collections.singletonList(
-        CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context)
-            .map(
-                catalogDatasetFacet ->
-                    outputDataset()
-                        .getDataset(
-                            di,
-                            outputSchema(schemaAttributes),
-                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                                .CREATE,
-                            catalogDatasetFacet))
-            .orElse(
-                outputDataset()
-                    .getDataset(
-                        di,
-                        outputSchema(schemaAttributes),
-                        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE)));
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di)
+            .schema(outputSchema(schemaAttributes))
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE)
+            .catalog()
+            .build());
   }
 
   private StructType outputSchema(List<Attribute> attrs) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
@@ -48,10 +48,12 @@ public class CreateTableCommandVisitor
 
     return Collections.singletonList(
         outputDataset()
-            .getDataset(
-                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
-                catalogTable.schema(),
-                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE));
+            .sparkDatasetBuilder()
+            .dataset(catalogTable)
+            .schema(catalogTable.schema())
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE)
+            .build());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
@@ -6,11 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -40,22 +35,12 @@ public class DropTableCommandVisitor
     if (!table.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
-
-    DatasetIdentifier datasetIdentifier =
-        PathUtils.fromCatalogTable(table.get(), context.getSparkSession().get());
-
-    DatasetFactory<OpenLineage.OutputDataset> factory = outputDataset();
-    DatasetCompositeFacetsBuilder facetsBuilder = factory.createCompositeFacetBuilder();
-    facetsBuilder
-        .getFacets()
-        .schema(null)
-        .dataSource(
-            PlanUtils.datasourceFacet(context.getOpenLineage(), datasetIdentifier.getNamespace()))
-        .lifecycleStateChange(
-            context
-                .getOpenLineage()
-                .newLifecycleStateChangeDatasetFacet(
-                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP, null));
-    return Collections.singletonList(factory.getDataset(datasetIdentifier, facetsBuilder));
+    return Collections.singletonList(
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(table.get())
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP)
+            .build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
@@ -6,9 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage.Dataset;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
@@ -41,14 +38,12 @@ public class HiveTableRelationVisitor<D extends Dataset>
     }
 
     HiveTableRelation hiveTable = (HiveTableRelation) x;
-    DatasetIdentifier datasetId =
-        PathUtils.fromCatalogTable(hiveTable.tableMeta(), context.getSparkSession().get());
-
     return Collections.singletonList(
-        CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context)
-            .map(
-                catalogDatasetFacet ->
-                    factory.getDataset(datasetId, x.schema(), catalogDatasetFacet))
-            .orElse(factory.getDataset(datasetId, x.schema())));
+        factory
+            .sparkDatasetBuilder()
+            .dataset(hiveTable.tableMeta())
+            .schema(x.schema())
+            .catalog()
+            .build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
@@ -6,10 +6,9 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -30,20 +29,15 @@ public class InsertIntoDataSourceDirVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoDataSourceDirCommand command = (InsertIntoDataSourceDirCommand) x;
     // URI is required by the InsertIntoDataSourceDirCommand
-    DatasetIdentifier di = PathUtils.fromURI(command.storage().locationUri().get());
-
-    OpenLineage.OutputDataset outputDataset;
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(command.storage().locationUri().get())
+            .schema(command.schema());
     if (command.overwrite()) {
-      outputDataset =
-          outputDataset()
-              .getDataset(
-                  di,
-                  command.schema(),
-                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
-    } else {
-      outputDataset = outputDataset().getDataset(di, command.schema());
+      builder.lifecycleStateChange(
+          OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
     }
-
-    return Collections.singletonList(outputDataset);
+    return Collections.singletonList(builder.build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
@@ -13,6 +13,7 @@ import io.openlineage.spark.agent.util.OpenLineageAbstractPartialFunction;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkOutputDatasetCompositeFacetsBuilder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -52,23 +53,13 @@ public class InsertIntoDataSourceVisitor
               ds.getFacets().getAdditionalProperties().putAll(facetsMap.build());
               if (command.overwrite()) {
                 // rebuild whole dataset with a LifecycleStateChange facet added
-                OpenLineage.DatasetFacets facets =
-                    DatasetFacetsUtils.copyToBuilder(context, ds.getFacets())
-                        .lifecycleStateChange(
-                            context
-                                .getOpenLineage()
-                                .newLifecycleStateChangeDatasetFacet(
-                                    OpenLineage.LifecycleStateChangeDatasetFacet
-                                        .LifecycleStateChange.OVERWRITE,
-                                    null))
-                        .build();
-
-                OpenLineage.OutputDataset newDs =
-                    context
-                        .getOpenLineage()
-                        .newOutputDataset(
-                            ds.getNamespace(), ds.getName(), facets, ds.getOutputFacets());
-                return newDs;
+                SparkOutputDatasetCompositeFacetsBuilder builder =
+                    new SparkOutputDatasetCompositeFacetsBuilder(context);
+                return builder
+                    .fromBuilder(DatasetFacetsUtils.copyToBuilder(context, ds.getFacets()))
+                    .lifecycleStateChange(
+                        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE)
+                    .build();
               }
               return ds;
             })

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
@@ -6,11 +6,10 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -37,20 +36,14 @@ public class InsertIntoDirVisitor
     return optionalUri
         .map(
             uri -> {
-              DatasetIdentifier di = PathUtils.fromURI(uri);
-              OpenLineage.OutputDataset outputDataset;
+              SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+                  outputDataset().sparkDatasetBuilder().dataset(uri).schema(cmd.child().schema());
               if (cmd.overwrite()) {
-                outputDataset =
-                    outputDataset()
-                        .getDataset(
-                            di,
-                            cmd.child().schema(),
-                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                                .OVERWRITE);
-              } else {
-                outputDataset = outputDataset().getDataset(di, cmd.child().schema());
+                builder.lifecycleStateChange(
+                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
               }
-              return Collections.singletonList(outputDataset);
+
+              return Collections.singletonList(builder.build());
             })
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -10,6 +10,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -32,24 +33,21 @@ public class InsertIntoHadoopFsRelationVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoHadoopFsRelationCommand command = (InsertIntoHadoopFsRelationCommand) x;
 
-    Optional<DatasetIdentifier> di = getDatasetIdentifier(command);
-    if (!di.isPresent()) {
-      return Collections.emptyList();
-    }
-
-    OpenLineage.OutputDataset outputDataset;
-    if (SaveMode.Overwrite == command.mode()) {
-      outputDataset =
-          outputDataset()
-              .getDataset(
-                  di.get(),
-                  command.query().schema(),
-                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
-    } else {
-      outputDataset = outputDataset().getDataset(di.get(), command.query().schema());
-    }
-
-    return Collections.singletonList(outputDataset);
+    return getDatasetIdentifier(command)
+        .map(
+            di -> {
+              SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+                  outputDataset()
+                      .sparkDatasetBuilder()
+                      .dataset(di)
+                      .schema(command.query().schema());
+              if (SaveMode.Overwrite == command.mode()) {
+                builder.lifecycleStateChange(
+                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+              }
+              return Collections.singletonList(builder.build());
+            })
+        .orElse(Collections.emptyList());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
@@ -6,11 +6,12 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -33,45 +34,20 @@ public class InsertIntoHiveDirVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoHiveDirCommand cmd = (InsertIntoHiveDirCommand) x;
     Optional<URI> optionalUri = ScalaConversionUtils.asJavaOptional(cmd.storage().locationUri());
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacetForHive =
-        CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
+
     return optionalUri
         .map(
             uri -> {
-              OpenLineage.OutputDataset outputDataset;
+              SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+                  outputDataset()
+                      .sparkDatasetBuilder()
+                      .dataset(uri)
+                      .schema(cmd.query().schema())
+                      .catalog();
               if (cmd.overwrite()) {
-                outputDataset =
-                    catalogDatasetFacetForHive
-                        .map(
-                            catalogFacet ->
-                                outputDataset()
-                                    .getDataset(
-                                        PathUtils.fromURI(uri),
-                                        cmd.query().schema(),
-                                        OpenLineage.LifecycleStateChangeDatasetFacet
-                                            .LifecycleStateChange.OVERWRITE,
-                                        catalogFacet))
-                        .orElse(
-                            outputDataset()
-                                .getDataset(
-                                    PathUtils.fromURI(uri),
-                                    cmd.query().schema(),
-                                    OpenLineage.LifecycleStateChangeDatasetFacet
-                                        .LifecycleStateChange.OVERWRITE));
-
-              } else {
-                outputDataset =
-                    catalogDatasetFacetForHive
-                        .map(
-                            catalogFacet ->
-                                outputDataset()
-                                    .getDataset(
-                                        PathUtils.fromURI(uri), cmd.query().schema(), catalogFacet))
-                        .orElse(
-                            outputDataset()
-                                .getDataset(PathUtils.fromURI(uri), cmd.query().schema()));
+                builder.lifecycleStateChange(LifecycleStateChange.OVERWRITE);
               }
-              return Collections.singletonList(outputDataset);
+              return Collections.singletonList(builder.build());
             })
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
@@ -6,10 +6,10 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -48,47 +48,13 @@ public class InsertIntoHiveTableVisitor
 
     InsertIntoHiveTable cmd = (InsertIntoHiveTable) x;
     CatalogTable table = cmd.table();
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacetForHive =
-        CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
-    OpenLineage.OutputDataset outputDataset;
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+        outputDataset().sparkDatasetBuilder().dataset(table).schema(table.schema()).catalog();
     if (cmd.overwrite()) {
-      outputDataset =
-          catalogDatasetFacetForHive
-              .map(
-                  catalogDatasetFacet ->
-                      outputDataset()
-                          .getDataset(
-                              PathUtils.fromCatalogTable(table, context.getSparkSession().get()),
-                              table.schema(),
-                              OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                                  .OVERWRITE,
-                              catalogDatasetFacet))
-              .orElse(
-                  outputDataset()
-                      .getDataset(
-                          PathUtils.fromCatalogTable(table, context.getSparkSession().get()),
-                          table.schema(),
-                          OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                              .OVERWRITE));
-
-    } else {
-      outputDataset =
-          catalogDatasetFacetForHive
-              .map(
-                  catalogDatasetFacet ->
-                      outputDataset()
-                          .getDataset(
-                              PathUtils.fromCatalogTable(table, context.getSparkSession().get()),
-                              table.schema(),
-                              catalogDatasetFacet))
-              .orElse(
-                  outputDataset()
-                      .getDataset(
-                          PathUtils.fromCatalogTable(table, context.getSparkSession().get()),
-                          table.schema()));
+      builder.lifecycleStateChange(
+          OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
     }
-
-    return Collections.singletonList(outputDataset);
+    return Collections.singletonList(builder.build());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaMicroBatchStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaMicroBatchStreamStrategy.java
@@ -83,7 +83,8 @@ public final class KafkaMicroBatchStreamStrategy extends StreamStrategy {
 
     List<InputDataset> datasets = new ArrayList<>();
     for (String topic : topics) {
-      InputDataset dataset = datasetFactory.getDataset(topic, namespace, schema);
+      InputDataset dataset =
+          datasetFactory.sparkDatasetBuilder().dataset(topic, namespace).schema(schema).build();
       datasets.add(dataset);
     }
     return datasets;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
@@ -239,7 +239,13 @@ public class KafkaRelationVisitor<D extends OpenLineage.Dataset>
 
     String namespace = KafkaBootstrapServerResolver.resolve(servers);
     return topics.stream()
-        .map(topic -> datasetFactory.getDataset(topic, namespace, schema))
+        .map(
+            topic ->
+                datasetFactory
+                    .sparkDatasetBuilder()
+                    .dataset(topic, namespace)
+                    .schema(schema)
+                    .build())
         .collect(Collectors.toList());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KinesisMicroBatchStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KinesisMicroBatchStreamStrategy.java
@@ -39,19 +39,22 @@ public class KinesisMicroBatchStreamStrategy extends StreamStrategy {
     Optional<String> endpointUrl = tryReadField(options.get(), "endpointUrl");
     Optional<String> streamName = tryReadField(options.get(), "streamName");
 
+    String namespace =
+        "kinesis://"
+            + endpointUrl
+                .map(URI::create)
+                .map(
+                    uri ->
+                        isValidPort(uri.getPort())
+                            ? uri.getHost() + ":" + uri.getPort()
+                            : uri.getHost())
+                .orElse("");
     return Collections.singletonList(
-        datasetFactory.getDataset(
-            streamName.orElse(""),
-            "kinesis://"
-                + endpointUrl
-                    .map(URI::create)
-                    .map(
-                        uri ->
-                            isValidPort(uri.getPort())
-                                ? uri.getHost() + ":" + uri.getPort()
-                                : uri.getHost())
-                    .orElse(""),
-            schema));
+        datasetFactory
+            .sparkDatasetBuilder()
+            .dataset(streamName.orElse(""), namespace)
+            .schema(schema)
+            .build());
   }
 
   boolean isValidPort(int port) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
@@ -159,23 +159,25 @@ public class KustoRelationVisitor<D extends OpenLineage.Dataset>
 
     String namespace =
         String.format("%s%s%s/%s", KUSTO_PREFIX, kustoCluster, KUSTO_URL_SUFFIX, database);
-    output = Collections.singletonList(datasetFactory.getDataset(name, namespace, schema));
+    output =
+        Collections.singletonList(
+            datasetFactory.sparkDatasetBuilder().dataset(name, namespace).schema(schema).build());
     return output;
   }
 
   @Override
   public List<D> apply(LogicalPlan x) {
     BaseRelation relation = ((LogicalRelation) x).relation();
-    List<D> output;
     Optional<String> name = getName(relation);
     Optional<String> namespace = getNamespace(relation);
     if (name.isPresent() && namespace.isPresent()) {
-      output =
-          Collections.singletonList(
-              factory.getDataset(name.get(), namespace.get(), relation.schema()));
-    } else {
-      output = Collections.emptyList();
+      return Collections.singletonList(
+          factory
+              .sparkDatasetBuilder()
+              .dataset(name.get(), namespace.get())
+              .schema(relation.schema())
+              .build());
     }
-    return output;
+    return Collections.emptyList();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -40,9 +39,10 @@ public class LoadDataCommandVisitor
             table ->
                 Collections.singletonList(
                     outputDataset()
-                        .getDataset(
-                            PathUtils.fromCatalogTable(table, context.getSparkSession().get()),
-                            table.schema())))
+                        .sparkDatasetBuilder()
+                        .dataset(table)
+                        .schema(table.schema())
+                        .build()))
         .orElseGet(Collections::emptyList);
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -18,7 +18,9 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -134,12 +136,9 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
     DatasetIdentifier di =
         PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get());
 
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder =
-        datasetFactory.createCompositeFacetBuilder();
-    datasetFacetsBuilder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), logRel.schema()))
-        .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()));
+    SparkDatasetCompositeFacetsBuilder<D> sparkBuilder =
+        datasetFactory.sparkDatasetBuilder().dataset(di).schema(logRel.schema());
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder = sparkBuilder.getInner();
 
     InputStatisticsInputDatasetFacetBuilder statsBuilder =
         context.getOpenLineage().newInputStatisticsInputDatasetFacetBuilder();
@@ -173,7 +172,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
             v -> DatasetVersionUtils.buildVersionOutputFacets(context, datasetFacetsBuilder, v));
 
     addCatalogAndStorageFacets(catalogTable, datasetFacetsBuilder);
-    return Collections.singletonList(datasetFactory.getDataset(di, datasetFacetsBuilder));
+    return Collections.singletonList(sparkBuilder.build());
   }
 
   private List<D> handleHadoopFsRelation(LogicalRelation x) {
@@ -186,53 +185,34 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
                 Configuration hadoopConfig =
                     session.sessionState().newHadoopConfWithOptions(relation.options());
 
-                DatasetCompositeFacetsBuilder datasetFacetsBuilder =
-                    datasetFactory.createCompositeFacetBuilder();
-                getDatasetVersion(x)
-                    .map(
-                        version ->
-                            datasetFacetsBuilder
-                                .getFacets()
-                                .version(
-                                    context
-                                        .getOpenLineage()
-                                        .newDatasetVersionDatasetFacet(version)));
+                Optional<OpenLineage.DatasetVersionDatasetFacet> datasetVersion =
+                    getDatasetVersion(x)
+                        .map(v -> context.getOpenLineage().newDatasetVersionDatasetFacet(v));
 
-                if (relation.inputFiles() != null) {
-                  datasetFacetsBuilder
-                      .getInputFacets()
-                      .inputStatistics(
-                          context
-                              .getOpenLineage()
-                              .newInputStatisticsInputDatasetFacetBuilder()
-                              .size(relation.sizeInBytes())
-                              .fileCount(
-                                  Optional.of(relation.inputFiles())
-                                      .map(l -> l.length)
-                                      .map(Long::valueOf)
-                                      .orElse(0L))
-                              .build());
-                }
+                Optional<OpenLineage.InputStatisticsInputDatasetFacet> inputStats =
+                    Optional.ofNullable(relation.inputFiles())
+                        .map(
+                            files ->
+                                context
+                                    .getOpenLineage()
+                                    .newInputStatisticsInputDatasetFacetBuilder()
+                                    .size(relation.sizeInBytes())
+                                    .fileCount((long) files.length)
+                                    .build());
 
                 Collection<Path> rootPaths =
                     ScalaConversionUtils.fromSeq(relation.location().rootPaths());
 
                 if (isSingleFileRelation(rootPaths, hadoopConfig)) {
                   return Collections.singletonList(
-                      datasetFactory.getDataset(
+                      buildHadoopDataset(
                           rootPaths.stream().findFirst().get().toUri(),
-                          relation.schema(),
-                          datasetFacetsBuilder));
+                          relation,
+                          datasetVersion,
+                          inputStats));
                 } else {
                   return PlanUtils.getDirectoryPaths(rootPaths, hadoopConfig).stream()
-                      .map(
-                          p -> {
-                            // TODO- refactor this to return a single partitioned dataset based on
-                            // static
-                            // static partitions in the relation
-                            return datasetFactory.getDataset(
-                                p.toUri(), relation.schema(), datasetFacetsBuilder);
-                          })
+                      .map(p -> buildHadoopDataset(p.toUri(), relation, datasetVersion, inputStats))
                       .collect(Collectors.toList());
                 }
               })
@@ -258,7 +238,12 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
       List<Path> paths =
           new ArrayList<>(ScalaConversionUtils.fromSeq(relation.location().rootPaths()));
       for (Path p : paths) {
-        inputDatasets.add(datasetFactory.getDataset(p.toUri(), relation.schema()));
+        inputDatasets.add(
+            datasetFactory
+                .sparkDatasetBuilder()
+                .dataset(p.toUri())
+                .schema(relation.schema())
+                .build());
       }
       if (inputDatasets.isEmpty()) {
         return Collections.emptyList();
@@ -266,6 +251,18 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
         return inputDatasets;
       }
     }
+  }
+
+  private D buildHadoopDataset(
+      URI uri,
+      HadoopFsRelation relation,
+      Optional<OpenLineage.DatasetVersionDatasetFacet> datasetVersion,
+      Optional<OpenLineage.InputStatisticsInputDatasetFacet> inputStats) {
+    SparkDatasetCompositeFacetsBuilder<D> b =
+        datasetFactory.sparkDatasetBuilder().dataset(uri).schema(relation.schema());
+    datasetVersion.ifPresent(b::version);
+    inputStats.ifPresent(s -> b.getInner().getInputFacets().inputStatistics(s));
+    return b.build();
   }
 
   @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/MongoMicroBatchStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/MongoMicroBatchStreamStrategy.java
@@ -38,8 +38,11 @@ public class MongoMicroBatchStreamStrategy extends StreamStrategy {
               String connectionURL = option.get("spark.mongodb.connection.uri");
               String collectionName = option.get("spark.mongodb.collection");
 
-              return datasetFactory.getDataset(
-                  collectionName, connectionURL + "/" + databaseName, schema);
+              return datasetFactory
+                  .sparkDatasetBuilder()
+                  .dataset(collectionName, connectionURL + "/" + databaseName)
+                  .schema(schema)
+                  .build();
             });
 
     return dataset.map(Arrays::asList).orElseGet(ArrayList::new);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
@@ -11,6 +11,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.SaveMode;
@@ -63,19 +64,14 @@ public class OptimizedCreateHiveTableAsSelectCommandVisitor
         PathUtils.fromCatalogTable(table, context.getSparkSession().get());
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
 
-    OpenLineage.OutputDataset outputDataset;
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> builder =
+        outputDataset().sparkDatasetBuilder().dataset(datasetIdentifier).schema(schema);
     if ((SaveMode.Overwrite == command.mode())) {
-      outputDataset =
-          outputDataset()
-              .getDataset(
-                  datasetIdentifier,
-                  schema,
-                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
-    } else {
-      outputDataset = outputDataset().getDataset(datasetIdentifier, schema);
+      builder.lifecycleStateChange(
+          OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
     }
 
-    return Collections.singletonList(outputDataset);
+    return Collections.singletonList(builder.build());
   }
 
   private StructType outputSchema(List<Attribute> attrs) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -17,7 +17,6 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.jdbc.JdbcDatasetUtils;
 import io.openlineage.spark.agent.util.DatasetFacetsUtils;
 import io.openlineage.spark.agent.util.LogicalRelationFactory;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
@@ -109,7 +108,11 @@ public class SaveIntoDataSourceCommandVisitor
 
       return datasetIdentifier != null
           ? Collections.singletonList(
-              outputDataset().getDataset(datasetIdentifier, getSchema(command)))
+              outputDataset()
+                  .sparkDatasetBuilder()
+                  .dataset(datasetIdentifier)
+                  .schema(getSchema(command))
+                  .build())
           : Collections.emptyList();
     }
 
@@ -144,9 +147,13 @@ public class SaveIntoDataSourceCommandVisitor
 
     if (command.dataSource().getClass().getName().contains("DeltaDataSource")) {
       if (command.options().contains("path")) {
-        URI uri = URI.create(command.options().get("path").get());
         return Collections.singletonList(
-            outputDataset().getDataset(PathUtils.fromURI(uri), schema, lifecycleStateChange));
+            outputDataset()
+                .sparkDatasetBuilder()
+                .dataset(URI.create(command.options().get("path").get()))
+                .schema(schema)
+                .lifecycleStateChange(lifecycleStateChange)
+                .build());
       }
     }
 
@@ -157,10 +164,13 @@ public class SaveIntoDataSourceCommandVisitor
         .equals(JdbcRelationProvider.class.getCanonicalName())) {
       String tableName = command.options().get("dbtable").get();
       String url = command.options().get("url").get();
-      DatasetIdentifier identifier =
-          JdbcDatasetUtils.getDatasetIdentifier(url, tableName, new Properties());
       return Collections.singletonList(
-          outputDataset().getDataset(identifier, schema, lifecycleStateChange));
+          outputDataset()
+              .sparkDatasetBuilder()
+              .dataset(JdbcDatasetUtils.getDatasetIdentifier(url, tableName, new Properties()))
+              .schema(schema)
+              .lifecycleStateChange(lifecycleStateChange)
+              .build());
     }
 
     SQLContext sqlContext = context.getSparkSession().get().sqlContext();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlDWDatabricksVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlDWDatabricksVisitor.java
@@ -127,6 +127,6 @@ public class SqlDWDatabricksVisitor<D extends OpenLineage.Dataset>
     DatasetIdentifier di =
         JdbcDatasetUtils.getDatasetIdentifier(jdbcUrl.get(), name.get(), new Properties());
     return Collections.singletonList(
-        factory.getDataset(di.getName(), di.getNamespace(), relation.schema()));
+        factory.sparkDatasetBuilder().dataset(di).schema(relation.schema()).build());
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
@@ -7,11 +7,8 @@ package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.OutputDataset;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -42,25 +39,13 @@ public class TruncateTableCommandVisitor
     if (!tableOpt.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
-
-    CatalogTable table = tableOpt.get();
-    DatasetIdentifier datasetIdentifier =
-        PathUtils.fromCatalogTable(table, context.getSparkSession().get());
-
-    DatasetFactory<OutputDataset> datasetFactory = outputDataset();
-    DatasetCompositeFacetsBuilder facetsBuilder = datasetFactory.createCompositeFacetBuilder();
-    facetsBuilder
-        .getFacets()
-        .schema(null)
-        .dataSource(
-            PlanUtils.datasourceFacet(context.getOpenLineage(), datasetIdentifier.getNamespace()))
-        .lifecycleStateChange(
-            context
-                .getOpenLineage()
-                .newLifecycleStateChangeDatasetFacet(
-                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.TRUNCATE,
-                    null));
-    return Collections.singletonList(datasetFactory.getDataset(datasetIdentifier, facetsBuilder));
+    return Collections.singletonList(
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(tableOpt.get())
+            .lifecycleStateChange(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.TRUNCATE)
+            .build());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
@@ -84,7 +84,8 @@ public final class WriteToDataSourceV2Visitor
     if (topicOpt.isPresent() && bootstrapServersOpt.isPresent()) {
       String topic = topicOpt.get();
 
-      OutputDataset dataset = outputDataset().getDataset(topic, namespace, schemaOpt);
+      OutputDataset dataset =
+          outputDataset().sparkDatasetBuilder().dataset(topic, namespace).schema(schemaOpt).build();
       return Collections.singletonList(dataset);
     } else {
       String topicPresent =

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/ExtensionLineageRelationHandler.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/ExtensionLineageRelationHandler.java
@@ -34,10 +34,10 @@ public class ExtensionLineageRelationHandler<D extends Dataset> {
             .getLineageDatasetIdentifier(x.relation(), event.getClass().getName());
 
     if (x.schema() != null) {
-      return Collections.singletonList(datasetFactory.getDataset(di, x.schema()));
-    } else {
       return Collections.singletonList(
-          datasetFactory.getDataset(di, datasetFactory.createCompositeFacetBuilder()));
+          datasetFactory.sparkDatasetBuilder().dataset(di).schema(x.schema()).build());
+    } else {
+      return Collections.singletonList(datasetFactory.sparkDatasetBuilder().dataset(di).build());
     }
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java
@@ -41,13 +41,13 @@ public class SqlUtils {
             meta ->
                 meta.inTables().stream()
                     .map(
-                        dbtm -> {
-                          return datasetFactory.getDataset(
-                              new DatasetIdentifier(
-                                  getName(defaultDatabase, defaultSchema, dbtm.qualifiedName()),
-                                  namespace),
-                              datasetFactory.createCompositeFacetBuilder());
-                        })
+                        dbtm ->
+                            datasetFactory
+                                .sparkDatasetBuilder()
+                                .dataset(
+                                    getName(defaultDatabase, defaultSchema, dbtm.qualifiedName()),
+                                    namespace)
+                                .build())
                     .collect(Collectors.toList()))
         .orElse(Collections.emptyList());
   }
@@ -78,10 +78,10 @@ public class SqlUtils {
                 DatasetIdentifier di = datasetIdentifierFunction.apply(dbtm);
 
                 if (numberOfTables > 1) {
-                  return datasetFactory.getDataset(di.getName(), di.getNamespace());
+                  return datasetFactory.sparkDatasetBuilder().dataset(di).build();
                 }
 
-                return datasetFactory.getDataset(di.getName(), di.getNamespace(), schema);
+                return datasetFactory.sparkDatasetBuilder().dataset(di).schema(schema).build();
               })
           .collect(Collectors.toList());
     }
@@ -89,8 +89,11 @@ public class SqlUtils {
         .map(
             dbtm -> {
               DatasetIdentifier di = datasetIdentifierFunction.apply(dbtm);
-              return datasetFactory.getDataset(
-                  di.getName(), di.getNamespace(), generateSchemaFromSqlMeta(dbtm, schema, meta));
+              return datasetFactory
+                  .sparkDatasetBuilder()
+                  .dataset(di)
+                  .schema(generateSchemaFromSqlMeta(dbtm, schema, meta))
+                  .build();
             })
         .collect(Collectors.toList());
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -8,24 +8,13 @@ package io.openlineage.spark.api;
 import static io.openlineage.client.OpenLineage.*;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.Builder;
-import io.openlineage.client.OpenLineage.DatasetFacets;
-import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.InputDataset;
-import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
-import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeOutputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark.agent.util.DatasetVersionUtils;
-import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
-import java.net.URI;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.spark.sql.types.StructType;
 
 /**
  * Defines factories for creating either {@link OpenLineage.InputDataset}s or {@link
@@ -53,12 +42,10 @@ public abstract class DatasetFactory<D extends Dataset> {
     this.namespaceResolver = new DatasetNamespaceCombinedResolver(context.getOpenLineageConfig());
   }
 
-  abstract OpenLineage.Builder<D> datasetBuilder(
-      String name, String namespace, DatasetCompositeFacetsBuilder facetsBuilder);
+  public abstract SparkDatasetCompositeFacetsBuilder<D> sparkDatasetBuilder();
 
-  @Deprecated
-  abstract OpenLineage.Builder<D> datasetBuilder(
-      String name, String namespace, DatasetFacets facets);
+  public abstract SparkDatasetCompositeFacetsBuilder<D> sparkDatasetBuilder(
+      DatasetCompositeFacetsBuilder inner);
 
   public abstract void buildVersionFacets(
       DatasetCompositeFacetsBuilder facetsBuilder, String version);
@@ -71,32 +58,21 @@ public abstract class DatasetFactory<D extends Dataset> {
    */
   public static DatasetFactory<OpenLineage.InputDataset> input(OpenLineageContext context) {
     return new DatasetFactory<OpenLineage.InputDataset>(context) {
-      @Override
-      public OpenLineage.Builder<OpenLineage.InputDataset> datasetBuilder(
-          String name, String namespace, DatasetCompositeFacetsBuilder facetsBuilder) {
-        return context
-            .getOpenLineage()
-            .newInputDatasetBuilder()
-            .namespace(namespaceResolver.resolve(namespace))
-            .name(name)
-            .inputFacets(facetsBuilder.getInputFacets().build())
-            .facets(facetsBuilder.getFacets().build());
-      }
-
-      @Deprecated
-      @Override
-      Builder<InputDataset> datasetBuilder(String name, String namespace, DatasetFacets facets) {
-        return context
-            .getOpenLineage()
-            .newInputDatasetBuilder()
-            .namespace(namespaceResolver.resolve(namespace))
-            .name(name)
-            .facets(facets);
-      }
 
       @Override
       public void buildVersionFacets(DatasetCompositeFacetsBuilder facetsBuilder, String version) {
         DatasetVersionUtils.buildVersionFacets(context, facetsBuilder, version);
+      }
+
+      @Override
+      public SparkDatasetCompositeFacetsBuilder<InputDataset> sparkDatasetBuilder() {
+        return new SparkInputDatasetCompositeFacetsBuilder(context);
+      }
+
+      @Override
+      public SparkDatasetCompositeFacetsBuilder<InputDataset> sparkDatasetBuilder(
+          DatasetCompositeFacetsBuilder inner) {
+        return new SparkInputDatasetCompositeFacetsBuilder(context, inner);
       }
     };
   }
@@ -109,273 +85,23 @@ public abstract class DatasetFactory<D extends Dataset> {
    */
   public static DatasetFactory<OpenLineage.OutputDataset> output(OpenLineageContext context) {
     return new DatasetFactory<OpenLineage.OutputDataset>(context) {
-      @Override
-      public OpenLineage.Builder<OpenLineage.OutputDataset> datasetBuilder(
-          String name, String namespace, DatasetCompositeFacetsBuilder facetsBuilder) {
-        return context
-            .getOpenLineage()
-            .newOutputDatasetBuilder()
-            .namespace(namespaceResolver.resolve(namespace))
-            .name(name)
-            .outputFacets(facetsBuilder.getOutputFacets().build())
-            .facets(facetsBuilder.getFacets().build());
-      }
-
-      @Deprecated
-      @Override
-      Builder<OutputDataset> datasetBuilder(String name, String namespace, DatasetFacets facets) {
-        return context
-            .getOpenLineage()
-            .newOutputDatasetBuilder()
-            .namespace(namespaceResolver.resolve(namespace))
-            .name(name)
-            .facets(facets);
-      }
 
       @Override
       public void buildVersionFacets(DatasetCompositeFacetsBuilder facetsBuilder, String version) {
         DatasetVersionUtils.buildVersionOutputFacets(context, facetsBuilder, version);
       }
+
+      @Override
+      public SparkDatasetCompositeFacetsBuilder<OutputDataset> sparkDatasetBuilder() {
+        return new SparkOutputDatasetCompositeFacetsBuilder(context);
+      }
+
+      @Override
+      public SparkDatasetCompositeFacetsBuilder<OutputDataset> sparkDatasetBuilder(
+          DatasetCompositeFacetsBuilder inner) {
+        return new SparkOutputDatasetCompositeFacetsBuilder(context, inner);
+      }
     };
-  }
-
-  /**
-   * Construct a dataset {@link Dataset} given a name, namespace, and {@link StructType} schema.
-   *
-   * @param name
-   * @param namespace
-   * @param schema
-   * @return
-   */
-  public D getDataset(String name, String namespace, StructType schema) {
-    DatasetCompositeFacetsBuilder facetsBuilder = createCompositeFacetBuilder();
-    facetsBuilder
-        .getFacets()
-        .dataSource(
-            PlanUtils.datasourceFacet(
-                context.getOpenLineage(), namespaceResolver.resolve(namespace)))
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema));
-
-    return datasetBuilder(name, namespace, facetsBuilder).build();
-  }
-
-  /**
-   * Given a {@link URI}, construct a valid {@link Dataset} following the expected naming
-   * conventions.
-   *
-   * @param outputPath
-   * @param schema
-   * @return
-   */
-  @Deprecated
-  public D getDataset(
-      URI outputPath, StructType schema, DatasetFacetsBuilder datasetFacetsBuilder) {
-    DatasetCompositeFacetsBuilder compositeFacetsBuilder =
-        new DatasetCompositeFacetsBuilder(context.openLineage);
-    compositeFacetsBuilder.setFacets(datasetFacetsBuilder);
-    return getDataset(outputPath, schema, compositeFacetsBuilder);
-  }
-
-  /**
-   * Given a {@link URI}, construct a valid {@link Dataset} following the expected naming
-   * conventions.
-   *
-   * @param outputPath
-   * @param schema
-   * @return
-   */
-  public D getDataset(
-      URI outputPath, StructType schema, DatasetCompositeFacetsBuilder datasetFacetsBuilder) {
-    DatasetIdentifier datasetIdentifier = PathUtils.fromURI(outputPath);
-    datasetFacetsBuilder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema))
-        .dataSource(
-            PlanUtils.datasourceFacet(
-                context.getOpenLineage(),
-                namespaceResolver.resolve(datasetIdentifier.getNamespace())));
-
-    return getDataset(datasetIdentifier, datasetFacetsBuilder);
-  }
-
-  /**
-   * Given a {@link URI}, construct a valid {@link Dataset} following the expected naming
-   * conventions.
-   *
-   * @param outputPath
-   * @param schema
-   * @return
-   */
-  public D getDataset(URI outputPath, StructType schema) {
-    String namespace = PlanUtils.namespaceUri(outputPath);
-    DatasetCompositeFacetsBuilder facetsBuilder = createCompositeFacetBuilder();
-    facetsBuilder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema))
-        .dataSource(
-            PlanUtils.datasourceFacet(
-                context.getOpenLineage(), namespaceResolver.resolve(namespace)));
-
-    return getDataset(PathUtils.fromURI(outputPath), facetsBuilder);
-  }
-
-  /**
-   * Construct a {@link Dataset} with the given {@link DatasetIdentifier}.
-   *
-   * @param ident
-   * @return
-   */
-  public D getDataset(DatasetIdentifier ident) {
-    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(ident.getNamespace());
-    includeSymlinksFacet(facetsBuilder, ident);
-    return getDataset(ident, facetsBuilder);
-  }
-
-  /**
-   * Construct a {@link Dataset} with the given {@link DatasetIdentifier} and schema.
-   *
-   * @param ident
-   * @param schema
-   * @return
-   */
-  public D getDataset(DatasetIdentifier ident, StructType schema) {
-    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(schema, ident.getNamespace());
-    includeSymlinksFacet(facetsBuilder, ident);
-    return getDataset(ident, facetsBuilder);
-  }
-
-  /**
-   * Construct a {@link Dataset} with the given {@link DatasetIdentifier}, schema and catalog facet.
-   *
-   * @param ident
-   * @param schema
-   * @param catalogDatasetFacet
-   * @return
-   */
-  public D getDataset(
-      DatasetIdentifier ident, StructType schema, CatalogDatasetFacet catalogDatasetFacet) {
-    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(schema, ident.getNamespace());
-    includeSymlinksFacet(facetsBuilder, ident);
-    includeCatalogFacet(facetsBuilder, catalogDatasetFacet);
-    return getDataset(ident, facetsBuilder);
-  }
-
-  /**
-   * Construct a {@link Dataset} with the given {@link DatasetIdentifier}, schema and facets map.
-   *
-   * @param ident
-   * @param schema
-   * @param lifecycleStateChange
-   * @return
-   */
-  public D getDataset(
-      DatasetIdentifier ident, StructType schema, LifecycleStateChange lifecycleStateChange) {
-    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(schema, ident.getNamespace());
-    facetsBuilder
-        .getFacets()
-        .lifecycleStateChange(
-            context
-                .getOpenLineage()
-                .newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null));
-    includeSymlinksFacet(facetsBuilder, ident);
-    return getDataset(new DatasetIdentifier(ident.getName(), ident.getNamespace()), facetsBuilder);
-  }
-
-  /**
-   * Construct a {@link Dataset} with the given {@link DatasetIdentifier}, schema and facets map.
-   *
-   * @param ident
-   * @param schema
-   * @param lifecycleStateChange
-   * @param catalogDatasetFacet
-   * @return
-   */
-  public D getDataset(
-      DatasetIdentifier ident,
-      StructType schema,
-      LifecycleStateChange lifecycleStateChange,
-      CatalogDatasetFacet catalogDatasetFacet) {
-    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(schema, ident.getNamespace());
-    facetsBuilder
-        .getFacets()
-        .lifecycleStateChange(
-            context
-                .getOpenLineage()
-                .newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null));
-    includeSymlinksFacet(facetsBuilder, ident);
-    includeCatalogFacet(facetsBuilder, catalogDatasetFacet);
-    return getDataset(new DatasetIdentifier(ident.getName(), ident.getNamespace()), facetsBuilder);
-  }
-
-  private void includeCatalogFacet(
-      DatasetCompositeFacetsBuilder builder, CatalogDatasetFacet catalogDatasetFacet) {
-    builder.getFacets().catalog(catalogDatasetFacet);
-  }
-
-  private void includeSymlinksFacet(DatasetCompositeFacetsBuilder builder, DatasetIdentifier di) {
-    if (!di.getSymlinks().isEmpty()) {
-      List<SymlinksDatasetFacetIdentifiers> symlinks =
-          di.getSymlinks().stream()
-              .map(
-                  symlink ->
-                      context
-                          .getOpenLineage()
-                          .newSymlinksDatasetFacetIdentifiersBuilder()
-                          .name(symlink.getName())
-                          .namespace(symlink.getNamespace())
-                          .type(symlink.getType().toString())
-                          .build())
-              .collect(Collectors.toList());
-
-      builder.getFacets().symlinks(context.getOpenLineage().newSymlinksDatasetFacet(symlinks));
-    }
-  }
-
-  /**
-   * Construct a {@link Dataset} with the given {@link DatasetIdentifier} and {@link
-   * OpenLineage.DatasetFacets}.
-   *
-   * @param ident
-   * @param facetsBuilder
-   * @return
-   */
-  public D getDataset(DatasetIdentifier ident, DatasetCompositeFacetsBuilder facetsBuilder) {
-    includeSymlinksFacet(facetsBuilder, ident);
-    return datasetBuilder(ident.getName(), ident.getNamespace(), facetsBuilder).build();
-  }
-
-  public D getDataset(String name, String namespace) {
-    return datasetBuilder(name, namespace, datasetFacetBuilder(namespace)).build();
-  }
-
-  /**
-   * Construct a {@link OpenLineage.DatasetFacets} given a schema and a namespace.
-   *
-   * @param schema
-   * @param namespaceUri
-   * @return
-   */
-  private DatasetCompositeFacetsBuilder datasetFacetBuilder(
-      StructType schema, String namespaceUri) {
-    DatasetCompositeFacetsBuilder builder = createCompositeFacetBuilder();
-    builder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema))
-        .dataSource(
-            PlanUtils.datasourceFacet(
-                context.getOpenLineage(), namespaceResolver.resolve(namespaceUri)));
-    return builder;
-  }
-
-  private DatasetCompositeFacetsBuilder datasetFacetBuilder(String namespaceUri) {
-    DatasetCompositeFacetsBuilder builder = createCompositeFacetBuilder();
-    builder
-        .getFacets()
-        .dataSource(
-            PlanUtils.datasourceFacet(
-                context.getOpenLineage(), namespaceResolver.resolve(namespaceUri)));
-
-    return builder;
   }
 
   public DatasetCompositeFacetsBuilder createCompositeFacetBuilder() {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkDatasetCompositeFacetsBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkDatasetCompositeFacetsBuilder.java
@@ -1,0 +1,206 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.api;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.CatalogDatasetFacet;
+import io.openlineage.client.OpenLineage.DatasetVersionDatasetFacet;
+import io.openlineage.client.OpenLineage.DatasourceDatasetFacet;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
+import io.openlineage.client.OpenLineage.SymlinksDatasetFacet;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.DatasetVersionUtils;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * A context-aware wrapper around {@link DatasetCompositeFacetsBuilder} that provides convenience
+ * overloads for facet-setter methods requiring an {@link OpenLineageContext}.
+ *
+ * <p>For example, {@link #schema(StructType)} converts a Spark {@link StructType} to a {@link
+ * SchemaDatasetFacet} using {@link PlanUtils#schemaFacet} internally, so callers do not need to
+ * hold a reference to the {@link OpenLineage} instance themselves.
+ *
+ * <p>All methods return {@code this} for fluent chaining. The underlying {@link
+ * DatasetCompositeFacetsBuilder} is accessible via {@link #getInner()} for passing to existing APIs
+ * that still require it.
+ */
+public abstract class SparkDatasetCompositeFacetsBuilder<T extends OpenLineage.Dataset> {
+
+  protected final OpenLineageContext context;
+  protected final DatasetNamespaceCombinedResolver namespaceResolver;
+
+  @Getter protected final DatasetCompositeFacetsBuilder inner;
+  @Getter protected String name;
+  @Getter protected String namespace;
+
+  public SparkDatasetCompositeFacetsBuilder(OpenLineageContext context) {
+    this(context, new DatasetCompositeFacetsBuilder(context.getOpenLineage()));
+  }
+
+  public SparkDatasetCompositeFacetsBuilder(
+      OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
+    this.context = context;
+    this.namespaceResolver = new DatasetNamespaceCombinedResolver(context.getOpenLineageConfig());
+    this.inner = inner;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataset(DatasetIdentifier datasetIdentifier) {
+    this.name = datasetIdentifier.getName();
+    this.namespace = datasetIdentifier.getNamespace();
+    dataSource(datasetIdentifier.getNamespace());
+    symlink(datasetIdentifier.getSymlinks());
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataset(String name, String namespace) {
+    return dataset(new DatasetIdentifier(name, namespace));
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataset(String name, URI outputPath) {
+    return dataset(new DatasetIdentifier(name, PlanUtils.namespaceUri(outputPath)));
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataset(URI outputPath) {
+    return dataset(PathUtils.fromURI(outputPath));
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataset(CatalogTable catalogTable) {
+    if (context.getSparkSession().isPresent()) {
+      dataset(PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()));
+    }
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> symlink(SymlinksDatasetFacet symlinksFacet) {
+    inner.getFacets().symlinks(symlinksFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> symlink(List<DatasetIdentifier.Symlink> symlinks) {
+    if (!symlinks.isEmpty()) {
+      List<OpenLineage.SymlinksDatasetFacetIdentifiers> symlinkIdentifiers =
+          symlinks.stream()
+              .map(
+                  symlink ->
+                      context
+                          .getOpenLineage()
+                          .newSymlinksDatasetFacetIdentifiersBuilder()
+                          .name(symlink.getName())
+                          .namespace(symlink.getNamespace())
+                          .type(symlink.getType().toString())
+                          .build())
+              .collect(Collectors.toList());
+      symlinks(
+          context
+              .getOpenLineage()
+              .newSymlinksDatasetFacetBuilder()
+              .identifiers(symlinkIdentifiers)
+              .build());
+    }
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> schema(SchemaDatasetFacet schemaFacet) {
+    inner.getFacets().schema(schemaFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> schema(StructType schema) {
+    return schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema));
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataSource(DatasourceDatasetFacet datasourceFacet) {
+    inner.getFacets().dataSource(datasourceFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> dataSource(String namespace) {
+    return dataSource(
+        PlanUtils.datasourceFacet(context.getOpenLineage(), namespaceResolver.resolve(namespace)));
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> catalog(CatalogDatasetFacet catalogFacet) {
+    inner.getFacets().catalog(catalogFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> catalog() {
+    CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context).ifPresent(this::catalog);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> symlinks(SymlinksDatasetFacet symlinksFacet) {
+    inner.getFacets().symlinks(symlinksFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+      LifecycleStateChangeDatasetFacet lifecycleFacet) {
+    inner.getFacets().lifecycleStateChange(lifecycleFacet);
+    return this;
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+      LifecycleStateChange lifecycleStateChange) {
+    return lifecycleStateChange(lifecycleStateChange, null);
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+      LifecycleStateChange lifecycleStateChange, String previousName, String previousNamespace) {
+    return lifecycleStateChange(
+        lifecycleStateChange,
+        context
+            .getOpenLineage()
+            .newLifecycleStateChangeDatasetFacetPreviousIdentifierBuilder()
+            .name(previousName)
+            .namespace(previousNamespace)
+            .build());
+  }
+
+  public SparkDatasetCompositeFacetsBuilder<T> lifecycleStateChange(
+      LifecycleStateChange lifecycleStateChange,
+      OpenLineage.LifecycleStateChangeDatasetFacetPreviousIdentifier previousIdentifier) {
+    return lifecycleStateChange(
+        context
+            .getOpenLineage()
+            .newLifecycleStateChangeDatasetFacetBuilder()
+            .lifecycleStateChange(lifecycleStateChange)
+            .previousIdentifier(previousIdentifier)
+            .build());
+  }
+
+  /**
+   * Sets the dataset version facet. For output datasets, also triggers vendor-specific output facet
+   * builders (e.g. Iceberg snapshot facets). Subclasses may override to provide richer behaviour.
+   */
+  public SparkDatasetCompositeFacetsBuilder<T> version(String version) {
+    DatasetVersionUtils.buildVersionFacets(context, inner, version);
+    return this;
+  }
+
+  /** Sets a pre-built {@link DatasetVersionDatasetFacet} directly on the facets builder. */
+  public SparkDatasetCompositeFacetsBuilder<T> version(DatasetVersionDatasetFacet versionFacet) {
+    inner.getFacets().version(versionFacet);
+    return this;
+  }
+
+  public abstract T build();
+
+  public abstract SparkDatasetCompositeFacetsBuilder<T> fromBuilder(
+      OpenLineage.DatasetFacetsBuilder facetsBuilder);
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkInputDatasetCompositeFacetsBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkInputDatasetCompositeFacetsBuilder.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.api;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+
+public class SparkInputDatasetCompositeFacetsBuilder
+    extends SparkDatasetCompositeFacetsBuilder<OpenLineage.InputDataset> {
+
+  public SparkInputDatasetCompositeFacetsBuilder(OpenLineageContext context) {
+    super(context);
+  }
+
+  public SparkInputDatasetCompositeFacetsBuilder(
+      OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
+    super(context, inner);
+  }
+
+  @Override
+  public OpenLineage.InputDataset build() {
+    return context
+        .getOpenLineage()
+        .newInputDatasetBuilder()
+        .namespace(namespaceResolver.resolve(namespace))
+        .name(name)
+        .inputFacets(inner.getInputFacets().build())
+        .facets(inner.getFacets().build())
+        .build();
+  }
+
+  @Override
+  public SparkDatasetCompositeFacetsBuilder<OpenLineage.InputDataset> fromBuilder(
+      OpenLineage.DatasetFacetsBuilder facetsBuilder) {
+    inner.setFacets(facetsBuilder);
+    return this;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOutputDatasetCompositeFacetsBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOutputDatasetCompositeFacetsBuilder.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.api;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.spark.agent.util.DatasetVersionUtils;
+
+public class SparkOutputDatasetCompositeFacetsBuilder
+    extends SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> {
+
+  public SparkOutputDatasetCompositeFacetsBuilder(OpenLineageContext context) {
+    super(context);
+  }
+
+  public SparkOutputDatasetCompositeFacetsBuilder(
+      OpenLineageContext context, DatasetCompositeFacetsBuilder inner) {
+    super(context, inner);
+  }
+
+  /** Overrides to also trigger vendor-specific output facet builders (e.g. Iceberg). */
+  @Override
+  public SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> version(String version) {
+    DatasetVersionUtils.buildVersionOutputFacets(context, inner, version);
+    return this;
+  }
+
+  @Override
+  public OpenLineage.OutputDataset build() {
+    return context
+        .getOpenLineage()
+        .newOutputDatasetBuilder()
+        .namespace(namespaceResolver.resolve(namespace))
+        .name(name)
+        .outputFacets(inner.getOutputFacets().build())
+        .facets(inner.getFacets().build())
+        .build();
+  }
+
+  @Override
+  public SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> fromBuilder(
+      OpenLineage.DatasetFacetsBuilder facetsBuilder) {
+    inner.setFacets(facetsBuilder);
+    return this;
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -1,0 +1,205 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
+import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
+import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+class CreateDataSourceTableAsSelectCommandVisitorTest {
+
+  private static final String DATABASE = "test_db";
+  private static final String TABLE = "test_table";
+  private static final String WAREHOUSE_PATH = "/warehouse/test_db/test_table";
+  private static final String FILE_SCHEME = "file";
+  private static final String HIVE_FRAMEWORK = "hive";
+  private static final String HIVE_METASTORE_URI = "hive://localhost:9083";
+  private static final String HIVE_SYMLINK_NAME = "test_db.test_table";
+
+  private SparkSession session;
+  private OpenLineageContext context;
+  private CreateDataSourceTableAsSelectCommandVisitor visitor;
+  private CatalogTable catalogTable;
+  private CreateDataSourceTableAsSelectCommand command;
+
+  @BeforeEach
+  void setup() {
+    session = mock(SparkSession.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
+    when(session.sparkContext()).thenReturn(sparkContext);
+
+    SparkOpenLineageConfig config = new SparkOpenLineageConfig();
+    context =
+        OpenLineageContext.builder()
+            .sparkSession(session)
+            .sparkContext(sparkContext)
+            .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+            .meterRegistry(new SimpleMeterRegistry())
+            .openLineageConfig(config)
+            .sparkExtensionVisitorWrapper(new SparkOpenLineageExtensionVisitorWrapper(config))
+            .build();
+
+    visitor = new CreateDataSourceTableAsSelectCommandVisitor(context);
+
+    TableIdentifier tableId = new TableIdentifier(TABLE, Option.apply(DATABASE));
+    catalogTable = CatalogTableTestUtils.getCatalogTable(tableId);
+
+    LogicalPlan query = mock(LogicalPlan.class);
+    when(query.schema()).thenReturn(catalogTable.schema());
+    command =
+        new CreateDataSourceTableAsSelectCommand(
+            catalogTable,
+            SaveMode.Overwrite,
+            query,
+            ScalaConversionUtils.<String>fromList(Collections.emptyList()));
+  }
+
+  @Test
+  void testApplyReturnsSingleDatasetWithCreateLifecycleState() {
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      assertThat(datasets.get(0).getFacets().getLifecycleStateChange().getLifecycleStateChange())
+          .isEqualTo(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
+    }
+  }
+
+  @Test
+  void testApplyWithoutHiveCatalogProducesNoCatalogFacet() {
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      assertThat(datasets.get(0).getFacets().getCatalog()).isNull();
+    }
+  }
+
+  @Test
+  void testApplyWithHiveCatalogIncludesSymlinkFacet() {
+    OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    OpenLineage.CatalogDatasetFacet hiveFacet =
+        ol.newCatalogDatasetFacetBuilder()
+            .framework(HIVE_FRAMEWORK)
+            .source("spark")
+            .name("default")
+            .type(HIVE_FRAMEWORK)
+            .metadataUri(HIVE_METASTORE_URI)
+            .warehouseUri("file:/tmp/warehouse")
+            .build();
+
+    // DatasetIdentifier with a TABLE symlink representing the Hive metastore logical name
+    DatasetIdentifier diWithSymlink = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+    diWithSymlink.withSymlink(
+        HIVE_SYMLINK_NAME, HIVE_METASTORE_URI, DatasetIdentifier.SymlinkType.TABLE);
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      pathUtils
+          .when(() -> PathUtils.fromCatalogTable(catalogTable, session))
+          .thenReturn(diWithSymlink);
+
+      catalogUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+          .thenReturn(Optional.of(hiveFacet));
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      OpenLineage.SymlinksDatasetFacet symlinks = datasets.get(0).getFacets().getSymlinks();
+      assertThat(symlinks).isNotNull();
+      assertThat(symlinks.getIdentifiers()).hasSize(1);
+      assertThat(symlinks.getIdentifiers().get(0).getName()).isEqualTo(HIVE_SYMLINK_NAME);
+      assertThat(symlinks.getIdentifiers().get(0).getNamespace()).isEqualTo(HIVE_METASTORE_URI);
+      assertThat(symlinks.getIdentifiers().get(0).getType())
+          .isEqualTo(DatasetIdentifier.SymlinkType.TABLE.toString());
+    }
+  }
+
+  @Test
+  void testApplyWithSchemaFallbackToQuerySchema() {
+    // CatalogTable with empty schema — visitor should fall back to query schema
+    TableIdentifier tableId = new TableIdentifier(TABLE, Option.apply(DATABASE));
+    CatalogTable emptySchemaTable = CatalogTableTestUtils.getCatalogTable(tableId);
+
+    StructType querySchema = catalogTable.schema(); // non-empty
+    LogicalPlan query = mock(LogicalPlan.class);
+    when(query.schema()).thenReturn(querySchema);
+    CreateDataSourceTableAsSelectCommand cmd =
+        new CreateDataSourceTableAsSelectCommand(
+            emptySchemaTable,
+            SaveMode.Overwrite,
+            query,
+            ScalaConversionUtils.<String>fromList(Collections.emptyList()));
+
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(emptySchemaTable, session)).thenReturn(di);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(cmd);
+
+      assertThat(datasets).hasSize(1);
+      assertThat(datasets.get(0).getFacets().getSchema().getFields()).isNotEmpty();
+    }
+  }
+
+  @Test
+  void testJobNameSuffix() {
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    assertThat(visitor.jobNameSuffix(command))
+        .isPresent()
+        .hasValueSatisfying(suffix -> assertThat(suffix).contains(TABLE));
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -1,0 +1,115 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
+import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
+import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.execution.command.CreateDataSourceTableCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+class CreateDataSourceTableCommandVisitorTest {
+
+  private static final String DATABASE = "test_db";
+  private static final String TABLE = "test_table";
+  private static final String WAREHOUSE_PATH = "/warehouse/test_db/test_table";
+  private static final String FILE_SCHEME = "file";
+
+  private SparkSession session;
+  private OpenLineageContext context;
+  private CreateDataSourceTableCommandVisitor visitor;
+  private CatalogTable catalogTable;
+  private CreateDataSourceTableCommand command;
+
+  @BeforeEach
+  void setup() {
+    session = mock(SparkSession.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
+    when(session.sparkContext()).thenReturn(sparkContext);
+
+    SparkOpenLineageConfig config = new SparkOpenLineageConfig();
+    context =
+        OpenLineageContext.builder()
+            .sparkSession(session)
+            .sparkContext(sparkContext)
+            .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+            .meterRegistry(new SimpleMeterRegistry())
+            .openLineageConfig(config)
+            .sparkExtensionVisitorWrapper(new SparkOpenLineageExtensionVisitorWrapper(config))
+            .build();
+
+    visitor = new CreateDataSourceTableCommandVisitor(context);
+
+    TableIdentifier tableId = new TableIdentifier(TABLE, Option.apply(DATABASE));
+    catalogTable = CatalogTableTestUtils.getCatalogTable(tableId);
+    command = new CreateDataSourceTableCommand(catalogTable, false);
+  }
+
+  @Test
+  void testApplyReturnsSingleDatasetWithCreateLifecycleState() {
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      assertThat(datasets.get(0).getFacets().getLifecycleStateChange().getLifecycleStateChange())
+          .isEqualTo(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
+    }
+  }
+
+  @Test
+  void testApplyWithoutHiveCatalogProducesNoCatalogFacet() {
+    try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class);
+        MockedStatic<CatalogDatasetFacetUtils> catalogUtils =
+            mockStatic(CatalogDatasetFacetUtils.class)) {
+
+      DatasetIdentifier di = new DatasetIdentifier(WAREHOUSE_PATH, FILE_SCHEME);
+      pathUtils.when(() -> PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
+
+      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+
+      assertThat(datasets).hasSize(1);
+      assertThat(datasets.get(0).getFacets().getCatalog()).isNull();
+    }
+  }
+
+  @Test
+  void testJobNameSuffix() {
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    assertThat(visitor.jobNameSuffix(command))
+        .isPresent()
+        .hasValueSatisfying(suffix -> assertThat(suffix).contains(TABLE));
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -5,14 +5,17 @@
 
 package io.openlineage.spark.agent.lifecycle.plan;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
@@ -29,12 +32,13 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import scala.collection.immutable.Map$;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class JdbcRelationHandlerTest {
   JdbcRelationHandler jdbcRelationHandler;
-  DatasetFactory datasetFactory = mock(DatasetFactory.class);
+  DatasetFactory datasetFactory = mock(DatasetFactory.class, RETURNS_DEEP_STUBS);
   JDBCRelation relation = mock(JDBCRelation.class);
   JDBCOptions jdbcOptions = mock(JDBCOptions.class);
   String jdbcQuery =
@@ -66,16 +70,24 @@ class JdbcRelationHandlerTest {
   @Test
   void testHandlingJdbcQuery() {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcQuery);
-    StructType schema1 =
-        new StructType().add("k", DataTypes.IntegerType).add("j1", DataTypes.StringType);
-    StructType schema2 = new StructType().add("j2", DataTypes.StringType);
 
     jdbcRelationHandler.getDatasets(relation);
 
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source1", "postgres://localhost:5432", schema1);
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source2", "postgres://localhost:5432", schema2);
+    ArgumentCaptor<DatasetIdentifier> diCaptor = ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(datasetFactory.sparkDatasetBuilder(), times(2)).dataset(diCaptor.capture());
+    List<DatasetIdentifier> allDis = diCaptor.getAllValues();
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source1".equals(di.getName())
+                        && "postgres://localhost:5432".equals(di.getNamespace())));
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source2".equals(di.getName())
+                        && "postgres://localhost:5432".equals(di.getNamespace())));
   }
 
   @Test
@@ -90,8 +102,11 @@ class JdbcRelationHandlerTest {
 
     jdbcRelationHandler.getDatasets(relation);
 
-    verify(datasetFactory, times(1))
-        .getDataset("test.tablename", "postgres://localhost:5432", schema);
+    ArgumentCaptor<DatasetIdentifier> diCaptor = ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(datasetFactory.sparkDatasetBuilder(), times(1)).dataset(diCaptor.capture());
+    DatasetIdentifier di = diCaptor.getValue();
+    assertEquals("test.tablename", di.getName());
+    assertEquals("postgres://localhost:5432", di.getNamespace());
   }
 
   @Test
@@ -103,48 +118,72 @@ class JdbcRelationHandlerTest {
                     JDBCOptions$.MODULE$.JDBC_TABLE_NAME(), jdbcDbTableAsSubQuery)));
     when(jdbcOptions.parameters()).thenReturn(params);
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcDbTableAsSubQuery);
-    StructType schema1 =
-        new StructType().add("k", DataTypes.IntegerType).add("j1", DataTypes.StringType);
-    StructType schema2 = new StructType().add("j2", DataTypes.StringType);
 
     jdbcRelationHandler.getDatasets(relation);
 
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source1", "postgres://localhost:5432", schema1);
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source2", "postgres://localhost:5432", schema2);
+    ArgumentCaptor<DatasetIdentifier> diCaptor = ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(datasetFactory.sparkDatasetBuilder(), times(2)).dataset(diCaptor.capture());
+    List<DatasetIdentifier> allDis = diCaptor.getAllValues();
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source1".equals(di.getName())
+                        && "postgres://localhost:5432".equals(di.getNamespace())));
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source2".equals(di.getName())
+                        && "postgres://localhost:5432".equals(di.getNamespace())));
   }
 
   @Test
   void testMysqlDialect() {
     when(jdbcOptions.tableOrQuery()).thenReturn(mysqlQuery);
     when(jdbcOptions.url()).thenReturn("jdbc:" + mysqlUrl);
-    StructType schema1 =
-        new StructType().add("k", DataTypes.IntegerType).add("j1", DataTypes.StringType);
-    StructType schema2 = new StructType().add("j2", DataTypes.StringType);
 
     jdbcRelationHandler.getDatasets(relation);
 
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source1", "mysql://localhost:3306", schema1);
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source2", "mysql://localhost:3306", schema2);
+    ArgumentCaptor<DatasetIdentifier> diCaptor = ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(datasetFactory.sparkDatasetBuilder(), times(2)).dataset(diCaptor.capture());
+    List<DatasetIdentifier> allDis = diCaptor.getAllValues();
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source1".equals(di.getName())
+                        && "mysql://localhost:3306".equals(di.getNamespace())));
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source2".equals(di.getName())
+                        && "mysql://localhost:3306".equals(di.getNamespace())));
   }
 
   @Test
   void testUnknownDialect() {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcQuery);
     when(jdbcOptions.url()).thenReturn("jdbc:" + unknownUrl);
-    StructType schema1 =
-        new StructType().add("k", DataTypes.IntegerType).add("j1", DataTypes.StringType);
-    StructType schema2 = new StructType().add("j2", DataTypes.StringType);
 
     jdbcRelationHandler.getDatasets(relation);
 
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source1", "unknown://localhost:1234", schema1);
-    verify(datasetFactory, times(1))
-        .getDataset("test.jdbc_source2", "unknown://localhost:1234", schema2);
+    ArgumentCaptor<DatasetIdentifier> diCaptor = ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(datasetFactory.sparkDatasetBuilder(), times(2)).dataset(diCaptor.capture());
+    List<DatasetIdentifier> allDis = diCaptor.getAllValues();
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source1".equals(di.getName())
+                        && "unknown://localhost:1234".equals(di.getNamespace())));
+    assertTrue(
+        allDis.stream()
+            .anyMatch(
+                di ->
+                    "test.jdbc_source2".equals(di.getName())
+                        && "unknown://localhost:1234".equals(di.getNamespace())));
   }
 
   @Test
@@ -153,7 +192,6 @@ class JdbcRelationHandlerTest {
     when(jdbcOptions.url()).thenReturn("jdbc:" + url);
     List datasets = jdbcRelationHandler.getDatasets(relation);
     assertTrue(datasets.isEmpty());
-    verify(datasetFactory, never())
-        .getDataset(any(String.class), any(String.class), any(StructType.class));
+    verify(datasetFactory.sparkDatasetBuilder(), never()).dataset(any(DatasetIdentifier.class));
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtilsTest.java
@@ -1,0 +1,88 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CatalogDatasetFacetUtilsTest {
+
+  private static final String HIVE_TYPE = "hive";
+
+  private SparkContext sparkContext;
+  private OpenLineageContext context;
+
+  @BeforeEach
+  void setup() {
+    sparkContext = mock(SparkContext.class);
+
+    context =
+        OpenLineageContext.builder()
+            .sparkContext(sparkContext)
+            .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+            .meterRegistry(new SimpleMeterRegistry())
+            .openLineageConfig(new SparkOpenLineageConfig())
+            .build();
+  }
+
+  @Test
+  void testGetCatalogDatasetFacetForVanillaHiveReturnsCatalogFacet() {
+    // Standard Hive: no BigLake factory class configured.
+    // isBigLakeHiveCatalog throws IllegalArgumentException (missing HiveConf ConfVar)
+    // and returns false, so the plain Hive path is taken.
+    SparkConf sparkConf =
+        new SparkConf()
+            .set("spark.sql.catalogImplementation", "hive")
+            .set("spark.sql.warehouse.dir", "file:///tmp/warehouse")
+            .set("spark.sql.hive.metastore.uris", "thrift://localhost:9083");
+    Configuration hadoopConf = new Configuration();
+
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+
+    Optional<OpenLineage.CatalogDatasetFacet> result =
+        CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
+
+    assertThat(result).isPresent();
+    OpenLineage.CatalogDatasetFacet facet = result.get();
+    assertThat(facet.getName()).isEqualTo("default");
+    assertThat(facet.getType()).isEqualTo(HIVE_TYPE);
+    assertThat(facet.getFramework()).isEqualTo(HIVE_TYPE);
+    assertThat(facet.getSource()).isEqualTo("spark");
+    assertThat(facet.getWarehouseUri()).contains("/tmp/warehouse");
+    assertThat(facet.getMetadataUri()).isEqualTo("hive://localhost:9083");
+  }
+
+  @Test
+  void testGetCatalogDatasetFacetForVanillaHiveReturnsEmptyWhenNoWarehouseConfigured() {
+    // No warehouse URI configured at all → getCatalogDatasetFacetForHive returns empty.
+    SparkConf sparkConf = new SparkConf().set("spark.sql.catalogImplementation", "hive");
+    Configuration hadoopConf = new Configuration();
+
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+
+    Optional<OpenLineage.CatalogDatasetFacet> result =
+        CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -6,13 +6,12 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -105,24 +104,20 @@ public class CreateReplaceDatasetBuilder
       return Collections.emptyList();
     }
 
-    OpenLineage openLineage = context.getOpenLineage();
-    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
-
-    builder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(openLineage, schema))
-        .lifecycleStateChange(
-            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di.get())
+            .schema(schema)
+            .lifecycleStateChange(lifecycleStateChange);
 
     if (includeDatasetVersion(event)) {
-      Optional<String> datasetVersion =
-          CatalogUtils3.getDatasetVersion(context, tableCatalog, identifier, tableProperties);
-      datasetVersion.ifPresent(
-          version -> DatasetVersionUtils.buildVersionOutputFacets(context, builder, version));
+      CatalogUtils3.getDatasetVersion(context, tableCatalog, identifier, tableProperties)
+          .ifPresent(sparkBuilder::version);
     }
-    CatalogUtils3.addStorageAndCatalogFacets(context, tableCatalog, tableProperties, builder);
-    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+    CatalogUtils3.addStorageAndCatalogFacets(
+        context, tableCatalog, tableProperties, sparkBuilder.getInner());
+    return Collections.singletonList(sparkBuilder.build());
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -5,8 +5,6 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
-import static java.util.Collections.singletonList;
-
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
@@ -63,13 +61,14 @@ public class CreateTableLikeCommandVisitor
                       .orElse(defaultLocation);
               DatasetIdentifier di = PathUtils.fromURI(location);
 
-              return singletonList(
+              return Collections.singletonList(
                   outputDataset()
-                      .getDataset(
-                          di,
-                          source.schema(),
-                          OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                              .CREATE));
+                      .sparkDatasetBuilder()
+                      .dataset(di)
+                      .schema(source.schema())
+                      .lifecycleStateChange(
+                          OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE)
+                      .build());
             })
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -6,12 +6,10 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -99,24 +97,14 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
         PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
 
     if (di.isPresent()) {
-      DatasetCompositeFacetsBuilder builder = outputDataset().createCompositeFacetBuilder();
-      CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
-          .ifPresent(
-              catalogDatasetFacet ->
-                  builder.getFacets().catalog(catalogDatasetFacet.getCatalogDatasetFacet()));
-      builder
-          .getFacets()
-          .schema(PlanUtils.schemaFacet(context.getOpenLineage(), resolvedTable.schema()));
-      builder
-          .getFacets()
-          .lifecycleStateChange(
-              context
-                  .getOpenLineage()
-                  .newLifecycleStateChangeDatasetFacet(
-                      OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP,
-                      null));
-
-      return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+      SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+          outputDataset()
+              .sparkDatasetBuilder()
+              .dataset(di.get())
+              .schema(resolvedTable.schema())
+              .lifecycleStateChange(
+                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
+      return Collections.singletonList(sparkBuilder.build());
     } else {
       return Collections.emptyList();
     }
@@ -156,22 +144,14 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
           PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
 
       if (di.isPresent()) {
-        DatasetCompositeFacetsBuilder builder = outputDataset().createCompositeFacetBuilder();
-        CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
-            .ifPresent(
-                catalogDatasetFacet ->
-                    builder.getFacets().catalog(catalogDatasetFacet.getCatalogDatasetFacet()));
-        builder.getFacets().schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema));
-        builder
-            .getFacets()
-            .lifecycleStateChange(
-                context
-                    .getOpenLineage()
-                    .newLifecycleStateChangeDatasetFacet(
-                        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP,
-                        null));
-
-        return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+        SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+            outputDataset()
+                .sparkDatasetBuilder()
+                .dataset(di.get())
+                .schema(schema)
+                .lifecycleStateChange(
+                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
+        return Collections.singletonList(sparkBuilder.build());
       } else {
         return Collections.emptyList();
       }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/RefreshTableCommandVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/RefreshTableCommandVisitor.java
@@ -6,11 +6,6 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -30,33 +25,17 @@ public class RefreshTableCommandVisitor
   @Override
   public List<OpenLineage.InputDataset> apply(LogicalPlan x) {
     Optional<CatalogTable> tableOption = catalogTableFor(((RefreshTableCommand) x).tableIdent());
-
-    if (!tableOption.isPresent()) {
-      return Collections.emptyList();
-    }
-
-    CatalogTable catalogTable = tableOption.get();
-
-    DatasetIdentifier di =
-        PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get());
-
-    OpenLineage.LifecycleStateChangeDatasetFacet lifecycleStateChangeDatasetFacet =
-        context
-            .getOpenLineage()
-            .newLifecycleStateChangeDatasetFacetBuilder()
-            .lifecycleStateChange(
-                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
-            .build();
-
-    DatasetFactory<OpenLineage.InputDataset> factory = inputDataset();
-
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
-    datasetFacetsBuilder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), catalogTable.schema()))
-        .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()))
-        .lifecycleStateChange(lifecycleStateChangeDatasetFacet);
-
-    return Collections.singletonList(factory.getDataset(di, datasetFacetsBuilder));
+    return tableOption
+        .map(
+            catalogTable ->
+                Collections.singletonList(
+                    inputDataset()
+                        .sparkDatasetBuilder()
+                        .dataset(catalogTable)
+                        .schema(catalogTable.schema())
+                        .lifecycleStateChange(
+                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
+                        .build()))
+        .orElseGet(() -> Collections.emptyList());
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -92,7 +92,10 @@ public class DataSourceV2RelationDatasetExtractor {
                   .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
                   .dataSource(PlanUtils.datasourceFacet(openLineage, identifier.getNamespace()));
 
-              return datasetFactory.getDataset(identifier, datasetFacetsBuilder);
+              return datasetFactory
+                  .sparkDatasetBuilder(datasetFacetsBuilder)
+                  .dataset(identifier)
+                  .build();
             })
         .collect(Collectors.toList());
   }
@@ -115,11 +118,14 @@ public class DataSourceV2RelationDatasetExtractor {
                               new DatasetIdentifier(dbtm.qualifiedName(), namespace);
 
                           if (numberOfTables > 1) {
-                            return datasetFactory.getDataset(di.getName(), di.getNamespace());
+                            return datasetFactory.sparkDatasetBuilder().dataset(di).build();
                           }
 
-                          return datasetFactory.getDataset(
-                              di.getName(), di.getNamespace(), relation.schema());
+                          return datasetFactory
+                              .sparkDatasetBuilder()
+                              .dataset(di)
+                              .schema(relation.schema())
+                              .build();
                         })
                     .collect(Collectors.toList());
               }
@@ -128,10 +134,11 @@ public class DataSourceV2RelationDatasetExtractor {
                       dbtm -> {
                         DatasetIdentifier di =
                             new DatasetIdentifier(dbtm.qualifiedName(), namespace);
-                        return datasetFactory.getDataset(
-                            di.getName(),
-                            di.getNamespace(),
-                            generateSchemaFromSqlMeta(dbtm, relation.schema(), sqm));
+                        return datasetFactory
+                            .sparkDatasetBuilder()
+                            .dataset(di)
+                            .schema(generateSchemaFromSqlMeta(dbtm, relation.schema(), sqm))
+                            .build();
                       })
                   .collect(Collectors.toList());
             })

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -68,6 +68,7 @@ class CreateTableLikeCommandVisitorTest {
     when(sessionCatalog.defaultTablePath(targetTableIdentifier))
         .thenReturn(new URI("/tmp/warehouse/newtable"));
     when(sourceCatalogTable.schema()).thenReturn(schema);
+    when(sourceCatalogTable.identifier()).thenReturn(sourceTableIdentifier);
 
     CreateTableLikeCommandVisitor visitor =
         new CreateTableLikeCommandVisitor(

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -7,6 +7,7 @@ package io.openlineage.spark3.agent.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,7 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
 import java.net.URI;
@@ -97,7 +99,12 @@ class DataSourceV2RelationDatasetExtractorTest {
         when(CatalogUtils3.getDatasetIdentifier(
                 openLineageContext, tableCatalog, identifier, tableProperties))
             .thenReturn(di);
-        when(datasetFactory.getDataset(di, datasetFacetsBuilder)).thenReturn(dataset);
+
+        SparkDatasetCompositeFacetsBuilder sparkBuilder =
+            mock(SparkDatasetCompositeFacetsBuilder.class);
+        when(datasetFactory.sparkDatasetBuilder(datasetFacetsBuilder)).thenReturn(sparkBuilder);
+        when(sparkBuilder.dataset(any(DatasetIdentifier.class))).thenReturn(sparkBuilder);
+        when(sparkBuilder.build()).thenReturn(dataset);
 
         assertEquals(
             Collections.singletonList(dataset),
@@ -110,13 +117,9 @@ class DataSourceV2RelationDatasetExtractorTest {
   @Test
   void testExtractFromDataSourceV2RelationWhenDatasetIdentifierEmpty() {
     try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
-      DatasetIdentifier di = mock(DatasetIdentifier.class);
-      OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
-
       when(CatalogUtils3.getDatasetIdentifier(
               openLineageContext, tableCatalog, identifier, tableProperties))
           .thenThrow(new UnsupportedCatalogException("exception"));
-      when(datasetFactory.getDataset(di, schema)).thenReturn(dataset);
 
       assertEquals(
           Collections.emptyList(),

--- a/integration/spark/spark31/src/main/java/io/openlineage/spark31/agent/lifecycle/plan/AlterTableDatasetBuilder.java
+++ b/integration/spark/spark31/src/main/java/io/openlineage/spark31/agent/lifecycle/plan/AlterTableDatasetBuilder.java
@@ -6,11 +6,10 @@
 package io.openlineage.spark31.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -49,23 +48,16 @@ public class AlterTableDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
             context, alterTable.catalog(), alterTable.ident(), table.properties());
 
     if (di.isPresent()) {
-      OpenLineage openLineage = context.getOpenLineage();
-      DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
-      builder
-          .getFacets()
-          .schema(PlanUtils.schemaFacet(openLineage, table.schema()))
-          .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+      SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+          outputDataset().sparkDatasetBuilder().dataset(di.get()).schema(table.schema());
 
       if (includeDatasetVersion(event)) {
-        Optional<String> datasetVersion =
-            CatalogUtils3.getDatasetVersion(
-                context, alterTable.catalog(), alterTable.ident(), table.properties());
-        datasetVersion.ifPresent(
-            version ->
-                builder.getFacets().version(openLineage.newDatasetVersionDatasetFacet(version)));
+        CatalogUtils3.getDatasetVersion(
+                context, alterTable.catalog(), alterTable.ident(), table.properties())
+            .ifPresent(sparkBuilder::version);
       }
 
-      return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+      return Collections.singletonList(sparkBuilder.build());
     } else {
       return Collections.emptyList();
     }

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -6,11 +6,10 @@
 package io.openlineage.spark32.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -84,24 +83,19 @@ public class AlterTableCommandDatasetBuilder
       return Collections.emptyList();
     }
 
-    OpenLineage openLineage = context.getOpenLineage();
-    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
-    builder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(openLineage, schema))
-        .lifecycleStateChange(
-            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di.get())
+            .schema(schema)
+            .lifecycleStateChange(lifecycleStateChange);
 
     if (includeDatasetVersion(event)) {
-      Optional<String> datasetVersion =
-          CatalogUtils3.getDatasetVersion(
-              context, resolvedTable.catalog(), resolvedTable.identifier(), table.properties());
-      datasetVersion.ifPresent(
-          version ->
-              builder.getFacets().version(openLineage.newDatasetVersionDatasetFacet(version)));
+      CatalogUtils3.getDatasetVersion(
+              context, resolvedTable.catalog(), resolvedTable.identifier(), table.properties())
+          .ifPresent(sparkBuilder::version);
     }
-    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+    return Collections.singletonList(sparkBuilder.build());
   }
 
   @Override

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/RepairTableCommandVisitor.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/RepairTableCommandVisitor.java
@@ -6,11 +6,6 @@
 package io.openlineage.spark32.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -32,31 +27,17 @@ public class RepairTableCommandVisitor
     RepairTableCommand cmd = (RepairTableCommand) x;
     Optional<CatalogTable> tableOption = catalogTableFor(cmd.tableName());
 
-    if (!tableOption.isPresent()) {
-      return Collections.emptyList();
-    }
-
-    CatalogTable catalogTable = tableOption.get();
-    DatasetIdentifier di =
-        PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get());
-
-    OpenLineage.LifecycleStateChangeDatasetFacet lifecycleStateChangeDatasetFacet =
-        context
-            .getOpenLineage()
-            .newLifecycleStateChangeDatasetFacetBuilder()
-            .lifecycleStateChange(
-                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
-            .build();
-
-    DatasetFactory<OpenLineage.OutputDataset> factory = outputDataset();
-
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
-    datasetFacetsBuilder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), catalogTable.schema()))
-        .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()))
-        .lifecycleStateChange(lifecycleStateChangeDatasetFacet);
-
-    return Collections.singletonList(factory.getDataset(di, datasetFacetsBuilder));
+    return tableOption
+        .map(
+            catalogTable ->
+                Collections.singletonList(
+                    outputDataset()
+                        .sparkDatasetBuilder()
+                        .dataset(catalogTable)
+                        .schema(catalogTable.schema())
+                        .lifecycleStateChange(
+                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
+                        .build()))
+        .orElse(Collections.emptyList());
   }
 }

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -7,13 +7,11 @@ package io.openlineage.spark33.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractOnCompleteOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
@@ -155,22 +153,20 @@ public class CreateReplaceDatasetBuilder
       return Collections.emptyList();
     }
 
-    OpenLineage openLineage = context.getOpenLineage();
-    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
-    builder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(openLineage, schema))
-        .lifecycleStateChange(
-            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di.get())
+            .schema(schema)
+            .lifecycleStateChange(lifecycleStateChange);
 
     if (includeDatasetVersion(event)) {
       CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties)
-          .ifPresent(
-              version -> DatasetVersionUtils.buildVersionOutputFacets(context, builder, version));
+          .ifPresent(sparkBuilder::version);
     }
-    CatalogUtils3.addStorageAndCatalogFacets(context, catalog, tableProperties, builder);
-    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+    CatalogUtils3.addStorageAndCatalogFacets(
+        context, catalog, tableProperties, sparkBuilder.getInner());
+    return Collections.singletonList(sparkBuilder.build());
   }
 
   @Override

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
@@ -6,8 +6,6 @@
 package io.openlineage.spark34.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -57,11 +55,12 @@ public class WriteToMicroBatchDataSourceV1DatasetBuilder
     // Currently, only FileStreamSink is supported
     if (writeToMicroBatchV1.sink() instanceof FileStreamSink) {
       if (writeToMicroBatchV1.catalogTable().isDefined()) {
-        DatasetIdentifier di =
-            PathUtils.fromCatalogTable(
-                writeToMicroBatchV1.catalogTable().get(), context.getSparkSession().get());
-
-        return Collections.singletonList(factory.getDataset(di, writeToMicroBatchV1.schema()));
+        return Collections.singletonList(
+            factory
+                .sparkDatasetBuilder()
+                .dataset(writeToMicroBatchV1.catalogTable().get())
+                .schema(writeToMicroBatchV1.schema())
+                .build());
       } else {
         return Collections.emptyList();
       }

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/DropTableDatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/DropTableDatasetBuilder.java
@@ -46,10 +46,12 @@ public class DropTableDatasetBuilder extends AbstractQueryPlanOutputDatasetBuild
         .map(
             di ->
                 outputDataset()
-                    .getDataset(
-                        di,
-                        resolvedIdentifier.schema(),
-                        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP))
+                    .sparkDatasetBuilder()
+                    .dataset(di)
+                    .schema(resolvedIdentifier.schema())
+                    .lifecycleStateChange(
+                        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP)
+                    .build())
         .map(d -> Collections.singletonList(d))
         .orElseGet(() -> Collections.emptyList());
   }

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
@@ -8,21 +8,17 @@ package io.openlineage.spark34.agent.lifecycle.plan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.List;
 import org.apache.spark.SparkContext;
@@ -40,7 +36,6 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import scala.Option;
 
 class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
@@ -124,7 +119,7 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
 
     assertTrue(result.isEmpty());
-    verify(factory, never()).getDataset(any(DatasetIdentifier.class), any(StructType.class));
+    verify(factory, never()).sparkDatasetBuilder();
   }
 
   @Test
@@ -138,9 +133,6 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
 
   @Test
   void testApply_WithFileStreamSink_ValidPath_WithCatalogTable() {
-    DatasetIdentifier catalogDatasetIdentifier =
-        new DatasetIdentifier("catalog_table", "catalog_namespace");
-
     OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
     CatalogTable catalogTable = mock(CatalogTable.class);
 
@@ -148,19 +140,19 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     when(writeToMicroBatchV1.schema()).thenReturn(schema);
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.apply(catalogTable));
 
-    try (MockedStatic<PathUtils> pathUtilsMock = mockStatic(PathUtils.class)) {
-      pathUtilsMock
-          .when(() -> PathUtils.fromCatalogTable(eq(catalogTable), any()))
-          .thenReturn(catalogDatasetIdentifier);
+    @SuppressWarnings("unchecked")
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        mock(SparkDatasetCompositeFacetsBuilder.class);
+    when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
+    when(sparkBuilder.dataset(catalogTable)).thenReturn(sparkBuilder);
+    when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);
+    when(sparkBuilder.build()).thenReturn(expectedDataset);
 
-      when(factory.getDataset(eq(catalogDatasetIdentifier), eq(schema)))
-          .thenReturn(expectedDataset);
+    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
 
-      List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
-
-      assertEquals(1, result.size());
-      assertEquals(expectedDataset, result.get(0));
-      verify(factory).getDataset(eq(catalogDatasetIdentifier), eq(schema));
-    }
+    assertEquals(1, result.size());
+    assertEquals(expectedDataset, result.get(0));
+    verify(sparkBuilder).dataset(catalogTable);
+    verify(sparkBuilder).schema(schema);
   }
 }

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -7,13 +7,11 @@ package io.openlineage.spark35.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.lang.reflect.InvocationTargetException;
@@ -163,24 +161,21 @@ public class CreateReplaceOutputDatasetBuilder
       return Collections.emptyList();
     }
 
-    OpenLineage openLineage = context.getOpenLineage();
-    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
-    builder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(openLineage, schema))
-        .lifecycleStateChange(
-            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di.get())
+            .schema(schema)
+            .lifecycleStateChange(lifecycleStateChange);
 
     if (includeDatasetVersion(event)) {
-      Optional<String> datasetVersion =
-          CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties);
-      datasetVersion.ifPresent(
-          version -> DatasetVersionUtils.buildVersionOutputFacets(context, builder, version));
+      CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties)
+          .ifPresent(sparkBuilder::version);
     }
 
-    CatalogUtils3.addStorageAndCatalogFacets(context, catalog, tableProperties, builder);
-    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+    CatalogUtils3.addStorageAndCatalogFacets(
+        context, catalog, tableProperties, sparkBuilder.getInner());
+    return Collections.singletonList(sparkBuilder.build());
   }
 
   @Override

--- a/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -6,11 +6,10 @@
 package io.openlineage.spark40.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetCompositeFacetsBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
@@ -83,24 +82,19 @@ public class AlterTableCommandDatasetBuilder
       return Collections.emptyList();
     }
 
-    OpenLineage openLineage = context.getOpenLineage();
-    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
-    builder
-        .getFacets()
-        .schema(PlanUtils.schemaFacet(openLineage, schema))
-        .lifecycleStateChange(
-            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    SparkDatasetCompositeFacetsBuilder<OpenLineage.OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(di.get())
+            .schema(schema)
+            .lifecycleStateChange(lifecycleStateChange);
 
     if (includeDatasetVersion(event)) {
-      Optional<String> datasetVersion =
-          CatalogUtils3.getDatasetVersion(
-              context, resolvedTable.catalog(), resolvedTable.identifier(), table.properties());
-      datasetVersion.ifPresent(
-          version ->
-              builder.getFacets().version(openLineage.newDatasetVersionDatasetFacet(version)));
+      CatalogUtils3.getDatasetVersion(
+              context, resolvedTable.catalog(), resolvedTable.identifier(), table.properties())
+          .ifPresent(sparkBuilder::version);
     }
-    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+    return Collections.singletonList(sparkBuilder.build());
   }
 
   @Override

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/SnowflakeDataset.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/SnowflakeDataset.java
@@ -53,7 +53,8 @@ public class SnowflakeDataset {
     StructType normalizedSchema = stripQuotesFromSchema(schema);
     if (dbtable.isPresent()) {
       String name = getQualifiedName(sfDatabase, sfSchema, dbtable.get());
-      return Collections.singletonList(factory.getDataset(name, namespace, normalizedSchema));
+      return Collections.singletonList(
+          factory.sparkDatasetBuilder().dataset(name, namespace).schema(normalizedSchema).build());
     } else if (query.isPresent()) {
       Optional<SqlMeta> sqlMeta =
           OpenLineageSql.parse(Collections.singletonList(query.get()), "snowflake");


### PR DESCRIPTION
### One-line summary for changelog:
Refactor of Dataset building in spark intergration to more flexible way.

### Meaningful description
So far the spark integration build datasets using overloaded `getDataset` methods, that required adding new method overload or working around the existing ones each time new configuration was required. Changed it to builder pattern to accommodate different configurations with less code requirements. 

This PR is a split of PR #4574 for better change logging.

### Checklist
- [X] AI was used in creating this PR
