### PR TITLE
Java: Fix port definition for JDBC IPv6 address

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
@@ -16,7 +16,7 @@ public class OverridingJdbcExtractor extends GenericJdbcExtractor implements Jdb
   private String overrideScheme;
   private String defaultPort;
   private static Pattern HOST_PORT_FORMAT =
-      Pattern.compile("^(?<host>[\\[\\]\\w\\d.-]+):(?<port>\\d+)?");
+      Pattern.compile("^(?<host>\\[.*]|[^:\\]]+):(?<port>\\d+)?$");
 
   public OverridingJdbcExtractor(String overrideScheme) {
     this(overrideScheme, null);

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForClickHouse.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForClickHouse.java
@@ -28,6 +28,12 @@ class JdbcDatasetUtilsTestForClickHouse {
                 "jdbc:clickhouse://test-host.com:9000", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:9000")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://[2001:db8::1]:9000", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://[2001:db8::1]:9000")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
@@ -65,6 +65,15 @@ class JdbcDatasetUtilsTestForMySql {
                 "jdbc:mysql://hostname:3307", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "mysql://hostname:3307")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:mysql://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:3307",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "mysql://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:3307")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -103,6 +103,15 @@ class JdbcDatasetUtilsTestForOracle {
                 "jdbc:oracle:thin:@hostname:1522", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1522",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "oracle://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1522")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
@@ -59,6 +59,15 @@ class JdbcDatasetUtilsTestForPostgres {
                 "jdbc:postgresql://hostname:5433", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "postgres://hostname:5433")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:postgresql://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:5433",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "postgres://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:5433")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Fix port extraction for JDBC IPv6 URLs with custom port


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->

#### Problem:
When parsing JDBC URLs with IPv6 host addresses, the port extraction logic fails because colons in the IPv6 address interfered with detecting the actual port delimiter.

#### Example of incorrect behavior:

```
Input:  jdbc:clickhouse://[2001:db8::1]:8124
Output: clickhouse://[2001:db8::1]:8124:8123 (custom port + default port appended)
```

#### Solution:
Update the regex pattern to correctly handle IPv6 addresses.

### Checklist
- [ ] AI was used in creating this PR
