### PR TITLE
spark3: IcebergHandler.hasClasses probes SparkCatalog instead of Catalog

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -65,10 +65,10 @@ public class IcebergHandler implements CatalogHandler {
   @Override
   public boolean hasClasses() {
     try {
-      IcebergHandler.class.getClassLoader().loadClass("org.apache.iceberg.catalog.Catalog");
+      IcebergHandler.class.getClassLoader().loadClass("org.apache.iceberg.spark.SparkCatalog");
       return true;
-    } catch (Exception e) {
-      log.debug("The iceberg catalog is not present");
+    } catch (NoClassDefFoundError | Exception e) {
+      log.debug("The iceberg spark catalog is not present");
     }
     return false;
   }


### PR DESCRIPTION
Detect Iceberg by the presence of the iceberg-spark SparkCatalog class rather than iceberg-core's Catalog, so the handler does not activate in environments where iceberg-core is on the classpath but iceberg-spark is not.

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Detect Iceberg by the presence of the iceberg-spark SparkCatalog class rather than iceberg-core's Catalog


### Meaningful description
OpenLineage Spark integration should activate Iceberg catalog handler only when `SparkCatalog` is available. Iceberg core `Catalog` is not enough. It should also not activate in environments where Iceberg `Catalog` is available but not as Spark dependency (this would require to include `SparkCatalog` too)


### Checklist
- [X] AI was used in creating this PR (but I verified it)
