### PR TITLE
hive: fix duplicated publishing

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -923,7 +923,6 @@ jobs:
 
           # Publish *.jar
           ./gradlew --no-daemon --console=plain clean publishToSonatype closeAndReleaseSonatypeStagingRepository
-          ./gradlew --no-daemon --console=plain clean publishToSonatype closeAndReleaseSonatypeStagingRepository
       - store_artifacts:
           path: ./build/libs
           destination: hive-client-artifacts


### PR DESCRIPTION
### One-line summary for changelog:
remove duplicated publish step from release workflow


### Meaningful description
remove duplicated publish step from release workflow
