### PR TITLE
spark: Missing output lineage for insertInto with append mode

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
@@ -28,7 +28,6 @@ public class DatabricksEventFilter implements EventFilter {
           "collect_limit",
           "describe_table",
           "local_table_scan",
-          "append_data_exec_v1",
           "serialize_from_object",
           "execute_set_catalog_command");
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
@@ -82,6 +82,13 @@ class DatabricksEventFilterTest {
   }
 
   @Test
+  @SetEnvironmentVariable(key = DATABRICKS_RUNTIME_VERSION, value = DATABRICKS_RUNTIME_13_3)
+  void testAppendDataExecIsNotFiltered() {
+    when(node.nodeName()).thenReturn("append_data_exec_v1");
+    assertThat(filter.isDisabled(event)).isFalse();
+  }
+
+  @Test
   void testNonDatabricksEnvironmentEarlyReturn() {
     // Without DATABRICKS_RUNTIME_VERSION env var and without workspace URL in SparkConf,
     // filter should return false

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -10,6 +10,7 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -18,7 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
 
 /**
  * {@link LogicalPlan} visitor that matches an {@link AppendData} commands and extracts the output
@@ -43,16 +46,34 @@ public class AppendDataDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
   @Override
   protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, AppendData x) {
     // Needs to cast to logical plan despite IntelliJ claiming otherwise.
-    LogicalPlan logicalPlan = (LogicalPlan) ((AppendData) x).table();
+    LogicalPlan table = (LogicalPlan) x.table();
+    Optional<DataSourceV2Relation> relation = resolveDataSourceV2Relation(table);
+    if (relation.isPresent()) {
+      return DataSourceV2RelationDatasetExtractor.extract(
+          factory, context, relation.get(), includeDatasetVersion(event));
+    }
 
     return delegate(
             context.getOutputDatasetQueryPlanVisitors(), context.getOutputDatasetBuilders(), event)
         .applyOrElse(
-            logicalPlan,
+            table,
             ScalaConversionUtils.toScalaFn(
                 (lp) -> Collections.<OpenLineage.OutputDataset>emptyList()))
         .stream()
         .collect(Collectors.toList());
+  }
+
+  private Optional<DataSourceV2Relation> resolveDataSourceV2Relation(LogicalPlan table) {
+    if (table instanceof DataSourceV2Relation) {
+      return Optional.of((DataSourceV2Relation) table);
+    }
+    if (table instanceof DataSourceV2ScanRelation) {
+      return Optional.of(((DataSourceV2ScanRelation) table).relation());
+    }
+    if (table instanceof SubqueryAlias) {
+      return resolveDataSourceV2Relation(((SubqueryAlias) table).child());
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -49,6 +49,9 @@ public class AppendDataDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
     LogicalPlan table = (LogicalPlan) x.table();
     Optional<DataSourceV2Relation> relation = resolveDataSourceV2Relation(table);
     if (relation.isPresent()) {
+      // Run query plan visitors (for example, Iceberg metrics reporter injection) before building
+      // output datasets directly from the target relation.
+      delegate(table, event);
       return DataSourceV2RelationDatasetExtractor.extract(
           factory, context, relation.get(), includeDatasetVersion(event));
     }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -34,6 +36,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 class AppendDataDatasetBuilderTest {
 
@@ -61,6 +64,7 @@ class AppendDataDatasetBuilderTest {
     AppendData appendData = mock(AppendData.class);
     DataSourceV2Relation table = mock(DataSourceV2Relation.class);
     OpenLineage.OutputDataset dataset = mock(OpenLineage.OutputDataset.class);
+    SparkListenerSQLExecutionEnd event = new SparkListenerSQLExecutionEnd(1L, 1L);
 
     when(appendData.table()).thenReturn(table);
 
@@ -70,11 +74,33 @@ class AppendDataDatasetBuilderTest {
           .when(() -> DataSourceV2RelationDatasetExtractor.extract(factory, context, table, true))
           .thenReturn(Collections.singletonList(dataset));
 
-      List<OpenLineage.OutputDataset> datasets =
-          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), appendData);
+      List<OpenLineage.OutputDataset> datasets = builder.apply(event, appendData);
 
       assertEquals(1, datasets.size());
       assertEquals(dataset, datasets.get(0));
+    }
+  }
+
+  @Test
+  void testApplyRunsQueryPlanVisitorsBeforeExtract() {
+    AppendData appendData = mock(AppendData.class);
+    DataSourceV2Relation table = mock(DataSourceV2Relation.class);
+    OpenLineage.OutputDataset dataset = mock(OpenLineage.OutputDataset.class);
+    SparkListenerSQLExecutionEnd event = new SparkListenerSQLExecutionEnd(1L, 1L);
+    AppendDataDatasetBuilder spyBuilder = spy(builder);
+
+    when(appendData.table()).thenReturn(table);
+    Mockito.doReturn(Collections.emptyList()).when(spyBuilder).delegate(table, event);
+
+    try (MockedStatic<DataSourceV2RelationDatasetExtractor> extractor =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      extractor
+          .when(() -> DataSourceV2RelationDatasetExtractor.extract(factory, context, table, true))
+          .thenReturn(Collections.singletonList(dataset));
+
+      spyBuilder.apply(event, appendData);
+
+      verify(spyBuilder).delegate(table, event);
     }
   }
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -21,6 +22,9 @@ import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrap
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import java.util.Collections;
+import java.util.List;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NamedRelation;
@@ -29,6 +33,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class AppendDataDatasetBuilderTest {
 
@@ -49,6 +54,28 @@ class AppendDataDatasetBuilderTest {
   void isDefinedAtLogicalPlan() {
     assertTrue(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
     assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyForDataSourceV2Relation() {
+    AppendData appendData = mock(AppendData.class);
+    DataSourceV2Relation table = mock(DataSourceV2Relation.class);
+    OpenLineage.OutputDataset dataset = mock(OpenLineage.OutputDataset.class);
+
+    when(appendData.table()).thenReturn(table);
+
+    try (MockedStatic<DataSourceV2RelationDatasetExtractor> extractor =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      extractor
+          .when(() -> DataSourceV2RelationDatasetExtractor.extract(factory, context, table, true))
+          .thenReturn(Collections.singletonList(dataset));
+
+      List<OpenLineage.OutputDataset> datasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), appendData);
+
+      assertEquals(1, datasets.size());
+      assertEquals(dataset, datasets.get(0));
+    }
   }
 
   @Test


### PR DESCRIPTION
closes: #4659 


### One-line summary for changelog:
This change fixes a bug where OpenLineage did not emit an output dataset when writing with:
```
df.write.mode("append").insertInto(TABLE_NAME)
```
The same write with mode("overwrite") produced correct lineage. The fix aligns append-mode handling with overwrite-mode handling by extracting the target table directly from the AppendData logical plan.


### Meaningful description
#### Problem

##### Observed behavior

Write mode | Code | Output dataset in event?
-- | -- | --
append | df.write.mode("append").insertInto(TABLE_2) | No
overwrite | df.write.mode("overwrite").insertInto(TABLE_2) | Yes

Data was written successfully in both cases; only lineage emission differed.

##### Expected behavior
Both append and overwrite insertInto writes should include the target table (TABLE_2) in the OpenLineage event outputs array.

##### Root cause
Spark resolves DataFrame insertInto differently depending on save mode:


Save mode | Resolved logical plan (typical) | OpenLineage builder
-- | -- | --
overwrite | OverwriteByExpression or InsertIntoStatement | TableContentChangeDatasetBuilder
append | AppendData | AppendDataDatasetBuilder

Two separate issues prevented append lineage from appearing on Databricks:

##### Issue 1: Event filtered before emission (Databricks only)

DatabricksEventFilter excluded all append_data_exec_v1 physical plans on Databricks. That blocks the entire OpenLineage event — no job, no outputs.

Overwrite uses overwrite_by_expression_exec_v1, which was not excluded. 

##### Fix:  
Remove append_data_exec_v1 from DatabricksEventFilter.excludedNodes. Internal staging writes are still filtered by DeltaEventFilter.isStagedDeltaTable() when the plan contains StagedDeltaTableV2.


##### Issue 2: Missing output dataset when event was emitted
AppendDataDatasetBuilder did not extract the table itself. Instead, it delegated to other output builders on the table sub-plan:

TableContentChangeDatasetBuilder extracts the target table directly using DataSourceV2RelationDatasetExtractor. This path resolves catalog metadata (Unity Catalog, Delta, Iceberg, etc.) and always produces an output dataset when the table is a V2 relation.

##### Why append failed
AppendDataDatasetBuilder did not extract the table itself. Instead, it delegated to other output builders on the table sub-plan:
AppendData
└── table: DataSourceV2Relation (target table)
└── query: LocalRelation / Project / ... (source data)

Delegation routed through DataSourceV2RelationOutputDatasetBuilder, which checks the Spark extension visitor first:

On Databricks with Unity Catalog and Delta tables, the extension visitor is often defined but returns no output datasets for write operations. Overwrite mode never hit this path because TableContentChangeDatasetBuilder calls DataSourceV2RelationDatasetExtractor directly.

SQL-based INSERT INTO ... append (which also resolves to AppendData) could still work in some environments (e.g. Iceberg integration tests) when the extension visitor is not involved and delegation reaches the catalog extractor successfully.

##### Fix

Update AppendDataDatasetBuilder to extract the target table directly when it is a known V2 relation type, matching the approach used by TableContentChangeDatasetBuilder.

### Checklist
- [x] AI was used in creating this PR (The generated changes were validated by testing and verifying the emitted append-mode OpenLineage events.)
