### PR TITLE
Fix Spark Snowflake column lineage for quoted identifiers (#4601)

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -5,6 +5,8 @@
 
 package io.openlineage.spark.agent.lifecycle.plan.column;
 
+import static io.openlineage.client.utils.SnowflakeUtils.stripQuotes;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage;
@@ -91,7 +93,7 @@ public class ColumnLevelLineageBuilder {
    */
   public void addOutput(ExprId exprId, String attributeName) {
     schema.getFields().stream()
-        .filter(field -> field.getName().equals(attributeName))
+        .filter(field -> stripQuotes(field.getName()).equals(stripQuotes(attributeName)))
         .findAny()
         .ifPresent(field -> outputs.putIfAbsent(field, exprId));
   }
@@ -138,7 +140,7 @@ public class ColumnLevelLineageBuilder {
 
   public Optional<ExprId> getOutputExprIdByFieldName(String field) {
     return outputs.keySet().stream()
-        .filter(fields -> fields.getName().equals(field))
+        .filter(fields -> stripQuotes(fields.getName()).equals(stripQuotes(field)))
         .findAny()
         .map(f -> outputs.get(f));
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlCollector.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlCollector.java
@@ -5,6 +5,8 @@
 
 package io.openlineage.spark.agent.util;
 
+import static io.openlineage.client.utils.SnowflakeUtils.stripQuotes;
+
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
 import io.openlineage.sql.ColumnLineage;
@@ -70,7 +72,7 @@ public class SqlCollector {
 
   private ExprId getDescendantId(List<Attribute> output, ColumnMeta column) {
     return output.stream()
-        .filter(e -> e.name().equals(column.name()))
+        .filter(e -> stripQuotes(e.name()).equals(stripQuotes(column.name())))
         .map(NamedExpression::exprId)
         .findFirst()
         .orElseGet(NamedExpression::newExprId);

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/QueryRelationColumnLineageCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/QueryRelationColumnLineageCollector.java
@@ -4,6 +4,8 @@
 */
 package io.openlineage.spark3.agent.lifecycle.plan.column;
 
+import static io.openlineage.client.utils.SnowflakeUtils.stripQuotes;
+
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
@@ -101,7 +103,7 @@ public class QueryRelationColumnLineageCollector {
 
   private static ExprId getDescendantId(List<Attribute> output, ColumnMeta column) {
     return output.stream()
-        .filter(e -> e.name().equals(column.name()))
+        .filter(e -> stripQuotes(e.name()).equals(stripQuotes(column.name())))
         .map(NamedExpression::exprId)
         .findFirst()
         .orElseGet(NamedExpression::newExprId);

--- a/integration/spark/vendor/snowflake/src/test/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/ColumnLevelLineageSnowflakeTest.java
+++ b/integration/spark/vendor/snowflake/src/test/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/ColumnLevelLineageSnowflakeTest.java
@@ -117,6 +117,61 @@ class ColumnLevelLineageSnowflakeTest {
   }
 
   @Test
+  void testSnowflakeColumnLineageWithDbtableLowerCase() {
+    // Glue ETL scenario: dbtable and schema fields are lowercase, no quotes
+    StructType lowerCaseSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("colorid", IntegerType$.MODULE$, false, Metadata.empty()),
+              new StructField("colorname", StringType$.MODULE$, false, Metadata.empty())
+            });
+    when(snowflakeRelation.schema()).thenReturn(lowerCaseSchema);
+
+    givenALogicalRelationWith(
+        aSnowflakeRelation("dbtable", "colors"),
+        anAttribute("colorid", 21L),
+        anAttribute("colorname", 22L));
+
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        buildFacetFor(anOutputSchemaWith(aField("colorid"), aField("colorname")));
+
+    assertFieldsPresent(facet, "colorid", "colorname");
+    assertFieldDependsOn(facet, "colorid", "snowflake_db.snowflake_schema.colors.colorid");
+    assertFieldDependsOn(facet, "colorname", "snowflake_db.snowflake_schema.colors.colorname");
+
+    when(snowflakeRelation.schema()).thenReturn(snowflakeSchema);
+  }
+
+  @Test
+  void testSnowflakeColumnLineageWithDbtableQuotedAttributes() {
+    // Quoted attributes vs unquoted schema — tests both addOutput and getDescendantId fix points
+    StructType unquotedSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("colorid", IntegerType$.MODULE$, false, Metadata.empty()),
+              new StructField("colorname", StringType$.MODULE$, false, Metadata.empty())
+            });
+    when(snowflakeRelation.schema()).thenReturn(unquotedSchema);
+
+    givenALogicalRelationWith(
+        aSnowflakeRelation("dbtable", "\"colors\""),
+        anAttribute("\"colorid\"", 21L),
+        anAttribute("\"colorname\"", 22L));
+
+    // Output schema has UNQUOTED field names (matches production behavior)
+    OpenLineage.SchemaDatasetFacet outputSchema =
+        anOutputSchemaWith(aField("colorid"), aField("colorname"));
+
+    OpenLineage.ColumnLineageDatasetFacet facet = buildFacetFor(outputSchema);
+
+    assertFieldsPresent(facet, "colorid", "colorname");
+    assertFieldDependsOn(facet, "colorid", "snowflake_db.snowflake_schema.colors.colorid");
+    assertFieldDependsOn(facet, "colorname", "snowflake_db.snowflake_schema.colors.colorname");
+
+    when(snowflakeRelation.schema()).thenReturn(snowflakeSchema);
+  }
+
+  @Test
   void testSnowflakeColumnLineageWithQuery() {
     givenALogicalRelationWith(
         aSnowflakeRelation("query", "SELECT COLORID, COLORNAME FROM COLORS"),
@@ -129,6 +184,21 @@ class ColumnLevelLineageSnowflakeTest {
     assertFieldsPresent(facet, "COLORID", "COLORNAME");
     assertFieldDependsOn(facet, "COLORID", "COLORID");
     assertFieldDependsOn(facet, "COLORNAME", "COLORNAME");
+  }
+
+  @Test
+  void testSnowflakeColumnLineageWithLowerCaseQuery() {
+    givenALogicalRelationWith(
+        aSnowflakeRelation("query", "SELECT colorid, colorname FROM COLORS"),
+        anAttribute("colorid", 21L),
+        anAttribute("colorname", 22L));
+
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        buildFacetFor(anOutputSchemaWith(aField("colorid"), aField("colorname")));
+
+    assertFieldsPresent(facet, "colorid", "colorname");
+    assertFieldDependsOn(facet, "colorid", "colorid");
+    assertFieldDependsOn(facet, "colorname", "colorname");
   }
 
   @Test
@@ -295,6 +365,21 @@ class ColumnLevelLineageSnowflakeTest {
         "COLORNAME",
         "snowflake_db.snowflake_schema.COLORS.COLORNAME",
         "different_snowflake_db.different_snowflake_schema.COLORS.COLORTINT");
+  }
+
+  @Test
+  void testSnowflakeQueryWithLowerCaseQuotedIdentifiers() {
+    givenALogicalRelationWith(
+        aSnowflakeRelation("query", "SELECT \"colorid\", \"colorname\" FROM \"COLORS\""),
+        anAttribute("colorid", 21L),
+        anAttribute("colorname", 22L));
+
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        buildFacetFor(anOutputSchemaWith(aField("colorid"), aField("colorname")));
+
+    assertFieldsPresent(facet, "colorid", "colorname");
+    assertFieldDependsOn(facet, "colorid", "colorid");
+    assertFieldDependsOn(facet, "colorname", "colorname");
   }
 
   private SnowflakeRelation aSnowflakeRelation(String option, String value) {


### PR DESCRIPTION
 <!--
  Thanks for opening a pull request!
  Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

  closes: [#4601](https://github.com/OpenLineage/OpenLineage/issues/4601)
  -->

  ### One-line summary for changelog:
  Fix Snowflake column lineage missing when Spark logical plan attributes contain quoted identifiers (e.g., AWS Glue ETL with `dbtable` path).

  ### Meaningful description

  **Problem:** When using the Snowflake Spark connector with quoted identifiers (e.g., `"\"my_table\""` in PySpark), Spark preserves the quotes in logical plan attribute names (`"colorid"#21` instead of
  `colorid#21`). The column lineage code uses plain `.equals()` to match these quoted attribute names against unquoted schema field names from `snowflakeRelation.schema().fields()`, causing the entire
  `columnLineage` facet to be absent from the output dataset.
  
  **Root Cause:** Two comparison points fail:
  1. `ColumnLevelLineageBuilder.addOutput()` — output schema field `colorid` vs attribute `"colorid"` → mismatch → output never registered
  2. `SqlCollector.getDescendantId()` — attribute `"colorid"` vs ColumnMeta `colorid` → mismatch → orphan ExprId, dependency chain broken

  **Solution:** Apply the existing `stripQuotes()` utility (already used for database/schema/table normalization) on both sides of identifier comparisons at these points. The `query` path is unaffected since
  `OpenLineageSql.parse()` already strips quotes during SQL parsing.

  **Alternatives considered:**
  - `equalsIgnoreCase()` — rejected because it breaks quoted identifier tests where two distinct columns from different tables share the same name in different case
  - Normalizing names at the source (`SnowflakeColumnLineageVisitorDelegate`) — would fix `getDescendantId` but not `addOutput`, since the output schema facet is built separately with unquoted names

  ### Testing
  I validated the fix by running a Glue ETL job where table, schema, and column names are enclosed with double quotes. With the snapshot jar, column lineage is now captured correctly — all field-to-field
  mappings are present including computed columns with multiple input dependencies.

  ### Checklist
  - [x] AI was used in creating this PR