### PR TITLE
spark: fix lakehouse detection mechanism

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -86,15 +86,14 @@ public class CatalogDatasetFacetUtils {
   }
 
   public static boolean isHiveCatalog(SparkSession session, TableIdentifier identifier) {
-    return "hive"
-            .equals(session.sparkContext().getConf().get("spark.sql.catalogImplementation", ""))
+    return isHiveSupportEnabled(session.sparkContext())
         && getCatalogPlugin(session, identifier)
-            .map(catalogPlugin -> isHiveCatalog(session.sparkContext(), catalogPlugin))
+            .map(CatalogDatasetFacetUtils::isHiveCatalog)
             .orElse(false);
   }
 
   @SuppressWarnings("PMD")
-  private static boolean isHiveCatalog(SparkContext context, CatalogPlugin catalogPlugin) {
+  public static boolean isHiveCatalog(CatalogPlugin catalogPlugin) {
     if (catalogPlugin instanceof V2SessionCatalog) {
       V2SessionCatalog v2Catalog = ((V2SessionCatalog) catalogPlugin);
       Field catalog = FieldUtils.getField(V2SessionCatalog.class, "catalog", true);
@@ -122,5 +121,9 @@ public class CatalogDatasetFacetUtils {
       //            log.debug("No catalog name, cannot add catalog/storage facets");
       return Optional.empty();
     }
+  }
+
+  public static boolean isHiveSupportEnabled(SparkContext sc) {
+    return "hive".equals(sc.getConf().get("spark.sql.catalogImplementation", ""));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtils.java
@@ -16,9 +16,11 @@ public class GoogleCloudPlatformUtils {
       // To use Big Lake Hive Catalog you have to use custom implementation of HiveConf that
       // contains this enum
       // if the enum is present, you can set the custom client factory
-      String name = HiveConf.ConfVars.valueOf("spark.hive.metastore.client.factory.class").name();
-      return conf.getOption(name)
-          .exists("com.google.cloud.spark.biglake.hive.BigLakeHiveClientFactory"::equals);
+      HiveConf.ConfVars.valueOf("METASTORE_CLIENT_FACTORY_CLASS");
+      log.debug("detected custom Metastore Client Factory class");
+      return conf.getOption("spark.hive.metastore.client.factory.class")
+          .exists(
+              "com.google.cloud.bigquery.metastore.client.BigLakeMetastoreClientFactory"::equals);
     } catch (IllegalArgumentException e) {
       return false;
     }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtilsTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.util;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -61,7 +62,7 @@ class GoogleCloudPlatformUtilsTest {
     conf.set(METASTORE_CLASS_KEY, VALID_METASTORE_CLASS_VALUE);
     try (MockedStatic<HiveConf.ConfVars> confVars = mockStatic(HiveConf.ConfVars.class)) {
       confVars.when(() -> HiveConf.ConfVars.valueOf(METASTORE_HIVE_CONF_STRING)).thenReturn(null);
-      assert (GoogleCloudPlatformUtils.isBigLakeHiveCatalog(conf));
+      assertTrue(GoogleCloudPlatformUtils.isBigLakeHiveCatalog(conf));
     }
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GoogleCloudPlatformUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mockStatic;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class GoogleCloudPlatformUtilsTest {
+
+  String METASTORE_HIVE_CONF_STRING = "METASTORE_CLIENT_FACTORY_CLASS";
+  String METASTORE_CLASS_KEY = "spark.hive.metastore.client.factory.class";
+  String VALID_METASTORE_CLASS_VALUE =
+      "com.google.cloud.bigquery.metastore.client.BigLakeMetastoreClientFactory";
+  String INVALID_METASTORE_CLASS_VALUE = "test";
+
+  @Test
+  void bigLakeMetastoreAbsentCustomHiveAbsent() {
+    SparkConf conf = new SparkConf();
+    conf.set(METASTORE_CLASS_KEY, INVALID_METASTORE_CLASS_VALUE);
+    try (MockedStatic<HiveConf.ConfVars> confVars = mockStatic(HiveConf.ConfVars.class)) {
+      confVars
+          .when(() -> HiveConf.ConfVars.valueOf(METASTORE_HIVE_CONF_STRING))
+          .thenThrow(new IllegalArgumentException());
+      assertFalse(GoogleCloudPlatformUtils.isBigLakeHiveCatalog(conf));
+    }
+  }
+
+  @Test
+  void bigLakeMetastorePresentCustomHiveAbsent() {
+    SparkConf conf = new SparkConf();
+    conf.set(METASTORE_CLASS_KEY, VALID_METASTORE_CLASS_VALUE);
+    try (MockedStatic<HiveConf.ConfVars> confVars = mockStatic(HiveConf.ConfVars.class)) {
+      confVars
+          .when(() -> HiveConf.ConfVars.valueOf(METASTORE_HIVE_CONF_STRING))
+          .thenThrow(new IllegalArgumentException());
+      assertFalse(GoogleCloudPlatformUtils.isBigLakeHiveCatalog(conf));
+    }
+  }
+
+  @Test
+  void bigLakeMetastoreAbsentCustomHivePresent() {
+    SparkConf conf = new SparkConf();
+    conf.set(METASTORE_CLASS_KEY, INVALID_METASTORE_CLASS_VALUE);
+    try (MockedStatic<HiveConf.ConfVars> confVars = mockStatic(HiveConf.ConfVars.class)) {
+      confVars.when(() -> HiveConf.ConfVars.valueOf(METASTORE_HIVE_CONF_STRING)).thenReturn(null);
+      assertFalse(GoogleCloudPlatformUtils.isBigLakeHiveCatalog(conf));
+    }
+  }
+
+  @Test
+  void bigLakeMetastorePresentCustomHivePresent() {
+    SparkConf conf = new SparkConf();
+    conf.set(METASTORE_CLASS_KEY, VALID_METASTORE_CLASS_VALUE);
+    try (MockedStatic<HiveConf.ConfVars> confVars = mockStatic(HiveConf.ConfVars.class)) {
+      confVars.when(() -> HiveConf.ConfVars.valueOf(METASTORE_HIVE_CONF_STRING)).thenReturn(null);
+      assert (GoogleCloudPlatformUtils.isBigLakeHiveCatalog(conf));
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
-import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
 import scala.Option;
 
 /**
@@ -75,7 +74,6 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
 
     CatalogManager catalogManager = context.getSparkSession().get().sessionState().catalogManager();
     Optional.of(catalogManager.catalog(catalogName))
-        .filter(catalogPlugin -> !(catalogPlugin instanceof V2SessionCatalog))
         .filter(catalogPlugin -> catalogPlugin instanceof TableCatalog)
         .map(TableCatalog.class::cast)
         .ifPresent(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -31,7 +31,7 @@ public class CatalogUtils3 {
             new DatabricksDeltaHandler(context),
             new DatabricksUnityV2Handler(context),
             new JdbcHandler(context),
-            new V2SessionCatalogHandler());
+            new V2SessionCatalogHandler(context));
     return handlers.stream().filter(CatalogHandler::hasClasses).collect(Collectors.toList());
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
@@ -5,12 +5,19 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import static io.openlineage.spark.agent.util.CatalogDatasetFacetUtils.isHiveCatalog;
+
 import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.DatasetIdentifier.Symlink;
 import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
+import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.GoogleCloudPlatformUtils;
 import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
@@ -20,6 +27,12 @@ import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
 
 @Slf4j
 public class V2SessionCatalogHandler implements CatalogHandler {
+  private OpenLineageContext context;
+
+  public V2SessionCatalogHandler(OpenLineageContext context) {
+    this.context = context;
+  }
+
   @Override
   public boolean hasClasses() {
     return true;
@@ -57,12 +70,37 @@ public class V2SessionCatalogHandler implements CatalogHandler {
               PathUtils.reconstructDefaultLocation(
                   namespaceLocation, identifier.namespace(), identifier.name()));
     }
+    if (CatalogDatasetFacetUtils.isHiveSupportEnabled(session.sparkContext())
+        && isHiveCatalog(tableCatalog)) {
+      if (GoogleCloudPlatformUtils.isBigLakeHiveCatalog(session.sparkContext().getConf())) {
+        di.withSymlink(new Symlink(identifier.toString(), "gcp_lakehouse", SymlinkType.TABLE));
+      } else {
+        PathUtils.getMetastoreUri(session.sparkContext())
+            .map(
+                uri ->
+                    FilesystemDatasetUtils.fromLocationAndName(
+                        PathUtils.prepareHiveUri(uri), identifier.toString()))
+            .ifPresent(
+                i -> di.withSymlink(new Symlink(i.getName(), i.getNamespace(), SymlinkType.TABLE)));
+      }
+    }
 
-    if (namespaceLocation != null) {
+    if (namespaceLocation != null && di.getSymlinks().isEmpty()) {
       di.withSymlink(
           new Symlink(identifier.toString(), namespaceMetadata.get("location"), SymlinkType.TABLE));
     }
     return di;
+  }
+
+  @Override
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
+      TableCatalog tableCatalog, Map<String, String> properties) {
+    return context
+        .getSparkContext()
+        .filter(CatalogDatasetFacetUtils::isHiveSupportEnabled)
+        .filter(sc -> CatalogDatasetFacetUtils.isHiveCatalog(tableCatalog))
+        .flatMap(c -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(context))
+        .map(CatalogWithAdditionalFacets::of);
   }
 
   @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandlerTest.java
@@ -7,35 +7,60 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import io.openlineage.spark.agent.util.CatalogDatasetFacetUtils;
+import io.openlineage.spark.agent.util.GoogleCloudPlatformUtils;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class V2SessionCatalogHandlerTest {
-  private V2SessionCatalogHandler catalogHandler = new V2SessionCatalogHandler();
-  private V2SessionCatalog catalog = mock(V2SessionCatalog.class);
+  private final OpenLineageContext context = mock(OpenLineageContext.class);
+  private final V2SessionCatalogHandler catalogHandler = new V2SessionCatalogHandler(context);
+  private final V2SessionCatalog catalog = mock(V2SessionCatalog.class);
+  private final SparkSession session = mock(SparkSession.class);
+  private final SparkContext sparkContext = mock(SparkContext.class);
+  private final Map<String, String> properties =
+      Collections.singletonMap("location", "file:/tmp/warehouse/schema.db/table");
+  private final Map<String, String> namespaceMetadata =
+      Collections.singletonMap("location", "file:/tmp/warehouse");
+  private final Identifier id = Identifier.of(new String[] {"catalog", "schema"}, "table");
+
+  @BeforeEach
+  void setUp() {
+    when(context.getSparkSession()).thenReturn(Optional.of(session));
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(session.sparkContext()).thenReturn(sparkContext);
+  }
 
   @Test
-  void testGetDatasetIdentifierWhenOnlyTableLocationPresent() {
-    Identifier id = Identifier.of(new String[] {"catalog", "schema"}, "table");
-
-    HashMap<String, String> properties = new HashMap();
-    properties.put("location", "file:/tmp/warehouse/schema.db/table");
-
+  void testGetNonHiveDatasetIdentifierWhenOnlyTableLocationPresent() {
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
     when(catalog.loadNamespaceMetadata(id.namespace())).thenReturn(Collections.emptyMap());
 
     DatasetIdentifier datasetIdentifier =
-        catalogHandler.getDatasetIdentifier(mock(SparkSession.class), catalog, id, properties);
+        catalogHandler.getDatasetIdentifier(session, catalog, id, properties);
 
     assertThat(datasetIdentifier)
         .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table")
@@ -46,17 +71,12 @@ class V2SessionCatalogHandlerTest {
   }
 
   @Test
-  void testGetDatasetIdentifierWhenWarehouseLocationPresent() {
-    Identifier id = Identifier.of(new String[] {"catalog", "schema"}, "table");
-
-    HashMap<String, String> properties = new HashMap();
-    properties.put("location", "file:/tmp/warehouse/schema.db/table");
-
-    when(catalog.loadNamespaceMetadata(id.namespace()))
-        .thenReturn(Collections.singletonMap("location", "file:/tmp/warehouse"));
+  void testGetNonHiveDatasetIdentifierWhenWarehouseLocationPresent() {
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(catalog.loadNamespaceMetadata(id.namespace())).thenReturn(namespaceMetadata);
 
     DatasetIdentifier datasetIdentifier =
-        catalogHandler.getDatasetIdentifier(mock(SparkSession.class), catalog, id, properties);
+        catalogHandler.getDatasetIdentifier(session, catalog, id, properties);
 
     assertThat(datasetIdentifier)
         .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table")
@@ -71,19 +91,128 @@ class V2SessionCatalogHandlerTest {
   }
 
   @Test
+  void testGetHiveDatasetIdentifier() {
+    when(catalog.loadNamespaceMetadata(id.namespace())).thenReturn(namespaceMetadata);
+
+    try (MockedStatic<CatalogDatasetFacetUtils> catalogDatasetUtils =
+        mockStatic(CatalogDatasetFacetUtils.class)) {
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(catalog))
+          .thenReturn(true);
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveSupportEnabled(sparkContext))
+          .thenReturn(true);
+      try (MockedStatic<PathUtils> pathUtils = mockStatic(PathUtils.class)) {
+        URI hiveUri = URI.create("hive://hive-host:9093");
+        pathUtils
+            .when(() -> PathUtils.getMetastoreUri(sparkContext))
+            .thenReturn(Optional.of(hiveUri));
+        pathUtils.when(() -> PathUtils.prepareHiveUri(hiveUri)).thenReturn(hiveUri);
+        pathUtils
+            .when(() -> PathUtils.fromPath(any()))
+            .thenReturn(new DatasetIdentifier("/tmp/warehouse/schema.db/table", "file"));
+
+        DatasetIdentifier datasetIdentifier =
+            catalogHandler.getDatasetIdentifier(session, catalog, id, properties);
+
+        assertThat(datasetIdentifier)
+            .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table")
+            .hasFieldOrPropertyWithValue("namespace", "file");
+
+        assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+
+        assertThat(datasetIdentifier.getSymlinks().get(0))
+            .hasFieldOrPropertyWithValue("name", "catalog.schema.table")
+            .hasFieldOrPropertyWithValue("namespace", "hive://hive-host:9093")
+            .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+      }
+    }
+  }
+
+  @Test
+  void testGetLakehouseHiveDatasetIdentifier() {
+    when(sparkContext.getConf())
+        .thenReturn(new SparkConf().set("spark.sql.catalogImplementation", "hive"));
+    when(catalog.loadNamespaceMetadata(id.namespace())).thenReturn(namespaceMetadata);
+
+    try (MockedStatic<CatalogDatasetFacetUtils> catalogDatasetUtils =
+        mockStatic(CatalogDatasetFacetUtils.class)) {
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(catalog))
+          .thenReturn(true);
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveSupportEnabled(sparkContext))
+          .thenReturn(true);
+      try (MockedStatic<GoogleCloudPlatformUtils> gcpUtils =
+          mockStatic(GoogleCloudPlatformUtils.class)) {
+        gcpUtils.when(() -> GoogleCloudPlatformUtils.isBigLakeHiveCatalog(any())).thenReturn(true);
+
+        DatasetIdentifier datasetIdentifier =
+            catalogHandler.getDatasetIdentifier(session, catalog, id, properties);
+
+        assertThat(datasetIdentifier)
+            .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table")
+            .hasFieldOrPropertyWithValue("namespace", "file");
+
+        assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+
+        assertThat(datasetIdentifier.getSymlinks().get(0))
+            .hasFieldOrPropertyWithValue("name", "catalog.schema.table")
+            .hasFieldOrPropertyWithValue("namespace", "gcp_lakehouse")
+            .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+      }
+    }
+  }
+
+  @Test
+  void testGetCatalogFacetForNonHive() {
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+
+    try (MockedStatic<CatalogDatasetFacetUtils> catalogDatasetUtils =
+        mockStatic(CatalogDatasetFacetUtils.class)) {
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(catalog))
+          .thenReturn(false);
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveSupportEnabled(sparkContext))
+          .thenReturn(true);
+
+      Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
+          catalogHandler.getCatalogDatasetFacet(mock(V2SessionCatalog.class), new HashMap<>());
+      assertThat(catalogDatasetFacet).isEmpty();
+    }
+  }
+
+  @Test
+  void testGetCatalogFacetForHive() {
+    OpenLineage.CatalogDatasetFacet cf = mock(OpenLineage.CatalogDatasetFacet.class);
+
+    try (MockedStatic<CatalogDatasetFacetUtils> catalogDatasetUtils =
+        mockStatic(CatalogDatasetFacetUtils.class)) {
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveCatalog(any()))
+          .thenReturn(true);
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.isHiveSupportEnabled(sparkContext))
+          .thenReturn(true);
+      catalogDatasetUtils
+          .when(() -> CatalogDatasetFacetUtils.getCatalogDatasetFacetForHive(any()))
+          .thenReturn(Optional.of(cf));
+      Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
+          catalogHandler.getCatalogDatasetFacet(mock(V2SessionCatalog.class), new HashMap<>());
+      assertThat(catalogDatasetFacet).isNotEmpty();
+      assertThat(catalogDatasetFacet.get().getCatalogDatasetFacet()).isEqualTo(cf);
+    }
+  }
+
+  @Test
   void testGetDatasetIdentifierWhenNoTableLocationPresent() {
-    Identifier id = Identifier.of(new String[] {"catalog", "schema"}, "table");
-
-    HashMap<String, String> properties = new HashMap();
-
     when(catalog.loadNamespaceMetadata(id.namespace())).thenReturn(Collections.emptyMap());
 
     OpenLineageClientException thrown =
         assertThrows(
             OpenLineageClientException.class,
-            () ->
-                catalogHandler.getDatasetIdentifier(
-                    mock(SparkSession.class), catalog, id, properties));
+            () -> catalogHandler.getDatasetIdentifier(session, catalog, id, new HashMap<>()));
 
     assertThat(thrown.getMessage())
         .contains("Unable to extract DatasetIdentifier from V2SessionCatalog");


### PR DESCRIPTION

### One-line summary for changelog:
fix lakehouse detection mechanism


### Meaningful description
first version of detection mechanism had used two incorrect properties, which worked in local reproduction but failed on the dataproc clusters

additionally the `*DatasetBuilder` logic relies heavily on catalog handlers so the extraction was also added to `V2SessionCatalogHandler`


### Checklist
- [ ] AI was used in creating this PR
