### PR TITLE
dbt model meta/config capture

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -5,6 +5,7 @@
 import attr
 from openlineage.client.facet_v2 import (
     BaseFacet,
+    DatasetFacet,
     JobFacet,
     parent_run,
 )
@@ -58,6 +59,40 @@ class DbtRunRunFacet(BaseFacet):
     @staticmethod
     def _get_schema() -> str:
         return GITHUB_LOCATION + "dbt-run-run-facet.json"
+
+
+@attr.define
+class DbtModelConfig:
+    """The resolved dbt model configuration fields most relevant for data observability.
+
+    These come from the *resolved* ``config`` of a dbt manifest node (after applying
+    project-level defaults from ``dbt_project.yml``, per-model overrides, etc.).
+    """
+
+    materialized: str | None = attr.field(default=None)
+    access: str | None = attr.field(default=None)
+    owner: str | None = attr.field(default=None)
+    group: str | None = attr.field(default=None)
+
+
+@attr.define
+class DbtModelDatasetFacet(DatasetFacet):
+    """Dataset facet capturing dbt-specific per-model config and meta from the dbt manifest.
+
+    dbt manifest nodes carry two sources of rich per-model metadata:
+
+    1. ``config`` - the resolved dbt configuration. The most observability-relevant fields
+       are ``materialized``, ``access``, ``owner`` and ``group``.
+    2. ``meta`` - an arbitrary user-defined key/value map, commonly used for ownership,
+       PII flags, team labels, etc.
+    """
+
+    config: DbtModelConfig | None = attr.field(default=None)
+    meta: dict | None = attr.field(default=None)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return GITHUB_LOCATION + "dbt-model-dataset-facet.json"
 
 
 @attr.define

--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -81,7 +81,7 @@ class DbtModelDatasetFacet(DatasetFacet):
 
     The most observability-relevant fields are ``materialized``, ``access``, ``owner`` and
     ``group``. The free-form ``meta`` map is emitted separately as dataset/run tags (source
-    ``dbt-meta``), not on this facet.
+    ``DBT_META``), not on this facet.
     """
 
     config: DbtModelConfig | None = attr.field(default=None)

--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -77,18 +77,14 @@ class DbtModelConfig:
 
 @attr.define
 class DbtModelDatasetFacet(DatasetFacet):
-    """Dataset facet capturing dbt-specific per-model config and meta from the dbt manifest.
+    """Dataset facet capturing the resolved dbt ``config`` of a manifest node.
 
-    dbt manifest nodes carry two sources of rich per-model metadata:
-
-    1. ``config`` - the resolved dbt configuration. The most observability-relevant fields
-       are ``materialized``, ``access``, ``owner`` and ``group``.
-    2. ``meta`` - an arbitrary user-defined key/value map, commonly used for ownership,
-       PII flags, team labels, etc.
+    The most observability-relevant fields are ``materialized``, ``access``, ``owner`` and
+    ``group``. The free-form ``meta`` map is emitted separately as dataset/run tags (source
+    ``dbt-meta``), not on this facet.
     """
 
     config: DbtModelConfig | None = attr.field(default=None)
-    meta: dict | None = attr.field(default=None)
 
     @staticmethod
     def _get_schema() -> str:

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections
 import datetime
+import json
 import logging
 from abc import abstractmethod
 from collections.abc import Sequence
@@ -353,10 +354,8 @@ class DbtArtifactProcessor:
                 job_facets["sql"] = sql_job.SQLJobFacet(query=sql, dialect=self.extract_dialect())
 
             run_facets: dict[str, RunFacet] = {}
-            if tags := output_node.get("tags", None):
-                run_facets["tags"] = tags_run.TagsRunFacet(
-                    tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-                )
+            if tags_facet := self._build_tags_run_facet(output_node.get("tags"), output_node.get("meta")):
+                run_facets["tags"] = tags_facet
 
             output_dataset = self.node_to_output_dataset(
                 ModelNode(
@@ -438,10 +437,8 @@ class DbtArtifactProcessor:
             }
 
             run_facets: dict[str, RunFacet] = {}
-            if tags := node.get("tags", None):
-                run_facets["tags"] = tags_run.TagsRunFacet(
-                    tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-                )
+            if tags_facet := self._build_tags_run_facet(node.get("tags"), node.get("meta")):
+                run_facets["tags"] = tags_facet
 
             run_id = str(generate_new_uuid())
             dataset_facets: dict[str, InputDatasetFacet] = {"dataQualityAssertions": assertion_facet}
@@ -500,10 +497,8 @@ class DbtArtifactProcessor:
             run_facets_per_test: dict[str, RunFacet] = {
                 "test": test_run.TestRunFacet(tests=[test_obj]),
             }
-            if tags := test_node.get("tags", None):
-                run_facets_per_test["tags"] = tags_run.TagsRunFacet(
-                    tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-                )
+            if tags_facet := self._build_tags_run_facet(test_node.get("tags"), test_node.get("meta")):
+                run_facets_per_test["tags"] = tags_facet
 
             job_facets_per_test: dict[str, JobFacet] = {
                 "jobType": job_type_job.JobTypeJobFacet(
@@ -840,11 +835,11 @@ class DbtArtifactProcessor:
         )
 
     def _create_dbt_model_dataset_facet(self, node: ModelNode) -> DbtModelDatasetFacet | None:
-        """Build a DbtModelDatasetFacet from a dbt manifest node's ``config`` and ``meta``.
+        """Build a DbtModelDatasetFacet from a dbt manifest node's resolved ``config``.
 
-        Reads the resolved ``config`` (``materialized``/``access``/``owner``/``group``) and the
-        free-form ``meta`` map from ``node.metadata_node``. Returns ``None`` when the node carries
-        neither, so we don't attach an empty facet to the dataset.
+        Reads ``materialized``/``access``/``owner``/``group`` from ``node.metadata_node["config"]``.
+        Returns ``None`` when the node carries none of them, so we don't attach an empty facet.
+        The node's ``meta`` map is emitted separately as tags (see ``_build_tags_run_facet``).
         """
         raw_config = node.metadata_node.get("config") or {}
         model_config = DbtModelConfig(
@@ -853,26 +848,38 @@ class DbtArtifactProcessor:
             owner=raw_config.get("owner") or None,
             group=raw_config.get("group") or None,
         )
-        has_config = any(
-            value is not None
-            for value in (
-                model_config.materialized,
-                model_config.access,
-                model_config.owner,
-                model_config.group,
-            )
-        )
-
-        meta = node.metadata_node.get("meta") or {}
-        has_meta = bool(meta)
-
-        if not has_config and not has_meta:
+        if not any(attr.astuple(model_config)):
             return None
 
-        return DbtModelDatasetFacet(
-            config=model_config if has_config else None,
-            meta=meta if has_meta else None,
-        )
+        return DbtModelDatasetFacet(config=model_config)
+
+    @staticmethod
+    def _meta_tag_value(value: Any) -> str:
+        """Render a dbt ``meta`` value as a tag value string.
+
+        Booleans use dbt's lowercase ``true``/``false`` (matching how plain dbt tags are emitted),
+        other scalars are stringified, and nested structures fall back to compact JSON.
+        """
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (int, float)):
+            return str(value)
+        return json.dumps(value)
+
+    def _build_tags_run_facet(self, tags: list | None, meta: dict | None) -> tags_run.TagsRunFacet | None:
+        """Build a TagsRunFacet from a dbt node's ``tags`` and ``meta``.
+
+        Plain dbt ``tags`` keep ``source="DBT"`` and value ``"true"``; each ``meta`` entry becomes a
+        key/value tag with ``source="dbt-meta"``. Returns ``None`` when there is nothing to emit.
+        """
+        fields = [tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in (tags or [])]
+        fields += [
+            tags_run.TagsRunFacetFields(key=key, value=self._meta_tag_value(value), source="dbt-meta")
+            for key, value in (meta or {}).items()
+        ]
+        return tags_run.TagsRunFacet(tags=fields) if fields else None
 
     @staticmethod
     def extract_metadata_fields(columns: list[dict]) -> list[schema_dataset.SchemaDatasetFacetFields]:

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -34,6 +34,8 @@ from openlineage.client.facet_v2 import (
 )
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import (
+    DbtModelConfig,
+    DbtModelDatasetFacet,
     DbtNodeJobFacet,
     DbtRunRunFacet,
     DbtVersionRunFacet,
@@ -817,6 +819,9 @@ class DbtArtifactProcessor:
                 facets["ownership"] = ownership_dataset.OwnershipDatasetFacet(
                     owners=[ownership_dataset.Owner(name=name) for name in names]
                 )
+
+            if dbt_model_facet := self._create_dbt_model_dataset_facet(node):
+                facets["dbt_model"] = dbt_model_facet
         else:
             facets = {}
         if node.type == "source":
@@ -832,6 +837,41 @@ class DbtArtifactProcessor:
             ),
             facets,
             input_facets,
+        )
+
+    def _create_dbt_model_dataset_facet(self, node: ModelNode) -> DbtModelDatasetFacet | None:
+        """Build a DbtModelDatasetFacet from a dbt manifest node's ``config`` and ``meta``.
+
+        Reads the resolved ``config`` (``materialized``/``access``/``owner``/``group``) and the
+        free-form ``meta`` map from ``node.metadata_node``. Returns ``None`` when the node carries
+        neither, so we don't attach an empty facet to the dataset.
+        """
+        raw_config = node.metadata_node.get("config") or {}
+        model_config = DbtModelConfig(
+            materialized=raw_config.get("materialized") or None,
+            access=raw_config.get("access") or None,
+            owner=raw_config.get("owner") or None,
+            group=raw_config.get("group") or None,
+        )
+        has_config = any(
+            value is not None
+            for value in (
+                model_config.materialized,
+                model_config.access,
+                model_config.owner,
+                model_config.group,
+            )
+        )
+
+        meta = node.metadata_node.get("meta") or {}
+        has_meta = bool(meta)
+
+        if not has_config and not has_meta:
+            return None
+
+        return DbtModelDatasetFacet(
+            config=model_config if has_config else None,
+            meta=meta if has_meta else None,
         )
 
     @staticmethod

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -872,11 +872,11 @@ class DbtArtifactProcessor:
         """Build a TagsRunFacet from a dbt node's ``tags`` and ``meta``.
 
         Plain dbt ``tags`` keep ``source="DBT"`` and value ``"true"``; each ``meta`` entry becomes a
-        key/value tag with ``source="dbt-meta"``. Returns ``None`` when there is nothing to emit.
+        key/value tag with ``source="DBT_META"``. Returns ``None`` when there is nothing to emit.
         """
         fields = [tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in (tags or [])]
         fields += [
-            tags_run.TagsRunFacetFields(key=key, value=self._meta_tag_value(value), source="dbt-meta")
+            tags_run.TagsRunFacetFields(key=key, value=self._meta_tag_value(value), source="DBT_META")
             for key, value in (meta or {}).items()
         ]
         return tags_run.TagsRunFacet(tags=fields) if fields else None

--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -22,7 +22,6 @@ from openlineage.client.facet_v2 import (
     job_type_job,
     processing_engine_run,
     sql_job,
-    tags_run,
     test_run,
 )
 from openlineage.client.uuid import generate_new_uuid
@@ -370,11 +369,11 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             "parent": self.dbt_run_metadata.to_openlineage(),
         }
 
-        # Add tags if they exist for this node
-        if tags := self._get_node_tags(node_unique_id):
-            run_facets["tags"] = tags_run.TagsRunFacet(
-                tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-            )
+        # Add tags (dbt tags + meta) if they exist for this node
+        if tags_facet := self._build_tags_run_facet(
+            self._get_node_tags(node_unique_id), self._get_node_meta(node_unique_id)
+        ):
+            run_facets["tags"] = tags_facet
 
         resource_type = event["data"]["node_info"]["resource_type"]
         job_name = self._get_job_name(event)
@@ -446,11 +445,11 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
                     source=self.dataset_namespace,
                 )
 
-        # Add tags if they exist for this node
-        if tags := self._get_node_tags(node_unique_id):
-            run_facets["tags"] = tags_run.TagsRunFacet(
-                tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-            )
+        # Add tags (dbt tags + meta) if they exist for this node
+        if tags_facet := self._build_tags_run_facet(
+            self._get_node_tags(node_unique_id), self._get_node_meta(node_unique_id)
+        ):
+            run_facets["tags"] = tags_facet
 
         job_name = self._get_job_name(event)
         node_metadata = self.compiled_manifest.get("nodes", {}).get(node_unique_id, {})
@@ -990,6 +989,15 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         all_nodes = {**self.compiled_manifest["nodes"], **self.compiled_manifest["sources"]}
         manifest_node = all_nodes[node_id]
         return manifest_node.get("tags", [])
+
+    @handle_keyerror
+    def _get_node_meta(self, node_id: str) -> dict:
+        """
+        Extract the free-form ``meta`` map from a dbt node in the compiled manifest
+        """
+        all_nodes = {**self.compiled_manifest["nodes"], **self.compiled_manifest["sources"]}
+        manifest_node = all_nodes[node_id]
+        return manifest_node.get("meta", {})
 
     def _get_model_inputs(self, node_id) -> list[ModelNode]:
         """

--- a/integration/common/tests/dbt/duckdb/result.json
+++ b/integration/common/tests/dbt/duckdb/result.json
@@ -25,11 +25,6 @@
               "materialized": "table",
               "access": "protected",
               "group": "finance"
-            },
-            "meta": {
-              "owner": "data-team",
-              "pii": false,
-              "tier": "gold"
             }
           },
           "dataSource": {
@@ -94,6 +89,25 @@
         },
         "dbt_run": {
           "invocation_id": "d205f9ce-0e55-4a5f-9f69-bfa170867a41"
+        },
+        "tags": {
+          "tags": [
+            {
+              "key": "owner",
+              "value": "data-team",
+              "source": "dbt-meta"
+            },
+            {
+              "key": "pii",
+              "value": "false",
+              "source": "dbt-meta"
+            },
+            {
+              "key": "tier",
+              "value": "gold",
+              "source": "dbt-meta"
+            }
+          ]
         }
       }
     }
@@ -124,11 +138,6 @@
               "materialized": "table",
               "access": "protected",
               "group": "finance"
-            },
-            "meta": {
-              "owner": "data-team",
-              "pii": false,
-              "tier": "gold"
             }
           },
           "dataSource": {
@@ -190,6 +199,25 @@
             "name": "dbt-job-name",
             "namespace": "dbt"
           }
+        },
+        "tags": {
+          "tags": [
+            {
+              "key": "owner",
+              "value": "data-team",
+              "source": "dbt-meta"
+            },
+            {
+              "key": "pii",
+              "value": "false",
+              "source": "dbt-meta"
+            },
+            {
+              "key": "tier",
+              "value": "gold",
+              "source": "dbt-meta"
+            }
+          ]
         }
       }
     }

--- a/integration/common/tests/dbt/duckdb/result.json
+++ b/integration/common/tests/dbt/duckdb/result.json
@@ -95,17 +95,17 @@
             {
               "key": "owner",
               "value": "data-team",
-              "source": "dbt-meta"
+              "source": "DBT_META"
             },
             {
               "key": "pii",
               "value": "false",
-              "source": "dbt-meta"
+              "source": "DBT_META"
             },
             {
               "key": "tier",
               "value": "gold",
-              "source": "dbt-meta"
+              "source": "DBT_META"
             }
           ]
         }
@@ -205,17 +205,17 @@
             {
               "key": "owner",
               "value": "data-team",
-              "source": "dbt-meta"
+              "source": "DBT_META"
             },
             {
               "key": "pii",
               "value": "false",
-              "source": "dbt-meta"
+              "source": "DBT_META"
             },
             {
               "key": "tier",
               "value": "gold",
-              "source": "dbt-meta"
+              "source": "DBT_META"
             }
           ]
         }

--- a/integration/common/tests/dbt/duckdb/result.json
+++ b/integration/common/tests/dbt/duckdb/result.json
@@ -20,6 +20,18 @@
     "outputs": [
       {
         "facets": {
+          "dbt_model": {
+            "config": {
+              "materialized": "table",
+              "access": "protected",
+              "group": "finance"
+            },
+            "meta": {
+              "owner": "data-team",
+              "pii": false,
+              "tier": "gold"
+            }
+          },
           "dataSource": {
             "name": "duckdb:///database/jaffle_shop.duckdb",
             "uri": "duckdb:///database/jaffle_shop.duckdb"
@@ -107,6 +119,18 @@
     "outputs": [
       {
         "facets": {
+          "dbt_model": {
+            "config": {
+              "materialized": "table",
+              "access": "protected",
+              "group": "finance"
+            },
+            "meta": {
+              "owner": "data-team",
+              "pii": false,
+              "tier": "gold"
+            }
+          },
           "dataSource": {
             "name": "duckdb:///database/jaffle_shop.duckdb",
             "uri": "duckdb:///database/jaffle_shop.duckdb"

--- a/integration/common/tests/dbt/duckdb/target/manifest.json
+++ b/integration/common/tests/dbt/duckdb/target/manifest.json
@@ -37,7 +37,7 @@
                 "database": null,
                 "tags": [],
                 "meta": {},
-                "group": null,
+                "group": "finance",
                 "materialized": "table",
                 "incremental_strategy": null,
                 "persist_docs": {},
@@ -128,7 +128,11 @@
                     "tags": []
                 }
             },
-            "meta": {},
+            "meta": {
+                "owner": "data-team",
+                "pii": false,
+                "tier": "gold"
+            },
             "group": null,
             "docs": {
                 "show": true,

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -597,7 +597,7 @@ class TestDbtModelDatasetFacet:
 
 
 class TestDbtMetaTags:
-    """Covers dbt ``tags`` (source DBT) and ``meta`` (source dbt-meta) -> TagsRunFacet."""
+    """Covers dbt ``tags`` (source DBT) and ``meta`` (source DBT_META) -> TagsRunFacet."""
 
     def test_none_when_empty(self, dbt_artifact_processor):
         assert dbt_artifact_processor._build_tags_run_facet(None, None) is None
@@ -615,18 +615,18 @@ class TestDbtMetaTags:
             None, {"owner": "data-team", "pii": False, "tier": "gold", "freshness_h": 24}
         )
         assert [(t.key, t.value, t.source) for t in facet.tags] == [
-            ("owner", "data-team", "dbt-meta"),
-            ("pii", "false", "dbt-meta"),
-            ("tier", "gold", "dbt-meta"),
-            ("freshness_h", "24", "dbt-meta"),
+            ("owner", "data-team", "DBT_META"),
+            ("pii", "false", "DBT_META"),
+            ("tier", "gold", "DBT_META"),
+            ("freshness_h", "24", "DBT_META"),
         ]
 
     def test_nested_meta_value_is_json(self, dbt_artifact_processor):
         facet = dbt_artifact_processor._build_tags_run_facet(None, {"sla": {"freshness_hours": 24}})
         assert facet.tags[0].key == "sla"
         assert facet.tags[0].value == '{"freshness_hours": 24}'
-        assert facet.tags[0].source == "dbt-meta"
+        assert facet.tags[0].source == "DBT_META"
 
     def test_tags_and_meta_combined(self, dbt_artifact_processor):
         facet = dbt_artifact_processor._build_tags_run_facet(["core"], {"tier": "gold"})
-        assert [(t.key, t.source) for t in facet.tags] == [("core", "DBT"), ("tier", "dbt-meta")]
+        assert [(t.key, t.source) for t in facet.tags] == [("core", "DBT"), ("tier", "DBT_META")]

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -540,3 +540,59 @@ class TestAggregateTestEventStatus:
             {"unique_id": "test.project.t1", "status": "warn", "failures": 1, "_severity": "warn"},
         ]
         assert self._event_types(processor, results) == ["START", "FAIL"]
+
+
+class TestDbtModelDatasetFacet:
+    """Covers parsing of dbt manifest node ``config``/``meta`` into the dbt_model dataset facet.
+
+    The facet is built in DbtArtifactProcessor.extract_dataset_data and is therefore shared by
+    both the legacy local processor and the structured-logs processor.
+    """
+
+    def _node(self, metadata_node):
+        from openlineage.common.provider.dbt.processor import ModelNode
+
+        base = {"database": "db", "schema": "sch", "alias": "orders", "columns": {}}
+        base.update(metadata_node)
+        return ModelNode(type="model", metadata_node=base)
+
+    def test_extracts_config_and_meta(self, dbt_artifact_processor):
+        node = self._node(
+            {
+                "config": {
+                    "materialized": "incremental",
+                    "access": "public",
+                    "group": "finance",
+                },
+                "meta": {"owner": "data-team", "pii": False},
+            }
+        )
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(node)
+        assert facet is not None
+        assert facet.config.materialized == "incremental"
+        assert facet.config.access == "public"
+        assert facet.config.group == "finance"
+        assert facet.config.owner is None
+        assert facet.meta == {"owner": "data-team", "pii": False}
+
+    def test_empty_strings_are_dropped(self, dbt_artifact_processor):
+        # config present but every field blank, and no meta -> no facet
+        node = self._node({"config": {"materialized": "", "access": ""}, "meta": {}})
+        assert dbt_artifact_processor._create_dbt_model_dataset_facet(node) is None
+
+    def test_meta_only(self, dbt_artifact_processor):
+        node = self._node({"config": {}, "meta": {"tier": "gold"}})
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(node)
+        assert facet is not None
+        assert facet.config is None
+        assert facet.meta == {"tier": "gold"}
+
+    def test_no_config_no_meta_returns_none(self, dbt_artifact_processor):
+        node = self._node({})
+        assert dbt_artifact_processor._create_dbt_model_dataset_facet(node) is None
+
+    def test_facet_attached_to_dataset_facets(self, dbt_artifact_processor):
+        node = self._node({"config": {"materialized": "table"}})
+        _, _, facets, _ = dbt_artifact_processor.extract_dataset_data(node, None, has_facets=True)
+        assert "dbt_model" in facets
+        assert facets["dbt_model"].config.materialized == "table"

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -543,10 +543,11 @@ class TestAggregateTestEventStatus:
 
 
 class TestDbtModelDatasetFacet:
-    """Covers parsing of dbt manifest node ``config``/``meta`` into the dbt_model dataset facet.
+    """Covers parsing of a dbt manifest node's resolved ``config`` into the dbt_model dataset facet.
 
     The facet is built in DbtArtifactProcessor.extract_dataset_data and is therefore shared by
-    both the legacy local processor and the structured-logs processor.
+    both the legacy local processor and the structured-logs processor. Node ``meta`` is no longer
+    on this facet — it is emitted as tags (see TestDbtMetaTags).
     """
 
     def _node(self, metadata_node):
@@ -556,7 +557,7 @@ class TestDbtModelDatasetFacet:
         base.update(metadata_node)
         return ModelNode(type="model", metadata_node=base)
 
-    def test_extracts_config_and_meta(self, dbt_artifact_processor):
+    def test_extracts_config(self, dbt_artifact_processor):
         node = self._node(
             {
                 "config": {
@@ -564,7 +565,6 @@ class TestDbtModelDatasetFacet:
                     "access": "public",
                     "group": "finance",
                 },
-                "meta": {"owner": "data-team", "pii": False},
             }
         )
         facet = dbt_artifact_processor._create_dbt_model_dataset_facet(node)
@@ -573,21 +573,19 @@ class TestDbtModelDatasetFacet:
         assert facet.config.access == "public"
         assert facet.config.group == "finance"
         assert facet.config.owner is None
-        assert facet.meta == {"owner": "data-team", "pii": False}
+        assert not hasattr(facet, "meta")
 
     def test_empty_strings_are_dropped(self, dbt_artifact_processor):
-        # config present but every field blank, and no meta -> no facet
-        node = self._node({"config": {"materialized": "", "access": ""}, "meta": {}})
+        # config present but every field blank -> no facet
+        node = self._node({"config": {"materialized": "", "access": ""}})
         assert dbt_artifact_processor._create_dbt_model_dataset_facet(node) is None
 
-    def test_meta_only(self, dbt_artifact_processor):
+    def test_meta_does_not_produce_config_facet(self, dbt_artifact_processor):
+        # meta alone no longer yields a dbt_model facet; it is emitted as tags instead
         node = self._node({"config": {}, "meta": {"tier": "gold"}})
-        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(node)
-        assert facet is not None
-        assert facet.config is None
-        assert facet.meta == {"tier": "gold"}
+        assert dbt_artifact_processor._create_dbt_model_dataset_facet(node) is None
 
-    def test_no_config_no_meta_returns_none(self, dbt_artifact_processor):
+    def test_no_config_returns_none(self, dbt_artifact_processor):
         node = self._node({})
         assert dbt_artifact_processor._create_dbt_model_dataset_facet(node) is None
 
@@ -596,3 +594,39 @@ class TestDbtModelDatasetFacet:
         _, _, facets, _ = dbt_artifact_processor.extract_dataset_data(node, None, has_facets=True)
         assert "dbt_model" in facets
         assert facets["dbt_model"].config.materialized == "table"
+
+
+class TestDbtMetaTags:
+    """Covers dbt ``tags`` (source DBT) and ``meta`` (source dbt-meta) -> TagsRunFacet."""
+
+    def test_none_when_empty(self, dbt_artifact_processor):
+        assert dbt_artifact_processor._build_tags_run_facet(None, None) is None
+        assert dbt_artifact_processor._build_tags_run_facet([], {}) is None
+
+    def test_plain_tags_keep_dbt_source(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._build_tags_run_facet(["pii", "core"], None)
+        assert [(t.key, t.value, t.source) for t in facet.tags] == [
+            ("pii", "true", "DBT"),
+            ("core", "true", "DBT"),
+        ]
+
+    def test_meta_becomes_dbt_meta_tags(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._build_tags_run_facet(
+            None, {"owner": "data-team", "pii": False, "tier": "gold", "freshness_h": 24}
+        )
+        assert [(t.key, t.value, t.source) for t in facet.tags] == [
+            ("owner", "data-team", "dbt-meta"),
+            ("pii", "false", "dbt-meta"),
+            ("tier", "gold", "dbt-meta"),
+            ("freshness_h", "24", "dbt-meta"),
+        ]
+
+    def test_nested_meta_value_is_json(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._build_tags_run_facet(None, {"sla": {"freshness_hours": 24}})
+        assert facet.tags[0].key == "sla"
+        assert facet.tags[0].value == '{"freshness_hours": 24}'
+        assert facet.tags[0].source == "dbt-meta"
+
+    def test_tags_and_meta_combined(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._build_tags_run_facet(["core"], {"tier": "gold"})
+        assert [(t.key, t.source) for t in facet.tags] == [("core", "DBT"), ("tier", "dbt-meta")]


### PR DESCRIPTION
dbt manifest nodes carry rich per-model metadata that the OpenLineage dbt integration was not using: the `config` - values like `materialized`, `access`, `owner`, and `group`) and the user-defined `meta` map (commonly used for ownership, PII flags, team labels, tiers, SLAs, etc.). 

None of this was being forwarded into emitted lineage events, so downstream consumers  had no visibility into how a model is materialized, who owns it, its access level, or any custom governance tags, even though the information was already sitting in the manifest dbt produces on every run. 

This change captures that metadata into a new `dbt_model` dataset facet (mirroring the dd-source Go implementation field-for-field, including the key name, so it round-trips correctly) and attaches it to datasets in both the legacy/local and structured-logs dbt processors, making per-model configuration and user metadata travel with the lineage events for both integration paths.


### One-line summary for changelog:
Capture dbt per-model config/meta values.

### Checklist
- [x] AI was used in creating this PR
