### PR TITLE
Use scanReportSupplier for building iceberg scan report facet if available.

### DIFF
--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergScanReportInputDatasetFacetBuilder.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergScanReportInputDatasetFacetBuilder.java
@@ -9,13 +9,24 @@ import static io.openlineage.spark.agent.vendor.iceberg.metrics.CatalogMetricsRe
 
 import io.openlineage.client.OpenLineage.InputDatasetFacet;
 import io.openlineage.spark.agent.vendor.iceberg.metrics.CatalogMetricsReporterHolder;
+import io.openlineage.spark.agent.vendor.iceberg.metrics.ScanReportsFacetBuilder;
 import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark.api.SparkOpenLineageConfig.VendorsConfig;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.spark.sql.connector.read.Scan;
 
 @Slf4j
@@ -23,6 +34,8 @@ public class IcebergScanReportInputDatasetFacetBuilder
     extends CustomFacetBuilder<Scan, InputDatasetFacet> {
 
   private final OpenLineageContext context;
+  private final Set<Scan> reportedScans =
+      Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
   public IcebergScanReportInputDatasetFacetBuilder(OpenLineageContext context) {
     super();
@@ -31,6 +44,15 @@ public class IcebergScanReportInputDatasetFacetBuilder
 
   @Override
   public boolean isDefinedAt(Object x) {
+    if (Optional.ofNullable(context.getOpenLineageConfig())
+        .map(SparkOpenLineageConfig::getVendors)
+        .map(VendorsConfig::getConfig)
+        .flatMap(config -> Optional.ofNullable(config.get("iceberg")))
+        .map(VendorsConfig.VendorConfig::getMetricsReporterDisabled)
+        .orElse(false)) {
+      return false;
+    }
+
     if (!(x instanceof Scan)) {
       return false;
     }
@@ -42,6 +64,14 @@ public class IcebergScanReportInputDatasetFacetBuilder
 
   @Override
   protected void build(Scan x, BiConsumer<String, ? super InputDatasetFacet> consumer) {
+    Optional<InputDatasetFacet> scanReport = getScanReport(x);
+    if (scanReport.isPresent()) {
+      if (reportedScans.add(x)) {
+        consumer.accept("icebergScanReport", scanReport.get());
+      }
+      return;
+    }
+
     try {
       Table table = (Table) MethodUtils.invokeMethod(x, true, "table");
 
@@ -61,5 +91,28 @@ public class IcebergScanReportInputDatasetFacetBuilder
       // something got wrong
       log.warn("Could not extract Iceberg scan report", e);
     }
+  }
+
+  private Optional<InputDatasetFacet> getScanReport(Scan scan) {
+    Field field = FieldUtils.getField(scan.getClass(), "scanReportSupplier", true);
+    if (field == null) {
+      return Optional.empty();
+    }
+
+    try {
+      Object value = field.get(scan);
+      if (!(value instanceof Supplier)) {
+        return Optional.empty();
+      }
+
+      Object report = ((Supplier<?>) value).get();
+      if (report instanceof ScanReport) {
+        return Optional.of(ScanReportsFacetBuilder.from((ScanReport) report));
+      }
+    } catch (IllegalAccessException | RuntimeException e) {
+      log.debug("Could not extract scan-local Iceberg report", e);
+    }
+
+    return Optional.empty();
   }
 }

--- a/integration/spark/vendor/iceberg/src/test/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergScanReportInputDatasetFacetBuilderTest.java
+++ b/integration/spark/vendor/iceberg/src/test/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergScanReportInputDatasetFacetBuilderTest.java
@@ -1,0 +1,154 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.vendor.iceberg.lifecycle.plan;
+
+import static io.openlineage.spark.agent.vendor.iceberg.metrics.CatalogMetricsReporterHolder.VENDOR_CONTEXT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage.InputDatasetFacet;
+import io.openlineage.spark.agent.facets.IcebergScanReportInputDatasetFacet;
+import io.openlineage.spark.agent.vendor.iceberg.metrics.CatalogMetricsReporterHolder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark.api.Vendors;
+import io.openlineage.spark.api.VendorsContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+class IcebergScanReportInputDatasetFacetBuilderTest {
+
+  @Test
+  void emitsScanLocalReportWithoutCatalogReporter() {
+    ScanReport report = scanReport(42L);
+    Map<String, InputDatasetFacet> facets = new HashMap<>();
+
+    builder(null).build(new TestingScanWithReport(() -> report), facets::put);
+
+    assertThat(facets.get("icebergScanReport"))
+        .isInstanceOf(IcebergScanReportInputDatasetFacet.class)
+        .extracting(facet -> ((IcebergScanReportInputDatasetFacet) facet).getSnapshotId())
+        .isEqualTo(42L);
+  }
+
+  @Test
+  void scanLocalReportTakesPrecedenceOverCatalogReporter() {
+    CatalogMetricsReporterHolder holder = mock(CatalogMetricsReporterHolder.class);
+    Map<String, InputDatasetFacet> facets = new HashMap<>();
+
+    builder(holder).build(new TestingScanWithReport(() -> scanReport(42L)), facets::put);
+
+    assertThat(facets).containsKey("icebergScanReport");
+    verifyNoInteractions(holder);
+  }
+
+  @Test
+  void emitsScanLocalReportOnlyOnce() {
+    IcebergScanReportInputDatasetFacetBuilder builder = builder(null);
+    TestingScanWithReport scan = new TestingScanWithReport(() -> scanReport(42L));
+    AtomicInteger emittedFacets = new AtomicInteger();
+
+    builder.build(scan, (name, facet) -> emittedFacets.incrementAndGet());
+    builder.build(scan, (name, facet) -> emittedFacets.incrementAndGet());
+
+    assertThat(emittedFacets).hasValue(1);
+  }
+
+  @Test
+  void isNotDefinedWhenMetricsReporterIsDisabled() {
+    IcebergScanReportInputDatasetFacetBuilder builder = builder(null, true);
+    Map<String, InputDatasetFacet> facets = new HashMap<>();
+    Scan scan = new org.apache.iceberg.spark.TestingScanWithReport(() -> scanReport(42L));
+
+    builder.accept(scan, facets::put);
+
+    assertThat(builder.isDefinedAt(scan)).isFalse();
+    assertThat(facets).isEmpty();
+  }
+
+  @Test
+  void doesNotLookUpCatalogReporterWhenScanLocalReportIsAbsentWithoutLegacyMethods() {
+    CatalogMetricsReporterHolder holder = mock(CatalogMetricsReporterHolder.class);
+    Map<String, InputDatasetFacet> facets = new HashMap<>();
+
+    builder(holder).build(new TestingScanWithoutReport(), facets::put);
+
+    assertThat(facets).isEmpty();
+    verifyNoInteractions(holder);
+  }
+
+  private IcebergScanReportInputDatasetFacetBuilder builder(CatalogMetricsReporterHolder holder) {
+    return builder(holder, false);
+  }
+
+  private IcebergScanReportInputDatasetFacetBuilder builder(
+      CatalogMetricsReporterHolder holder, boolean metricsReporterDisabled) {
+    VendorsContext vendorsContext = new VendorsContext();
+    if (holder != null) {
+      vendorsContext.register(VENDOR_CONTEXT_KEY, holder);
+    }
+
+    Vendors vendors = mock(Vendors.class);
+    when(vendors.getVendorsContext()).thenReturn(vendorsContext);
+
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    when(context.getVendors()).thenReturn(vendors);
+    if (metricsReporterDisabled) {
+      SparkOpenLineageConfig config = mock(SparkOpenLineageConfig.class);
+      SparkOpenLineageConfig.VendorsConfig vendorsConfig =
+          new SparkOpenLineageConfig.VendorsConfig();
+      vendorsConfig
+          .getConfig()
+          .put("iceberg", new SparkOpenLineageConfig.VendorsConfig.VendorConfig(true));
+      when(config.getVendors()).thenReturn(vendorsConfig);
+      when(context.getOpenLineageConfig()).thenReturn(config);
+    }
+    return new IcebergScanReportInputDatasetFacetBuilder(context);
+  }
+
+  private ScanReport scanReport(long snapshotId) {
+    ScanReport report = mock(ScanReport.class);
+    when(report.snapshotId()).thenReturn(snapshotId);
+    when(report.projectedFieldNames()).thenReturn(Collections.emptyList());
+    when(report.metadata()).thenReturn(Collections.emptyMap());
+    return report;
+  }
+
+  private abstract static class TestingScanWithReportBase implements Scan {
+    private final Supplier<ScanReport> scanReportSupplier;
+
+    private TestingScanWithReportBase(Supplier<ScanReport> scanReportSupplier) {
+      this.scanReportSupplier = scanReportSupplier;
+    }
+
+    @Override
+    public StructType readSchema() {
+      return new StructType();
+    }
+  }
+
+  private static class TestingScanWithReport extends TestingScanWithReportBase {
+    private TestingScanWithReport(Supplier<ScanReport> scanReportSupplier) {
+      super(scanReportSupplier);
+    }
+  }
+
+  private static class TestingScanWithoutReport implements Scan {
+    @Override
+    public StructType readSchema() {
+      return new StructType();
+    }
+  }
+}

--- a/integration/spark/vendor/iceberg/src/test/java/org/apache/iceberg/spark/TestingScanWithReport.java
+++ b/integration/spark/vendor/iceberg/src/test/java/org/apache/iceberg/spark/TestingScanWithReport.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.apache.iceberg.spark;
+
+import java.util.function.Supplier;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.types.StructType;
+
+public class TestingScanWithReport implements Scan {
+  private final Supplier<ScanReport> scanReportSupplier;
+
+  public TestingScanWithReport(Supplier<ScanReport> scanReportSupplier) {
+    this.scanReportSupplier = scanReportSupplier;
+  }
+
+  @Override
+  public StructType readSchema() {
+    return new StructType();
+  }
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
This PR fixes the missing scan report bug by using `scanReportSupplier` when available.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
`OpenLineageMetricsReporter` is registered to the catalog by the `IcebergMetricsReporterInjector` which is `QueryPlanVisitor`. The problem is that the the actual iceberg scan happens before the visitor traverses the nodes, and when iceberg is sending the report to the configured MetricsReporter, there is no configured one and it becomes no-op. This caused the missing scan report from the inputFacets.
This PR uses `scanReportSupplier` directly from the facet builder if available, and for the compatibility, it falls back to the original implementation when `scanReportSupplier` is not available.

The bug can be reproducible with simple CTAS/RTAS query on iceberg catalog.

### Checklist
- [x] AI was used in creating this PR
