### PR TITLE
Add missing column lineage for structured log processor.

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -495,7 +495,16 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         ]
         outputs = []
         if node := self._get_model_node(node_unique_id):
-            outputs = [self.node_to_output_dataset(node=node, has_facets=True)]
+            output_dataset = self.node_to_output_dataset(node=node, has_facets=True)
+            if resource_type in ("model", "snapshot") and event_type in (RunState.COMPLETE, RunState.FAIL):
+                compiled_sql = node.metadata_node.get("compiled_code") or node.metadata_node.get(
+                    "compiled_sql"
+                )
+                if compiled_sql:
+                    column_lineage = self.get_column_lineage(output_dataset.namespace, compiled_sql)
+                    if column_lineage:
+                        output_dataset.facets["columnLineage"] = column_lineage  # type: ignore
+            outputs = [output_dataset]
 
         if resource_type == "test":
             success = node_status == "pass"

--- a/integration/common/tests/dbt/structured_logs/bigquery/run/results/successful_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/bigquery/run/results/successful_run_ol_events.json
@@ -174,6 +174,37 @@
                 "name": "location_id"
               }
             ]
+          },
+          "columnLineage": {
+            "fields": {
+              "location_id": {
+                "inputFields": [
+                  {
+                    "namespace": "bigquery",
+                    "name": "example-bigquery-project.raw.raw_stores",
+                    "field": "id"
+                  }
+                ]
+              },
+              "location_name": {
+                "inputFields": [
+                  {
+                    "namespace": "bigquery",
+                    "name": "example-bigquery-project.raw.raw_stores",
+                    "field": "name"
+                  }
+                ]
+              },
+              "tax_rate": {
+                "inputFields": [
+                  {
+                    "namespace": "bigquery",
+                    "name": "example-bigquery-project.raw.raw_stores",
+                    "field": "tax_rate"
+                  }
+                ]
+              }
+            }
           }
         },
         "outputFacets": {}

--- a/integration/common/tests/dbt/structured_logs/bigquery/run/target/manifest.json
+++ b/integration/common/tests/dbt/structured_logs/bigquery/run/target/manifest.json
@@ -39,7 +39,7 @@
           "source.jaffle_shop.raw.raw_stores"
         ]
       },
-      "compiled_code": "with source as (\n\n    select * from `example-bigquery-project`.`raw`.`raw_stores`\n\n),\n\nrenamed as (\n\n    select\n        id as location_id,\n        name as location_name,\n        tax_rate\n    from source\n\n)\n\nselect * from renamed",
+      "compiled_code": "with renamed as (\n\n    select\n        id as location_id,\n        name as location_name,\n        tax_rate\n    from `example-bigquery-project`.`raw`.`raw_stores`\n\n)\n\nselect\n    location_id,\n    location_name,\n    tax_rate\nfrom renamed",
       "relation_name": "`example-bigquery-project`.`jaffle_shop`.`stg_locations`"
     }
   },

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -523,9 +523,9 @@ def test_node_finished_column_lineage_parse_failure_has_no_column_lineage():
 
 def test_test_node_finished_has_no_column_lineage():
     processor = node_finished_processor()
-    processor._compiled_manifest["nodes"]["test.jaffle_shop.not_null_orders_id"][
-        "compiled_code"
-    ] = "select id from REPORTING.TEST_GENERAL.orders"
+    processor._compiled_manifest["nodes"]["test.jaffle_shop.not_null_orders_id"]["compiled_code"] = (
+        "select id from REPORTING.TEST_GENERAL.orders"
+    )
     processor.get_column_lineage = mock.Mock(return_value=sample_column_lineage_facet())
 
     event = processor.parse_node_finished_event(

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -9,6 +9,7 @@ from unittest import mock
 import attr
 import pytest
 import yaml
+from openlineage.client.facet_v2 import column_lineage_dataset
 from openlineage.common.provider.dbt.facets import ParentRunMetadata
 from openlineage.common.provider.dbt.processor import Adapter
 from openlineage.common.provider.dbt.structured_logs import (
@@ -134,6 +135,22 @@ def node_finished_event(
         },
         "info": {"name": "NodeFinished", "ts": "2024-01-01T00:00:01.000000Z"},
     }
+
+
+def sample_column_lineage_facet():
+    return column_lineage_dataset.ColumnLineageDatasetFacet(
+        fields={
+            "order_id": column_lineage_dataset.Fields(
+                inputFields=[
+                    column_lineage_dataset.InputField(
+                        namespace="test-namespace",
+                        name="REPORTING.TEST_GENERAL.stg_orders",
+                        field="id",
+                    )
+                ]
+            )
+        }
+    )
 
 
 ##################
@@ -435,6 +452,93 @@ def test_test_node_finished_has_no_external_query():
     )
 
     assert "externalQuery" not in ol_event_to_dict(event)["run"]["facets"]
+
+
+@pytest.mark.parametrize(
+    "unique_id, resource_type, node_status",
+    [
+        ("model.jaffle_shop.orders", "model", "success"),
+        ("model.jaffle_shop.orders", "model", "fail"),
+        ("snapshot.jaffle_shop.orders_snapshot", "snapshot", "success"),
+    ],
+    ids=["model_complete", "model_fail", "snapshot_complete"],
+)
+def test_node_finished_attaches_column_lineage(unique_id, resource_type, node_status):
+    processor = node_finished_processor()
+    compiled_sql = "select id as order_id from REPORTING.TEST_GENERAL.stg_orders"
+    processor._compiled_manifest["nodes"][unique_id]["compiled_code"] = compiled_sql
+    facet = sample_column_lineage_facet()
+    processor.get_column_lineage = mock.Mock(return_value=facet)
+
+    event = processor.parse_node_finished_event(
+        node_finished_event(
+            unique_id=unique_id,
+            resource_type=resource_type,
+            node_status=node_status,
+        )
+    )
+    output_facets = ol_event_to_dict(event)["outputs"][0]["facets"]
+
+    assert output_facets["columnLineage"] == ol_event_to_dict(facet)
+    processor.get_column_lineage.assert_called_once_with("test-namespace", compiled_sql)
+
+
+def test_node_finished_missing_compiled_sql_has_no_column_lineage():
+    processor = node_finished_processor()
+    processor.get_column_lineage = mock.Mock(return_value=sample_column_lineage_facet())
+
+    event = processor.parse_node_finished_event(node_finished_event())
+    output_facets = ol_event_to_dict(event)["outputs"][0]["facets"]
+
+    assert "columnLineage" not in output_facets
+    processor.get_column_lineage.assert_not_called()
+
+
+def test_node_finished_uses_compiled_sql_fallback_for_column_lineage():
+    processor = node_finished_processor()
+    compiled_sql = "select id as order_id from REPORTING.TEST_GENERAL.stg_orders"
+    processor._compiled_manifest["nodes"]["model.jaffle_shop.orders"]["compiled_sql"] = compiled_sql
+    facet = sample_column_lineage_facet()
+    processor.get_column_lineage = mock.Mock(return_value=facet)
+
+    event = processor.parse_node_finished_event(node_finished_event())
+    output_facets = ol_event_to_dict(event)["outputs"][0]["facets"]
+
+    assert output_facets["columnLineage"] == ol_event_to_dict(facet)
+    processor.get_column_lineage.assert_called_once_with("test-namespace", compiled_sql)
+
+
+def test_node_finished_column_lineage_parse_failure_has_no_column_lineage():
+    processor = node_finished_processor()
+    compiled_sql = "select id as order_id from REPORTING.TEST_GENERAL.stg_orders"
+    processor._compiled_manifest["nodes"]["model.jaffle_shop.orders"]["compiled_code"] = compiled_sql
+    processor.get_column_lineage = mock.Mock(return_value=None)
+
+    event = processor.parse_node_finished_event(node_finished_event())
+    output_facets = ol_event_to_dict(event)["outputs"][0]["facets"]
+
+    assert "columnLineage" not in output_facets
+    processor.get_column_lineage.assert_called_once_with("test-namespace", compiled_sql)
+
+
+def test_test_node_finished_has_no_column_lineage():
+    processor = node_finished_processor()
+    processor._compiled_manifest["nodes"]["test.jaffle_shop.not_null_orders_id"][
+        "compiled_code"
+    ] = "select id from REPORTING.TEST_GENERAL.orders"
+    processor.get_column_lineage = mock.Mock(return_value=sample_column_lineage_facet())
+
+    event = processor.parse_node_finished_event(
+        node_finished_event(
+            unique_id="test.jaffle_shop.not_null_orders_id",
+            resource_type="test",
+            node_status="pass",
+        )
+    )
+    output_facets = ol_event_to_dict(event)["outputs"][0]["facets"]
+
+    assert "columnLineage" not in output_facets
+    processor.get_column_lineage.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
This PR is to add missing column lineage facet for `DbtStructuredLogsProcessor`.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
Currently the column lineage facet is not included in the event when using `--consume-structured-logs` option. This PR attaches the column lineage facet to the output dataset when parsing node finished event.

### Checklist
- [x] AI was used in creating this PR
