### PR TITLE
flink: add timeout-aware run event emission support

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -13,6 +13,7 @@ import io.openlineage.client.circuitBreaker.CircuitBreaker;
 import io.openlineage.client.metrics.MicrometerProvider;
 import io.openlineage.client.transports.ConsoleTransport;
 import io.openlineage.client.transports.Transport;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -72,6 +73,23 @@ public final class OpenLineageClient implements AutoCloseable {
    * @param runEvent The run event to emit.
    */
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
+    emitRunEvent(runEvent, () -> transport.emit(runEvent));
+  }
+
+  /**
+   * Emit the given run event with a bounded wait when supported by the configured transport.
+   *
+   * <p>Transports that do not support bounded delivery acknowledgement may fall back to regular
+   * asynchronous emit semantics.
+   *
+   * @param runEvent The run event to emit.
+   * @param timeout Maximum time to wait for transports that support bounded delivery.
+   */
+  public void emit(@NonNull OpenLineage.RunEvent runEvent, @NonNull Duration timeout) {
+    emitRunEvent(runEvent, () -> transport.emit(runEvent, timeout));
+  }
+
+  private void emitRunEvent(@NonNull OpenLineage.RunEvent runEvent, Runnable emit) {
     if (log.isDebugEnabled()) {
       log.debug(
           "OpenLineageClient will emit lineage event: {}", OpenLineageClientUtils.toJson(runEvent));
@@ -84,7 +102,7 @@ public final class OpenLineageClient implements AutoCloseable {
       engagedCircuitBreaker.set(0);
     }
     emitStart.increment();
-    emitTime.record(() -> transport.emit(runEvent));
+    emitTime.record(emit);
     emitComplete.increment();
   }
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -7,6 +7,8 @@ package io.openlineage.client.transports;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClientUtils;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -100,6 +102,11 @@ public final class KafkaTransport extends Transport {
   }
 
   @Override
+  public void emit(@NonNull OpenLineage.RunEvent runEvent, @NonNull Duration timeout) {
+    emit(OpenLineageClientUtils.toJson(runEvent), getMessageKey(runEvent), timeout);
+  }
+
+  @Override
   public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
     emit(OpenLineageClientUtils.toJson(datasetEvent), getMessageKey(datasetEvent));
   }
@@ -110,6 +117,10 @@ public final class KafkaTransport extends Transport {
   }
 
   private void emit(String eventAsJson, String eventKey) {
+    emit(eventAsJson, eventKey, null);
+  }
+
+  private void emit(String eventAsJson, String eventKey, Duration timeout) {
     String partitionKey = messageKey;
     if (partitionKey == null) {
       partitionKey = eventKey;
@@ -118,7 +129,14 @@ public final class KafkaTransport extends Transport {
     final ProducerRecord<String, String> record =
         new ProducerRecord<>(topicName, partitionKey, eventAsJson);
     try {
-      producer.send(record);
+      if (timeout == null) {
+        producer.send(record);
+      } else {
+        producer.send(record).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("Interrupted while waiting to collect lineage event: {}", eventAsJson, e);
     } catch (Exception e) {
       log.error("Failed to collect lineage event: {}", eventAsJson, e);
     }

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -6,6 +6,7 @@
 package io.openlineage.client.transports;
 
 import io.openlineage.client.OpenLineage;
+import java.time.Duration;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
@@ -16,6 +17,16 @@ public abstract class Transport implements AutoCloseable {
   public abstract void emit(@NonNull OpenLineage.DatasetEvent datasetEvent);
 
   public abstract void emit(@NonNull OpenLineage.JobEvent jobEvent);
+
+  /**
+   * Emit the given run event with a bounded wait when supported by the transport.
+   *
+   * <p>The default implementation keeps regular emit behavior for transports that do not support
+   * delivery acknowledgement.
+   */
+  public void emit(@NonNull OpenLineage.RunEvent runEvent, @NonNull Duration timeout) {
+    emit(runEvent);
+  }
 
   @Override
   public void close() throws Exception {}

--- a/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
@@ -22,8 +22,10 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.OpenLineageClientUtils;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,28 @@ class KafkaTransportTest {
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
     assertThat(captor.getValue().key()).isEqualTo("run:test-namespace/test-job");
     assertThat(captor.getValue().value()).isEqualTo(OpenLineageClientUtils.toJson(event));
+  }
+
+  @Test
+  void clientEmitsRunEventKafkaTransportWithTimeout() throws Exception {
+    KafkaProducer<String, String> producer = mock(KafkaProducer.class);
+    KafkaConfig config = new KafkaConfig();
+
+    Properties properties = new Properties();
+    properties.setProperty("bootstrap.servers", "localhost:9092;external:9092");
+
+    config.setTopicName("test-topic");
+    config.setProperties(properties);
+
+    KafkaTransport transport = new KafkaTransport(producer, config);
+    OpenLineageClient client = new OpenLineageClient(transport);
+    Future future = mock(Future.class);
+    when(producer.send(any(ProducerRecord.class))).thenReturn(future);
+
+    OpenLineage.RunEvent event = runEvent();
+    client.emit(event, Duration.ofSeconds(5));
+
+    verify(future, times(1)).get(5000, TimeUnit.MILLISECONDS);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Adds a timeout-aware `RunEvent` emit overload to the Java client and transport API. This is split out as a small prerequisite PR based on the discussion here: https://github.com/OpenLineage/OpenLineage/pull/4596#discussion_r3355040919

## Changes
This lets callers provide a bounded wait when emitting RunEvents, while keeping existing transport behavior unchanged by default. Kafka transport will use the provided timeout to wait for producer acknowledgement before returning.

## Notes
This PR only adds the reusable client/transport API. The Flink detached/session listener change that consumes this overload will remain in a follow-up PR here: https://github.com/OpenLineage/OpenLineage/pull/4596