### PR TITLE
spark3: extract DeltaVersionUtils from DeltaHandler

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -11,12 +11,10 @@ import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
@@ -24,7 +22,6 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.V1Table;
-import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.catalog.DeltaCatalog;
 import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 import scala.Option;
@@ -129,44 +126,7 @@ public class DeltaHandler implements CatalogHandler {
   public Optional<String> getDatasetVersion(
       TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
     DeltaCatalog deltaCatalog = (DeltaCatalog) tableCatalog;
-    Table table = deltaCatalog.loadTable(identifier);
-
-    if (table instanceof DeltaTableV2) {
-      DeltaTableV2 deltaTable = (DeltaTableV2) table;
-      Optional<Snapshot> snapshot = getDeltaTableSnapshot(deltaTable);
-      if (snapshot.isPresent()) {
-        return Optional.of(Long.toString(snapshot.get().version()));
-      }
-    }
-    return Optional.empty();
-  }
-
-  /**
-   * Versions of Delta differ in implementation of {@link DeltaTableV2} class. This method retrieves
-   * the table snapshot regardless of the Delta version. Previously `snapshot` method was available
-   * in Scala class for Delta < 3. Recent changes in Delta 3+ changed the naming of this function to
-   * be 'initialSnapshot'. The developers wanted to indicate with this rename that the snapshot we
-   * are getting, is a lazy value that returns the initial version you read. If the table has been
-   * changed in the meantime, you will not get the latest snapshot but that initial version you
-   * read.
-   *
-   * @return Optional SnapShot of the deltaTable.
-   */
-  private Optional<Snapshot> getDeltaTableSnapshot(DeltaTableV2 deltaTable) {
-    if (MethodUtils.getAccessibleMethod(deltaTable.getClass(), "snapshot") != null) {
-      try {
-        return Optional.of((Snapshot) MethodUtils.invokeMethod(deltaTable, "snapshot"));
-      } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-        log.error("Could not invoke method", e);
-      }
-    } else if (MethodUtils.getAccessibleMethod(deltaTable.getClass(), "initialSnapshot") != null) {
-      try {
-        return Optional.of((Snapshot) MethodUtils.invokeMethod(deltaTable, "initialSnapshot"));
-      } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-        log.error("Could not invoke method", e);
-      }
-    }
-    return Optional.empty();
+    return DeltaVersionUtils.getDatasetVersion(deltaCatalog.loadTable(identifier));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaVersionUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaVersionUtils.java
@@ -1,0 +1,65 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.delta.Snapshot;
+import org.apache.spark.sql.delta.catalog.DeltaTableV2;
+
+/**
+ * Resolves the Delta snapshot version used as the OpenLineage dataset version. Shared by the
+ * catalog handlers that surface Delta tables: {@link DeltaHandler} and the open source Unity
+ * Catalog handler in the {@code spark40} module.
+ */
+@Slf4j
+public final class DeltaVersionUtils {
+
+  private DeltaVersionUtils() {}
+
+  /**
+   * Returns the Delta snapshot version of the given table, or empty when the table is not a {@link
+   * DeltaTableV2} or its snapshot cannot be retrieved.
+   */
+  public static Optional<String> getDatasetVersion(Table table) {
+    if (table instanceof DeltaTableV2) {
+      return getDeltaTableSnapshot((DeltaTableV2) table)
+          .map(snapshot -> Long.toString(snapshot.version()));
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Versions of Delta differ in implementation of {@link DeltaTableV2} class. This method retrieves
+   * the table snapshot regardless of the Delta version. Previously `snapshot` method was available
+   * in Scala class for Delta < 3. Recent changes in Delta 3+ changed the naming of this function to
+   * be 'initialSnapshot'. The developers wanted to indicate with this rename that the snapshot we
+   * are getting, is a lazy value that returns the initial version you read. If the table has been
+   * changed in the meantime, you will not get the latest snapshot but that initial version you
+   * read.
+   *
+   * @return Optional SnapShot of the deltaTable.
+   */
+  private static Optional<Snapshot> getDeltaTableSnapshot(DeltaTableV2 deltaTable) {
+    if (MethodUtils.getAccessibleMethod(deltaTable.getClass(), "snapshot") != null) {
+      try {
+        return Optional.of((Snapshot) MethodUtils.invokeMethod(deltaTable, "snapshot"));
+      } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+        log.error("Could not invoke method", e);
+      }
+    } else if (MethodUtils.getAccessibleMethod(deltaTable.getClass(), "initialSnapshot") != null) {
+      try {
+        return Optional.of((Snapshot) MethodUtils.invokeMethod(deltaTable, "initialSnapshot"));
+      } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+        log.error("Could not invoke method", e);
+      }
+    }
+    return Optional.empty();
+  }
+}


### PR DESCRIPTION
Move the Delta snapshot/version reflection logic into a dedicated DeltaVersionUtils so it can be reused; no behavior change.

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Move the Delta snapshot/version reflection logic into a dedicated DeltaVersionUtils


### Meaningful description
The functionality to determine Delta snapshot version deserves refactoring into a separate file. In addition, the same functionality will be used in a planned handler for Unity Catalog


### Checklist
- [X] AI was used in creating this PR (but I verified every single line)
