### PR TITLE
buildSrc: close leaked file streams in jarVerification bytecode check

### DIFF
--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginDelegate.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginDelegate.kt
@@ -75,22 +75,23 @@ class JarVerificationPluginDelegate(
      * For example, for Java 8 compiled classes should contain class major version equal to 52.
      */
     private fun hasCompiledClassesMajorVersionAboveAllowed(): Boolean {
+        val highest = extension.highestMajorClassVersionAllowed.get()
         return target
             .zipTree(locateJar(target).toPath())
             .files
             .filter { it.extension == "class" }
             .filter { !it.path.contains("META-INF") }
-            .filter { majorVersionOf(it.path) > extension.highestMajorClassVersionAllowed.get() }
-            .map { p ->
-                logger.error("[ERROR] Major class version for '${p.path}' " +
-                        "is '${majorVersionOf(p.path)}', which is above " +
-                        "'${extension.highestMajorClassVersionAllowed.get()}'")
+            .map { it.path to majorVersionOf(it.path) }
+            .filter { (_, version) -> version > highest }
+            .map { (path, version) ->
+                logger.error("[ERROR] Major class version for '$path' " +
+                        "is '$version', which is above '$highest'")
             }
             .isNotEmpty()
     }
 
     private fun majorVersionOf(path: String): Int {
-        return ClassFile(DataInputStream(FileInputStream(File(path)))).majorVersion
+        return DataInputStream(FileInputStream(File(path))).use { ClassFile(it).majorVersion }
     }
 
     /**


### PR DESCRIPTION
majorVersionOf opened a FileInputStream per class and never closed it, and hasCompiledClassesMajorVersionAboveAllowed called it twice per class. On a large shadow jar this leaked enough file descriptors that Gradle's post-task output fingerprinting failed with 'Too many open files'. Close the stream via use{} and read each class once.

### One-line summary for changelog:
Fixed file descriptor leak in JarVerificationPlugin


### Meaningful description
The solution closes files with classes opened by `JarVerificationPluginDelegate` as soon as it doesn't need them anymore.

Before:
<img width="1195" height="394" alt="open files broken" src="https://github.com/user-attachments/assets/1f2e6d31-33e1-4f3e-a96a-3b849bc5c053" />

After:
<img width="1204" height="389" alt="open files fixed" src="https://github.com/user-attachments/assets/9a9833c9-c40f-4465-b255-3829b7b9bb4f" />



### Checklist
- [X] AI was used in creating this PR (but I checked manually if it works and fully understand the problem and the solution)

Fixes: #4631
