### PR TITLE
client/java: normalize abfs/wasb to abfss/wasbs in ObjectStorageDatasetExtractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtils.java
@@ -14,7 +14,16 @@ public class FilesystemDatasetUtils {
     new LocalFilesystemDatasetExtractor(),
     new ObjectStorageDatasetExtractor("s3"),
     new ObjectStorageDatasetExtractor("gs"),
-    new ObjectStorageDatasetExtractor("wasbs")
+    // Azure ADLS Gen2 ("abfs"/"abfss") and Blob storage ("wasb"/"wasbs"). Within each pair the
+    // schemes differ only in transport security (the trailing "s" tells the driver to use TLS) and
+    // address the same data, so both variants are normalized to the canonical TLS scheme defined by
+    // the OpenLineage naming spec ("abfss"/"wasbs"). ObjectStorageDatasetExtractor matches on
+    // scheme
+    // prefix, so the "abfs" extractor also claims "abfss" URIs (and "wasb" claims "wasbs"), and
+    // rewrites them to the canonical scheme -- mirroring how the "s3" extractor normalizes
+    // "s3a"/"s3n" to "s3".
+    new ObjectStorageDatasetExtractor("abfs", "abfss"),
+    new ObjectStorageDatasetExtractor("wasb", "wasbs")
   };
 
   private static FilesystemDatasetExtractor getExtractor(URI location) {

--- a/client/java/src/main/java/io/openlineage/client/utils/filesystem/ObjectStorageDatasetExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/filesystem/ObjectStorageDatasetExtractor.java
@@ -12,9 +12,21 @@ import lombok.SneakyThrows;
 
 public class ObjectStorageDatasetExtractor implements FilesystemDatasetExtractor {
   private final String scheme;
+  private final String canonicalScheme;
 
   public ObjectStorageDatasetExtractor(String scheme) {
+    this(scheme, scheme);
+  }
+
+  /**
+   * @param scheme the scheme prefix this extractor matches (e.g. {@code abfs}, which also matches
+   *     {@code abfss} since matching is by prefix)
+   * @param canonicalScheme the scheme emitted in the resulting namespace; matched variants are
+   *     normalized to it (e.g. {@code abfs} and {@code abfss} both normalize to {@code abfss})
+   */
+  public ObjectStorageDatasetExtractor(String scheme, String canonicalScheme) {
     this.scheme = scheme;
+    this.canonicalScheme = canonicalScheme;
   }
 
   @Override
@@ -33,7 +45,8 @@ public class ObjectStorageDatasetExtractor implements FilesystemDatasetExtractor
   @Override
   @SneakyThrows
   public DatasetIdentifier extract(URI location, String rawName) {
-    URI fixedLocation = new URI(scheme, location.getAuthority(), location.getPath(), null, null);
+    URI fixedLocation =
+        new URI(canonicalScheme, location.getAuthority(), location.getPath(), null, null);
     String namespace = FilesystemUriSanitizer.removeLastSlash(fixedLocation.toString());
     String name =
         Optional.of(rawName)

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForABFSS.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForABFSS.java
@@ -1,0 +1,113 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.filesystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import java.net.URI;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class FilesystemDatasetUtilsTestForABFSS {
+  @Test
+  @SneakyThrows
+  void testFromLocation() {
+    assertThat(
+            FilesystemDatasetUtils.fromLocation(
+                new URI("abfss://container@account.dfs.core.windows.net")))
+        .hasFieldOrPropertyWithValue("namespace", "abfss://container@account.dfs.core.windows.net")
+        .hasFieldOrPropertyWithValue("name", "/");
+
+    assertThat(
+            FilesystemDatasetUtils.fromLocation(
+                new URI("abfss://container@account.dfs.core.windows.net/warehouse")))
+        .hasFieldOrPropertyWithValue("namespace", "abfss://container@account.dfs.core.windows.net")
+        .hasFieldOrPropertyWithValue("name", "warehouse");
+
+    assertThat(
+            FilesystemDatasetUtils.fromLocation(
+                new URI("abfss://container@account.dfs.core.windows.net/warehouse/location")))
+        .hasFieldOrPropertyWithValue("namespace", "abfss://container@account.dfs.core.windows.net")
+        .hasFieldOrPropertyWithValue("name", "warehouse/location");
+
+    assertThat(
+            FilesystemDatasetUtils.fromLocation(
+                new URI("abfss://container@account.dfs.core.windows.net/warehouse/location/")))
+        .hasFieldOrPropertyWithValue("namespace", "abfss://container@account.dfs.core.windows.net")
+        .hasFieldOrPropertyWithValue("name", "warehouse/location");
+  }
+
+  /**
+   * The non-TLS scheme {@code abfs} differs from {@code abfss} only in transport security and
+   * addresses the same data, so it is normalized to the canonical {@code abfss} scheme defined by
+   * the OpenLineage naming spec
+   */
+  @Test
+  @SneakyThrows
+  void testFromLocationWithDifferentProtocol() {
+    assertThat(
+            FilesystemDatasetUtils.fromLocation(
+                new URI("abfs://container@account.dfs.core.windows.net/warehouse")))
+        .hasFieldOrPropertyWithValue("namespace", "abfss://container@account.dfs.core.windows.net")
+        .hasFieldOrPropertyWithValue("name", "warehouse");
+  }
+
+  @Test
+  @SneakyThrows
+  void testFromLocationAndNameWithDifferentProtocol() {
+    assertThat(
+            FilesystemDatasetUtils.fromLocationAndName(
+                new URI("abfs://container@account.dfs.core.windows.net/warehouse"),
+                "default.table"))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "abfss://container@account.dfs.core.windows.net/warehouse")
+        .hasFieldOrPropertyWithValue("name", "default.table");
+  }
+
+  @Test
+  @SneakyThrows
+  void testFromLocationAndName() {
+    assertThat(
+            FilesystemDatasetUtils.fromLocationAndName(
+                new URI("abfss://container@account.dfs.core.windows.net/warehouse"),
+                "default.table"))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "abfss://container@account.dfs.core.windows.net/warehouse")
+        .hasFieldOrPropertyWithValue("name", "default.table");
+
+    assertThat(
+            FilesystemDatasetUtils.fromLocationAndName(
+                new URI("abfss://container@account.dfs.core.windows.net/warehouse"), ""))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "abfss://container@account.dfs.core.windows.net/warehouse")
+        .hasFieldOrPropertyWithValue("name", "/");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("/", "abfss://container@account.dfs.core.windows.net")))
+        .isEqualTo(new URI("abfss://container@account.dfs.core.windows.net"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier(
+                    "warehouse", "abfss://container@account.dfs.core.windows.net")))
+        .isEqualTo(new URI("abfss://container@account.dfs.core.windows.net/warehouse"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier(
+                    "default.table",
+                    "abfss://container@account.dfs.core.windows.net/warehouse/location")))
+        .isEqualTo(
+            new URI(
+                "abfss://container@account.dfs.core.windows.net/warehouse/location/default.table"));
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForWASBS.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForWASBS.java
@@ -39,6 +39,27 @@ class FilesystemDatasetUtilsTestForWASBS {
 
   @Test
   @SneakyThrows
+  void testFromLocationWithDifferentProtocol() {
+    // The non-TLS scheme {@code wasb} differs from {@code wasbs} only in transport security and
+    // addresses the same data, so it is normalized to the canonical {@code wasbs} scheme defined by
+    // the OpenLineage naming spec
+    assertThat(FilesystemDatasetUtils.fromLocation(new URI("wasb://container@bucket/warehouse")))
+        .hasFieldOrPropertyWithValue("namespace", "wasbs://container@bucket")
+        .hasFieldOrPropertyWithValue("name", "warehouse");
+  }
+
+  @Test
+  @SneakyThrows
+  void testFromLocationAndNameWithDifferentProtocol() {
+    assertThat(
+            FilesystemDatasetUtils.fromLocationAndName(
+                new URI("wasb://container@bucket/warehouse"), "default.table"))
+        .hasFieldOrPropertyWithValue("namespace", "wasbs://container@bucket/warehouse")
+        .hasFieldOrPropertyWithValue("name", "default.table");
+  }
+
+  @Test
+  @SneakyThrows
   void testFromLocationAndName() {
     assertThat(
             FilesystemDatasetUtils.fromLocationAndName(

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -238,7 +238,7 @@ class InputFieldsCollectorTest {
     verify(builder, times(1))
         .addInput(
             exprId,
-            new DatasetIdentifier("/path", "abfss://tmp@storage.dfs.core.windows.net"),
+            new DatasetIdentifier("path", "abfss://tmp@storage.dfs.core.windows.net"),
             SOME_NAME);
   }
 


### PR DESCRIPTION
Treat abfs:// and wasb:// the same as their TLS variants (abfss/wasbs) when deriving the object-storage namespace, and add ABFSS/WASBS coverage. Also update the spark3 InputFieldsCollectorTest assertion: it exercises abfss naming through the published client jar and now expects the normalized name with no leading slash (path, not /path).

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Treat abfs:// and wasb:// the same as their TLS variants (abfss/wasbs) when deriving the object-storage namespace


### Meaningful description
abfs and abfss (wasb, wasbs) point at the same files. Only the transport layer differs.


### Checklist
- [X] AI was used in creating this PR (but I verified every single line)