### PR TITLE
fix(great-expectations): preserve datasource url ports

### DIFF
--- a/integration/common/src/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/src/openlineage/common/provider/great_expectations/action.py
@@ -426,11 +426,16 @@ class OpenLineageValidationAction(ValidationAction):
         if url.scheme == "bigquery":
             return Source(scheme="bigquery", connection_url="bigquery")
 
+        hostname = url.hostname or ""
+        authority = f"[{hostname}]" if ":" in hostname else hostname
+        if authority and url.port is not None:
+            authority = f"{authority}:{url.port}"
+
         return Source(
             scheme=url.scheme,
             authority=url.hostname,
             # Remove credentials from the URL if present
-            connection_url=url._replace(netloc=url.hostname, query=None, fragment=None).geturl(),
+            connection_url=url._replace(netloc=authority, query=None, fragment=None).geturl(),
         )
 
     def results_facet(self, validation_result: ExpectationSuiteValidationResult):

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -5,6 +5,7 @@ import datetime
 import os
 import sqlite3
 import tempfile
+from urllib.parse import urlparse
 
 import pandas
 import pytest
@@ -344,3 +345,20 @@ def test_dataset_from_pandas_source_v3_api(tmpdir):
         k in input_ds["inputFacets"]
         for k in ["dataQuality", "greatExpectations_assertions", "dataQualityMetrics"]
     )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_connection_url"),
+    [
+        ("postgresql://user:pass@localhost:5432/db?sslmode=require", "postgresql://localhost:5432/db"),
+        ("postgresql://user:pass@localhost:0/db", "postgresql://localhost:0/db"),
+        ("postgresql://user:pass@[::1]/db", "postgresql://[::1]/db"),
+    ],
+)
+def test_source_strips_credentials_and_preserves_authority(url, expected_connection_url):
+    action = OpenLineageValidationAction.__new__(OpenLineageValidationAction)
+
+    source = action._source(urlparse(url))
+
+    assert source.scheme == "postgresql"
+    assert source.connection_url == expected_connection_url


### PR DESCRIPTION
﻿## Summary

- preserve datasource URL ports when Great Expectations strips credentials
- add regression coverage for credential stripping with a host and port

## Issue

Fixes #4678

## Tests

- `uv run pytest tests/great_expectations/test_great_expectations_validation_action.py -k "source_strips_credentials"`
- `uv run ruff check src/openlineage/common/provider/great_expectations/action.py tests/great_expectations/test_great_expectations_validation_action.py`
