### PR TITLE
 [DBT] Add experimental Core `v2` integration test support

### DIFF
--- a/integration/common/pyproject.toml
+++ b/integration/common/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 
 dependencies = [
     "attrs>=19.3.0",
+    "jinja2>=3.0.0",
     "openlineage-python",
     "openlineage_sql",
     "pyyaml>=5.3.1",

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -86,6 +86,16 @@ $ cd integration/dbt
 $ uv sync --extra dev
 ```
 
+### dbt Core v2 (experimental)
+
+Published installs keep `dbt-core>=1.0,<3` (dbt 1.x by default). To test against [dbt Core v2 alpha](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v2) locally:
+
+```bash
+$ uv sync --extra dev --extra dbt-v2
+```
+
+Docker-based integration tests pin v2 in `tests/integration/Dockerfile.dbt`; see `tests/integration/scripts/build-wheels.sh`.
+
 ----
 SPDX-License-Identifier: Apache-2.0\
 Copyright 2018-2026 contributors to the OpenLineage project

--- a/integration/dbt/pyproject.toml
+++ b/integration/dbt/pyproject.toml
@@ -13,13 +13,13 @@ keywords = ["openlineage"]
 dependencies = [
     "tqdm>=4.62.0",
     "openlineage-integration-common==1.48.0",
-    "dbt-core>=1.0.0",
+    "dbt-core>=1.0.0,<3",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
-    "pytest-cov", 
+    "pytest-cov",
     "pytest-xdist>=2.5.0",
     "mock",
     "ruff",
@@ -27,7 +27,11 @@ dev = [
     "python-dateutil",
     "requests>=2.25.0",
     "docker>=6.0.0",
-    "mypy"
+    "mypy",
+]
+# Experimental: dbt Core v2 alpha for local/dev testing (Docker integration tests pin v2 in Dockerfile.dbt)
+dbt-v2 = [
+    "dbt-core==2.0.0-alpha.1",
 ]
 
 [project.scripts]

--- a/integration/dbt/tests/integration/Dockerfile.dbt
+++ b/integration/dbt/tests/integration/Dockerfile.dbt
@@ -1,39 +1,28 @@
 FROM python:3.10-slim
 
-# Install system dependencies including Rust for building SQL parser
 RUN apt-get update && \
-    apt-get install -y gcc g++ curl git && \
+    apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
-
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:$PATH"
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 
-# Install dbt-duckdb first
-RUN uv pip install --system dbt-duckdb==1.7.0
+# dbt Core v2: prebuilt Rust binary; DuckDB driver is fetched via `dbt system update`
+# https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v2
+RUN uv pip install --system "dbt-core==2.0.0-alpha.1" && \
+    dbt system update || true
 
-# Copy pre-built wheels
-COPY wheels/ /opt/wheels/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# List available wheels
-RUN ls -la /opt/wheels/
+# OpenLineage wheels are built on the host and mounted at /opt/wheels (see docker-compose.yml)
+RUN mkdir -p /opt/wheels /opt/dbt/data
 
-# Install OpenLineage dependencies from wheels
-RUN uv pip install --system /opt/wheels/*.whl
-
-# Create data directory for DuckDB
-RUN mkdir -p /opt/dbt/data
-
-# Set working directory
 WORKDIR /opt/dbt_project
 
-# Set environment variables
 ENV PYTHONPATH=/opt/openlineage
 ENV DBT_PROFILES_DIR=/opt/dbt_project
 
-# Keep container running
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["tail", "-f", "/dev/null"]

--- a/integration/dbt/tests/integration/dbt_project/models/marts/schema.yml
+++ b/integration/dbt/tests/integration/dbt_project/models/marts/schema.yml
@@ -3,7 +3,8 @@ version: 2
 models:
   - name: customers
     description: Customer dimension table with order aggregations
-    tags: ['some_tag']
+    config:
+      tags: ['some_tag']
     columns:
       - name: customer_id
         description: Unique identifier for customers
@@ -36,4 +37,5 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['paid', 'partial', 'unpaid']
+              arguments:
+                values: ['paid', 'partial', 'unpaid']

--- a/integration/dbt/tests/integration/dbt_project/models/staging/schema.yml
+++ b/integration/dbt/tests/integration/dbt_project/models/staging/schema.yml
@@ -27,8 +27,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('stg_customers')
-              field: customer_id
+              arguments:
+                to: ref('stg_customers')
+                field: customer_id
       - name: amount
         description: Order amount
         tests:
@@ -47,8 +48,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('stg_orders')
-              field: order_id
+              arguments:
+                to: ref('stg_orders')
+                field: order_id
       - name: amount
         description: Payment amount
         tests:

--- a/integration/dbt/tests/integration/docker-compose.yml
+++ b/integration/dbt/tests/integration/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     working_dir: /opt/dbt_project
     volumes:
       - ./dbt_project:/opt/dbt_project
+      - ./wheels:/opt/wheels
       - ./data:/opt/data  # For DuckDB database file
     environment:
       - OPENLINEAGE_URL=http://test-server:8080

--- a/integration/dbt/tests/integration/docker-entrypoint.sh
+++ b/integration/dbt/tests/integration/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+if ls /opt/wheels/*.whl >/dev/null 2>&1; then
+  echo "Installing OpenLineage wheels from /opt/wheels ..."
+  uv pip install --system /opt/wheels/*.whl
+else
+  echo "No wheels in /opt/wheels — run scripts/build-wheels.sh before integration tests."
+fi
+
+exec "$@"

--- a/integration/dbt/tests/integration/scripts/build-wheels.sh
+++ b/integration/dbt/tests/integration/scripts/build-wheels.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WHEELS_DIR="${TEST_DIR}/wheels"
+OPENLINEAGE_ROOT="$(cd "${TEST_DIR}/../../../.." && pwd)"
+
+mkdir -p "${WHEELS_DIR}"
+rm -f "${WHEELS_DIR}"/*.whl
+
+echo "Building client/python wheel..."
+uv build --wheel --out-dir "${WHEELS_DIR}" "${OPENLINEAGE_ROOT}/client/python"
+
+DBT_VERSION="$(
+  python3 -c "import tomllib; print(tomllib.load(open('${OPENLINEAGE_ROOT}/integration/dbt/pyproject.toml','rb'))['project']['version'])"
+)"
+SQL_DIST="${OPENLINEAGE_ROOT}/integration/sql/iface-py/dist"
+SQL_WHEEL="$(find "${SQL_DIST}" -name "openlineage_sql-${DBT_VERSION}-*linux*.whl" 2>/dev/null | head -1 || true)"
+
+if [[ -n "${SQL_WHEEL}" ]]; then
+  echo "Using existing SQL wheel: ${SQL_WHEEL}"
+  cp "${SQL_WHEEL}" "${WHEELS_DIR}/"
+else
+  echo "Building integration/sql wheel via Docker..."
+  docker build -t openlineage-sql-builder \
+    -f "${OPENLINEAGE_ROOT}/integration/sql/Dockerfile.python" \
+    "${OPENLINEAGE_ROOT}/integration/sql"
+  docker run --rm -v "${WHEELS_DIR}:/output" openlineage-sql-builder \
+    sh -c "cp /wheels/* /output/"
+fi
+
+echo "Building integration/common wheel..."
+uv build --wheel --out-dir "${WHEELS_DIR}" "${OPENLINEAGE_ROOT}/integration/common"
+
+echo "Building integration/dbt wheel..."
+uv build --wheel --out-dir "${WHEELS_DIR}" "${OPENLINEAGE_ROOT}/integration/dbt"
+
+echo "Wheels ready in ${WHEELS_DIR}:"
+ls -la "${WHEELS_DIR}"/*.whl


### PR DESCRIPTION
## Summary

Work toward [dbt Core v2](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v2) compatibility ([#4589](https://github.com/OpenLineage/OpenLineage/issues/4589)).

- Declare `jinja2` as a runtime dependency of `openlineage-integration-common` (required by `dbt-ol` on minimal installs).
- Keep published `openlineage-dbt` on `dbt-core>=1.0,<3`; add optional `dbt-v2` extra pinning `2.0.0-alpha.1`.
- Run Docker integration tests against dbt Core v2 alpha (`dbt system update`, host-built wheels).
- Update the integration sample project YAML for v2 parsing (`config.tags`, test `arguments`).

## Test plan

- [ ] `cd integration/common && uv sync --extra dev && uv run pytest tests/dbt`
- [ ] `cd integration/dbt && uv sync --extra dev && uv run pytest tests/ --ignore=tests/integration`
- [ ] `cd integration/dbt/tests/integration && ./scripts/build-wheels.sh && docker compose up -d --build && uv run pytest tests/integration/ -v`