### PR TITLE
fix: Extend env var facet instead of overwriting it

### DIFF
--- a/client/python/src/openlineage/client/client.py
+++ b/client/python/src/openlineage/client/client.py
@@ -452,11 +452,40 @@ class OpenLineageClient:
             env_vars := self._collect_environment_variables()
         ):
             event.run.facets = event.run.facets or {}
+
+            # Vars the client was configured to collect from the environment
+            client_collected_env_vars = [
+                environment_variables_run.EnvironmentVariable(name=name, value=value)
+                for name, value in env_vars.items()
+            ]
+
+            # Vars already provided in the event
+            event_env_vars: list[environment_variables_run.EnvironmentVariable] = []
+            current_env_vars_facet = event.run.facets.get("environmentVariables")
+            if isinstance(current_env_vars_facet, environment_variables_run.EnvironmentVariablesRunFacet):
+                event_env_vars = current_env_vars_facet.environmentVariables or []
+
+            # Event-supplied vars take precedence; skip client vars that would overwrite them
+            event_env_vars_by_name = {ev.name: ev for ev in event_env_vars}
+            additional_env_vars = []
+            for client_env_var in client_collected_env_vars:
+                if client_env_var.name in event_env_vars_by_name:
+                    event_env_var_value = event_env_vars_by_name[client_env_var.name].value
+                    if client_env_var.value != event_env_var_value:
+                        log.warning(
+                            "Environment variable `%s` is already present in the event with value `%s`, "
+                            "but the OpenLineage client wanted to set it to `%s`. "
+                            "Keeping the event-supplied value `%s`.",
+                            client_env_var.name,
+                            event_env_var_value,
+                            client_env_var.value,
+                            event_env_var_value,
+                        )
+                else:
+                    additional_env_vars.append(client_env_var)
+
             event.run.facets["environmentVariables"] = environment_variables_run.EnvironmentVariablesRunFacet(
-                environmentVariables=[
-                    environment_variables_run.EnvironmentVariable(name=name, value=value)
-                    for name, value in env_vars.items()
-                ]
+                environmentVariables=event_env_vars + additional_env_vars
             )
         return event
 

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -565,6 +565,152 @@ def test_add_environment_facets():
     )
 
 
+@patch.dict(os.environ, {"NEW_VAR": "new_value"})
+def test_add_environment_facets_extends_existing_facet():
+    client = OpenLineageClient()
+    client._config = OpenLineageConfig(  # noqa: SLF001
+        facets=FacetsConfig(environment_variables=["NEW_VAR"])
+    )
+    pre_existing = environment_variables_run.EnvironmentVariable(name="PRE_EXISTING", value="already_there")
+
+    for run_event in (
+        RunEvent(
+            eventType=RunState.START,
+            eventTime="2021-11-03T10:53:52.427343",
+            run=Run(runId=str(generate_new_uuid())),
+            job=Job(name="name", namespace=""),
+            producer="",
+            schemaURL="",
+        ),
+        event_v2.RunEvent(
+            eventType=event_v2.RunState.START,
+            eventTime="2021-11-03T10:53:52.427343",
+            run=Run(runId=str(generate_new_uuid())),
+            job=event_v2.Job(name="name", namespace=""),
+            producer="",
+        ),
+    ):
+        run_event.run.facets = {
+            "environmentVariables": environment_variables_run.EnvironmentVariablesRunFacet([pre_existing])
+        }
+        modified = client.add_environment_facets(run_event)
+        result_vars = modified.run.facets["environmentVariables"].environmentVariables
+        assert len(result_vars) == 2
+        assert result_vars[0] == pre_existing
+        assert result_vars[1] == environment_variables_run.EnvironmentVariable(
+            name="NEW_VAR", value="new_value"
+        )
+
+
+@patch.dict(os.environ, {"SHARED_VAR": "client_value"})
+def test_add_environment_facets_event_var_takes_precedence_with_warning():
+    """Pre-existing event var wins over client-collected value; warning names all three details."""
+    client = OpenLineageClient()
+    client._config = OpenLineageConfig(  # noqa: SLF001
+        facets=FacetsConfig(environment_variables=["SHARED_VAR"])
+    )
+    run_event = RunEvent(
+        eventType=RunState.START,
+        eventTime="2021-11-03T10:53:52.427343",
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(name="name", namespace=""),
+        producer="",
+        schemaURL="",
+    )
+    run_event.run.facets = {
+        "environmentVariables": environment_variables_run.EnvironmentVariablesRunFacet(
+            [environment_variables_run.EnvironmentVariable(name="SHARED_VAR", value="event_value")]
+        )
+    }
+
+    with patch("openlineage.client.client.log") as mock_log:
+        modified = client.add_environment_facets(run_event)
+
+        mock_log.warning.assert_called_once()
+        fmt, *args = mock_log.warning.call_args.args
+        rendered = fmt % tuple(args)
+        assert "SHARED_VAR" in rendered
+        assert "event_value" in rendered
+        assert "client_value" in rendered
+
+    result_vars = modified.run.facets["environmentVariables"].environmentVariables
+    assert len(result_vars) == 1
+    assert result_vars[0] == environment_variables_run.EnvironmentVariable(
+        name="SHARED_VAR", value="event_value"
+    )
+
+
+@patch.dict(os.environ, {"SHARED_VAR": "same_value"})
+def test_add_environment_facets_deduplicates_same_value_no_warning():
+    """No warning when pre-existing var has the same value as the collected one."""
+    client = OpenLineageClient()
+    client._config = OpenLineageConfig(  # noqa: SLF001
+        facets=FacetsConfig(environment_variables=["SHARED_VAR"])
+    )
+    run_event = RunEvent(
+        eventType=RunState.START,
+        eventTime="2021-11-03T10:53:52.427343",
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(name="name", namespace=""),
+        producer="",
+        schemaURL="",
+    )
+    run_event.run.facets = {
+        "environmentVariables": environment_variables_run.EnvironmentVariablesRunFacet(
+            [environment_variables_run.EnvironmentVariable(name="SHARED_VAR", value="same_value")]
+        )
+    }
+    with patch("openlineage.client.client.log") as mock_log:
+        client.add_environment_facets(run_event)
+        mock_log.warning.assert_not_called()
+
+
+@patch.dict(os.environ, {"NEW_VAR": "new_value"})
+def test_add_environment_facets_none_environment_variables_is_safe():
+    """Existing facet with environmentVariables=None must not raise TypeError."""
+    client = OpenLineageClient()
+    client._config = OpenLineageConfig(  # noqa: SLF001
+        facets=FacetsConfig(environment_variables=["NEW_VAR"])
+    )
+    run_event = RunEvent(
+        eventType=RunState.START,
+        eventTime="2021-11-03T10:53:52.427343",
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(name="name", namespace=""),
+        producer="",
+        schemaURL="",
+    )
+    run_event.run.facets = {
+        "environmentVariables": environment_variables_run.EnvironmentVariablesRunFacet(
+            environmentVariables=None
+        )
+    }
+    modified = client.add_environment_facets(run_event)
+    result_vars = modified.run.facets["environmentVariables"].environmentVariables
+    assert result_vars == [environment_variables_run.EnvironmentVariable(name="NEW_VAR", value="new_value")]
+
+
+def test_add_environment_facets_no_configured_vars_preserves_existing_facet():
+    """When no env vars are configured the existing facet must be left untouched."""
+    client = OpenLineageClient()
+    client._config = OpenLineageConfig(  # noqa: SLF001
+        facets=FacetsConfig(environment_variables=[])
+    )
+    pre_existing = environment_variables_run.EnvironmentVariable(name="PRE_EXISTING", value="already_there")
+    original_facet = environment_variables_run.EnvironmentVariablesRunFacet([pre_existing])
+    run_event = RunEvent(
+        eventType=RunState.START,
+        eventTime="2021-11-03T10:53:52.427343",
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(name="name", namespace=""),
+        producer="",
+        schemaURL="",
+    )
+    run_event.run.facets = {"environmentVariables": original_facet}
+    modified = client.add_environment_facets(run_event)
+    assert modified.run.facets["environmentVariables"] is original_facet
+
+
 @patch("openlineage.client.client.OpenLineageClient._find_yaml_config_path")
 @patch("openlineage.client.client.OpenLineageClient._get_config_file_content")
 def test_config_property_loads_yaml(mock_get_config_content, mock_find_yaml):

--- a/website/docs/client/python/configuration.md
+++ b/website/docs/client/python/configuration.md
@@ -1809,6 +1809,14 @@ While the configuration is read only at client creation time (so the environment
 a client has been created) - the value of the variables will be read and appended to the event at the time of event emission.
 :::
 
+### Merge behavior
+
+If the event already contains an `environmentVariables` facet (set by an integration or producer), the client-configured variables are **merged** into it rather than replacing it.
+
+- Variables already present in the event take precedence over client-configured ones.
+- If the same variable name exists in both with different values, the event-supplied value is kept and a warning is logged.
+- Variables present only in the client configuration are appended to the existing facet.
+
 ### Examples
 
 <Tabs groupId="env-vars-run-facet">


### PR DESCRIPTION
### One-line summary for changelog:
Python client: environment variables configured for collection no longer overwrite variables already present in the event.

### Meaningful description
Previously, client-configured environment variables would always replace any `environmentVariables` facet set by the producer. Now they are merged, with event-supplied values taking precedence. A warning is logged when a conflict is detected.

### Checklist
- [x] AI was used in creating this PR