### PR TITLE
flink: emit abort event for canceled jobs

### DIFF
--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/util/JobStatusUtil.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/util/JobStatusUtil.java
@@ -18,9 +18,11 @@ public class JobStatusUtil {
    */
   public static EventType fromJobStatus(JobStatus jobStatus) {
     if (jobStatus.isGloballyTerminalState()) {
-      // termination status
       if (jobStatus.equals(JobStatus.FINISHED)) {
         return EventType.COMPLETE;
+      }
+      if (jobStatus.equals(JobStatus.CANCELED)) {
+        return EventType.ABORT;
       }
       return EventType.FAIL;
     }

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerTest.java
@@ -227,6 +227,36 @@ class OpenLineageJobStatusChangedListenerTest {
   }
 
   @Test
+  @SneakyThrows
+  void testOnEventJobCanceled() {
+    listener = new OpenLineageJobStatusChangedListener(context, factory);
+
+    // emit start event
+    JobCreatedEvent createdEvent = mock(JobCreatedEvent.class);
+    when(createdEvent.jobName()).thenReturn("event-job-name");
+    listener.onEvent(createdEvent);
+
+    // emit abort event
+    DefaultJobExecutionStatusEvent statusEvent =
+        new DefaultJobExecutionStatusEvent(
+            new JobID(1, 2),
+            "jobName",
+            JobStatus.RUNNING,
+            JobStatus.CANCELED,
+            mock(Throwable.class));
+    listener.onEvent(statusEvent);
+
+    List<RunEvent> eventsEmitted =
+        Files.readAllLines(Path.of(eventFileLocation)).stream()
+            .map(OpenLineageClientUtils::runEventFromJson)
+            .collect(Collectors.toList());
+
+    assertThat(eventsEmitted).hasSize(2);
+    assertThat(eventsEmitted.get(0).getEventType()).isEqualTo(EventType.START);
+    assertThat(eventsEmitted.get(1).getEventType()).isEqualTo(EventType.ABORT);
+  }
+
+  @Test
   void testCircuitBreaker() {
     OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
     CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/util/JobStatusUtilTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/util/JobStatusUtilTest.java
@@ -18,7 +18,7 @@ class JobStatusUtilTest {
   void testFromJobStatus() {
     assertThat(JobStatusUtil.fromJobStatus(JobStatus.INITIALIZING)).isEqualTo(EventType.START);
 
-    assertThat(JobStatusUtil.fromJobStatus(JobStatus.CANCELED)).isEqualTo(EventType.FAIL);
+    assertThat(JobStatusUtil.fromJobStatus(JobStatus.CANCELED)).isEqualTo(EventType.ABORT);
     assertThat(JobStatusUtil.fromJobStatus(JobStatus.FAILED)).isEqualTo(EventType.FAIL);
 
     assertThat(JobStatusUtil.fromJobStatus(JobStatus.FINISHED)).isEqualTo(EventType.COMPLETE);


### PR DESCRIPTION
closes: #4614
 
### One-line summary for changelog:
  Flink 2 now emits ABORT events for canceled jobs instead of FAIL events.

  ### Meaningful description
  Flink 2 job status handling previously mapped all globally terminal statuses other than FINISHED to FAIL. That caused user-canceled jobs to be reported as failed executions in downstream OpenLineage consumers.

  This change maps `JobStatus.CANCELED` to `EventType.ABORT` while keeping `FAILED` mapped to `FAIL` and `FINISHED` mapped to `COMPLETE`. It also updates the unit test expectation and adds listener-level coverage for canceled job status events.

  Tests:
  - `./gradlew :flink2:test --tests io.openlineage.flink.util.JobStatusUtilTest --tests io.openlineage.flink.listener.OpenLineageJobStatusChangedListenerTest`

  ### Checklist
  - [x] AI was used in creating this PR
