### PR TITLE
flink: add docs for the special detached job tracking flow

### DIFF
--- a/website/docs/integrations/flink/flink2.md
+++ b/website/docs/integrations/flink/flink2.md
@@ -46,3 +46,40 @@ Following [PR](https://github.com/apache/flink/pull/26089#issuecomment-262654207
 contains a potential extension to Flink to make it available. Please refer to 
 [this document for more information about the implementation](https://docs.google.com/document/d/1XmbHy6XqBrMoH9rkSyOG0wbwQZgf0epz-07lr_NfikI/edit?tab=t.0#heading=h.gw6ivvgpdre0).
 
+## Special Detached Job Tracking Flow
+
+### How to know if you need this flow
+
+You likely need detached job tracking if either of these is true:
+- You're submitting your job in detached mode, with the job client running on a remote machine meaning the client and the JobManager are in different JVMs.
+- In the default flow, you're only seeing the `START` event and no `RUNNING`, `COMPLETE`, or `FAIL` events afterward, which is a strong signal that your job is being submitted remotely in detached mode.
+
+### Enabling it
+
+Enable the flow by setting `openlineage.flink.enableDetachedJobTracking` to `true`. See the
+[configuration section](./configuration.md#flink-specific-configuration) for this option and the related
+`openlineage.flink.detachedStartEventEmitTimeoutInSeconds` timeout.
+
+With this enabled, the `START` event is emitted from the submitting (client) process, while later status
+events (`RUNNING`, `COMPLETE`, `FAIL`) are handled by the JobManager listener.
+
+### How it works
+
+When you submit remotely in detached mode, the job client and the JobManager run in different JVMs,
+typically on different machines. The default flow assumes both lifecycle stages happen in the same JVM:
+the client-side `START` event carries the Flink job ID, and the JobManager-side listener relies on that
+same event to initialize its tracking.
+
+Because the client is remote and lives in a separate JVM, the JobManager-side listener never receives
+that job ID. It cannot associate incoming status changes with the existing run, so it does not emit OpenLineage
+events for them. This is why you see `START` event but nothing after it.
+
+Detached job tracking fixes this by having the JobManager-side listener reconstruct the same OpenLineage
+run id from the Flink job id and the job start time exposed by the Flink jobs API, so the
+post-submission lifecycle events correlate back to the original `START`.
+
+### Limitation
+
+Unlike the default flow, detached job tracking does not emit an immediate `RUNNING` event right after `START`
+to avoid race conditions. Later `RUNNING` events will be emitted as normal from checkpoint tracking using the
+`openlineage.trackingIntervalInSeconds` interval.


### PR DESCRIPTION
### One-line summary for changelog:
Adding docs for the new detached job tracking flow in flink

### Meaningful description
- Adding docs for this change added here: https://github.com/OpenLineage/OpenLineage/pull/4596
- This PR explains when to use this special flow, what it does and its' limitations

### Checklist
- [ ] AI was used in creating this PR
