### PR TITLE
java: change shaded paths to avoid conflicts while using composite transport

### DIFF
--- a/client/java/transports-datazone/build.gradle
+++ b/client/java/transports-datazone/build.gradle
@@ -30,8 +30,8 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'software.amazon', 'io.openlineage.client.shaded.software.amazon'
-    relocate 'org.apache', 'io.openlineage.client.shaded.org.apache'
+    relocate 'software.amazon', 'io.openlineage.client.transports.datazone.shaded.software.amazon'
+    relocate 'org.apache', 'io.openlineage.client.transports.datazone.shaded.org.apache'
     exclude 'org.slf4j'
 }
 

--- a/client/java/transports-gcplineage/build.gradle
+++ b/client/java/transports-gcplineage/build.gradle
@@ -29,14 +29,14 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'datalineage.shaded', 'io.openlineage.client.shaded.datalineage.shaded'
-    relocate 'com.google.cloud', 'io.openlineage.client.shaded.com.google.cloud'
-    relocate 'com.google.api', 'io.openlineage.client.shaded.com.google.api'
-    relocate 'com.google.auth', 'io.openlineage.client.shaded.com.google.auth'
-    relocate 'com.google.protobuf', 'io.openlineage.client.shaded.com.google.protobuf'
+    relocate 'datalineage.shaded', 'io.openlineage.client.transports.gcplineage.shaded.datalineage.shaded'
+    relocate 'com.google.cloud', 'io.openlineage.client.transports.gcplineage.shaded.com.google.cloud'
+    relocate 'com.google.api', 'io.openlineage.client.transports.gcplineage.shaded.com.google.api'
+    relocate 'com.google.auth', 'io.openlineage.client.transports.gcplineage.shaded.com.google.auth'
+    relocate 'com.google.protobuf', 'io.openlineage.client.transports.gcplineage.shaded.com.google.protobuf'
 
-    relocate 'META-INF/native/libdatalineage_shaded_io_grpc_netty_shaded_netty', 'META-INF/native/libio_openlineage_client_io_grpc_netty_shaded_netty'
-    relocate 'META-INF/native/datalineage_shaded_io_grpc_netty_shaded_netty', 'META-INF/native/io_openlineage_client_io_grpc_netty_shaded_netty'
+    relocate 'META-INF/native/libdatalineage_shaded_io_grpc_netty_shaded_netty', 'META-INF/native/libio_openlineage_client_transports_gcplineage_io_grpc_netty_shaded_netty'
+    relocate 'META-INF/native/datalineage_shaded_io_grpc_netty_shaded_netty', 'META-INF/native/io_openlineage_client_transports_gcplineage_io_grpc_netty_shaded_netty'
 
     mergeServiceFiles()
 }

--- a/client/java/transports-gcs/build.gradle
+++ b/client/java/transports-gcs/build.gradle
@@ -36,16 +36,16 @@ shadowJar {
         exclude 'org/slf4j/**'
     }
 
-    relocate "com.google", "io.openlineage.client.shaded.com.google"
-    relocate "org.checkerframework", "io.openlineage.client.shaded.org.checkerframework"
-    relocate "org.codehaus", "io.openlineage.client.shaded.org.codehaus"
-    relocate "org.conscrypt", "io.openlineage.client.shaded.org.conscrypt"
-    relocate "org.threeten", "io.openlineage.client.shaded.org.threeten"
-    relocate "org.apache", "io.openlineage.client.shaded.org.apache"
-    relocate "io.opencensus", "io.openlineage.client.shaded.io.opencensus"
-    relocate "io.grpc", "io.openlineage.client.shaded.io.grpc"
-    relocate "io.opentelemetry", "io.openlineage.client.shaded.io.opentelemetry"
-    relocate "io.perfmark", "io.openlineage.client.shaded.io.perfmark"
+    relocate "com.google", "io.openlineage.client.transports.gcs.shaded.com.google"
+    relocate "org.checkerframework", "io.openlineage.client.transports.gcs.shaded.org.checkerframework"
+    relocate "org.codehaus", "io.openlineage.client.transports.gcs.shaded.org.codehaus"
+    relocate "org.conscrypt", "io.openlineage.client.transports.gcs.shaded.org.conscrypt"
+    relocate "org.threeten", "io.openlineage.client.transports.gcs.shaded.org.threeten"
+    relocate "org.apache", "io.openlineage.client.transports.gcs.shaded.org.apache"
+    relocate "io.opencensus", "io.openlineage.client.transports.gcs.shaded.io.opencensus"
+    relocate "io.grpc", "io.openlineage.client.transports.gcs.shaded.io.grpc"
+    relocate "io.opentelemetry", "io.openlineage.client.transports.gcs.shaded.io.opentelemetry"
+    relocate "io.perfmark", "io.openlineage.client.transports.gcs.shaded.io.perfmark"
 }
 
 apply from: '../transports.build.gradle'

--- a/client/java/transports-s3/build.gradle
+++ b/client/java/transports-s3/build.gradle
@@ -47,10 +47,10 @@ dependencies {
 }
 
 shadowJar {
-    relocate "software.amazon", "io.openlineage.client.shaded.software.amazon"
-    relocate "org.apache", "io.openlineage.client.shaded.org.apache"
-    relocate "org.reactivestreams", "io.openlineage.client.shaded.org.reactivestreams"
-    relocate "org.slf4j", "io.openlineage.client.shaded.org.slf4j"
+    relocate "software.amazon", "io.openlineage.client.transports.s3.shaded.software.amazon"
+    relocate "org.apache", "io.openlineage.client.transports.s3.shaded.org.apache"
+    relocate "org.reactivestreams", "io.openlineage.client.transports.s3.shaded.org.reactivestreams"
+    relocate "org.slf4j", "io.openlineage.client.transports.s3.shaded.org.slf4j"
 }
 
 apply from: '../transports.build.gradle'


### PR DESCRIPTION
### One-line summary for changelog:
Change shaded paths in transports to avoid conflicts while using composite transport


### Meaningful description
When using `gcs` and `gcp-lineages` in `composite` transport we have conflict in versions of google libraries, it happens because in case of all transports we shade with `relocate "x", "io.opnelineage.client.shaded.x"`. 

To fix this, all shading will be done with `relocate "x", "io.opnelineage.client.transports.<transport>.shaded.x"`


### Checklist
- [ ] AI was used in creating this PR
