### PR TITLE
Feat add ol context

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -20,20 +20,26 @@ class ParentRunMetadata:
     root_parent_job_name: str | None = attr.field(default=None)
     root_parent_job_namespace: str | None = attr.field(default=None)
     root_parent_run_id: str | None = attr.field(default=None)
+    job_facets: dict | None = attr.field(default=None)
+    run_facets: dict | None = attr.field(default=None)
+    root_job_facets: dict | None = attr.field(default=None)
+    root_run_facets: dict | None = attr.field(default=None)
 
     def to_openlineage(self) -> parent_run.ParentRunFacet:
         root = None
         if self.root_parent_run_id and self.root_parent_job_namespace and self.root_parent_job_name:
             root = parent_run.Root(
-                run=parent_run.RootRun(runId=self.root_parent_run_id),
+                run=parent_run.RootRun(runId=self.root_parent_run_id, facets=self.root_run_facets),
                 job=parent_run.RootJob(
-                    namespace=self.root_parent_job_namespace, name=self.root_parent_job_name
+                    namespace=self.root_parent_job_namespace,
+                    name=self.root_parent_job_name,
+                    facets=self.root_job_facets,
                 ),
             )
 
         return parent_run.ParentRunFacet(
-            run=parent_run.Run(runId=self.run_id),
-            job=parent_run.Job(namespace=self.job_namespace, name=self.job_name),
+            run=parent_run.Run(runId=self.run_id, facets=self.run_facets),
+            job=parent_run.Job(namespace=self.job_namespace, name=self.job_name, facets=self.job_facets),
             root=root,
         )
 

--- a/integration/common/src/openlineage/common/provider/dbt/utils.py
+++ b/integration/common/src/openlineage/common/provider/dbt/utils.py
@@ -1,5 +1,6 @@
 # Copyright 2018-2026 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
+import json
 import logging
 import os
 import uuid
@@ -117,10 +118,67 @@ def generate_random_log_file_name() -> str:
     return log_directory_name
 
 
+def get_parent_run_metadata_from_context() -> ParentRunMetadata | None:
+    """
+    Parses the standardized OPENLINEAGE_CONTEXT env var, a JSON payload shaped like:
+    {"parent": {"run": {...}, "job": {...}, "root": {"run": {...}, "job": {...}}}}
+    Returns None (rather than raising) on any missing/malformed input, so callers can fall back
+    to the legacy OPENLINEAGE_PARENT_ID / OPENLINEAGE_ROOT_PARENT_ID env vars.
+    """
+    raw = os.getenv("OPENLINEAGE_CONTEXT")
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        log.warning(
+            "Received OPENLINEAGE_CONTEXT but failed to parse it as JSON; ignoring.",
+        )
+        log.debug("Exception details", exc_info=True)
+        return None
+
+    parent_info = data.get("parent") if isinstance(data, dict) else None
+    if not isinstance(parent_info, dict):
+        log.debug("OPENLINEAGE_CONTEXT is missing a valid 'parent' key; ignoring")
+        return None
+
+    try:
+        run, job = parent_info["run"], parent_info["job"]
+        run_id, job_namespace, job_name = run["runId"], job["namespace"], job["name"]
+    except (KeyError, TypeError) as e:
+        log.warning("OPENLINEAGE_CONTEXT.parent is missing required run/job fields; ignoring. Error: %s", e)
+        log.debug("Exception details", exc_info=True)
+        return None
+
+    root = parent_info.get("root") or {}
+    root_run, root_job = root.get("run") or {}, root.get("job") or {}
+    # default root to self, matching legacy OPENLINEAGE_ROOT_PARENT_ID-absent behavior
+    root_run_id = root_run.get("runId", run_id)
+    root_job_namespace = root_job.get("namespace", job_namespace)
+    root_job_name = root_job.get("name", job_name)
+
+    return ParentRunMetadata(
+        run_id=run_id,
+        job_name=job_name,
+        job_namespace=job_namespace,
+        job_facets=job.get("facets"),
+        run_facets=run.get("facets"),
+        root_parent_run_id=root_run_id,
+        root_parent_job_name=root_job_name,
+        root_parent_job_namespace=root_job_namespace,
+        root_job_facets=root_job.get("facets"),
+        root_run_facets=root_run.get("facets"),
+    )
+
+
 def get_parent_run_metadata():
     """
     The parent job that started the dbt command. Usually the scheduler (Airflow, ...etc)
     """
+    from_context = get_parent_run_metadata_from_context()
+    if from_context is not None:
+        return from_context
+
     parent_id = os.getenv("OPENLINEAGE_PARENT_ID")
     root_parent_id = os.getenv("OPENLINEAGE_ROOT_PARENT_ID")
     parent_run_metadata = None

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -17,6 +17,10 @@ from openlineage.common.provider.dbt.local import (
     LazyJinjaLoadDict,
 )
 from openlineage.common.provider.dbt.processor import ParentRunMetadata
+from openlineage.common.provider.dbt.utils import (
+    get_parent_run_metadata,
+    get_parent_run_metadata_from_context,
+)
 from openlineage.common.test import match
 
 CURRENT_DIR = str(Path(__file__).absolute().parent)
@@ -37,6 +41,157 @@ def parent_run_metadata():
         root_parent_job_name="root-parent-job-name",
         root_parent_job_namespace="root-parent-job-namespace",
     )
+
+
+def test_get_parent_run_metadata_from_context_valid(monkeypatch):
+    monkeypatch.setenv(
+        "OPENLINEAGE_CONTEXT",
+        json.dumps(
+            {
+                "parent": {
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11",
+                        "facets": {"processing_engine": {"version": "2.10.0"}},
+                    },
+                    "job": {
+                        "namespace": "airflow",
+                        "name": "my_dag.my_task",
+                        "facets": {"jobType": {"processingType": "BATCH", "integration": "AIRFLOW"}},
+                    },
+                    "root": {
+                        "run": {
+                            "runId": "a0000000-3c3c-1a1a-2b2b-c1b95c24ff11",
+                            "facets": {"processing_engine": {"version": "2.10.0"}},
+                        },
+                        "job": {
+                            "namespace": "airflow",
+                            "name": "my_dag",
+                            "facets": {"jobType": {"processingType": "BATCH", "integration": "AIRFLOW"}},
+                        },
+                    },
+                }
+            }
+        ),
+    )
+
+    metadata = get_parent_run_metadata_from_context()
+
+    assert metadata == ParentRunMetadata(
+        run_id="f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11",
+        job_name="my_dag.my_task",
+        job_namespace="airflow",
+        run_facets={"processing_engine": {"version": "2.10.0"}},
+        job_facets={"jobType": {"processingType": "BATCH", "integration": "AIRFLOW"}},
+        root_parent_run_id="a0000000-3c3c-1a1a-2b2b-c1b95c24ff11",
+        root_parent_job_name="my_dag",
+        root_parent_job_namespace="airflow",
+        root_run_facets={"processing_engine": {"version": "2.10.0"}},
+        root_job_facets={"jobType": {"processingType": "BATCH", "integration": "AIRFLOW"}},
+    )
+
+
+def test_get_parent_run_metadata_from_context_not_set(monkeypatch):
+    monkeypatch.delenv("OPENLINEAGE_CONTEXT", raising=False)
+    assert get_parent_run_metadata_from_context() is None
+
+
+def test_get_parent_run_metadata_from_context_malformed_json(monkeypatch, caplog):
+    monkeypatch.setenv("OPENLINEAGE_CONTEXT", "not valid json")
+    assert get_parent_run_metadata_from_context() is None
+    assert "failed to parse it as JSON" in caplog.text
+
+
+def test_get_parent_run_metadata_from_context_missing_parent_run_key(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_CONTEXT", json.dumps({"somethingElse": {}}))
+    assert get_parent_run_metadata_from_context() is None
+
+
+@pytest.mark.parametrize(
+    "parent",
+    [
+        {"run": {"runId": "abc"}},  # job missing entirely
+        {"job": {"namespace": "ns", "name": "job"}},  # run missing entirely
+        {"run": {"runId": "abc"}, "job": {"name": "job"}},  # job.namespace missing
+        {"run": {}, "job": {"namespace": "ns", "name": "job"}},  # run.runId missing
+    ],
+    ids=["missing_job", "missing_run", "missing_job_namespace", "missing_run_id"],
+)
+def test_get_parent_run_metadata_from_context_missing_required_fields(monkeypatch, caplog, parent):
+    monkeypatch.setenv("OPENLINEAGE_CONTEXT", json.dumps({"parent": parent}))
+
+    assert get_parent_run_metadata_from_context() is None
+    assert "missing required run/job fields" in caplog.text
+
+
+def test_get_parent_run_metadata_from_context_without_root_defaults_to_self(monkeypatch):
+    monkeypatch.setenv(
+        "OPENLINEAGE_CONTEXT",
+        json.dumps(
+            {
+                "parent": {
+                    "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"},
+                    "job": {"namespace": "airflow", "name": "my_dag.my_task"},
+                }
+            }
+        ),
+    )
+
+    metadata = get_parent_run_metadata_from_context()
+
+    assert metadata.root_parent_run_id == metadata.run_id
+    assert metadata.root_parent_job_name == metadata.job_name
+    assert metadata.root_parent_job_namespace == metadata.job_namespace
+
+
+def test_get_parent_run_metadata_from_context_unknown_top_level_keys_ignored(monkeypatch):
+    monkeypatch.setenv(
+        "OPENLINEAGE_CONTEXT",
+        json.dumps(
+            {
+                "someFutureField": {"anything": "goes"},
+                "parent": {
+                    "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"},
+                    "job": {"namespace": "airflow", "name": "my_dag.my_task"},
+                },
+            }
+        ),
+    )
+
+    assert get_parent_run_metadata_from_context() is not None
+
+
+def test_get_parent_run_metadata_context_takes_precedence_over_legacy(monkeypatch):
+    monkeypatch.setenv(
+        "OPENLINEAGE_CONTEXT",
+        json.dumps(
+            {
+                "parent": {
+                    "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"},
+                    "job": {"namespace": "context-namespace", "name": "context-job"},
+                }
+            }
+        ),
+    )
+    monkeypatch.setenv(
+        "OPENLINEAGE_PARENT_ID", "legacy-namespace/legacy-job/f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+    )
+
+    metadata = get_parent_run_metadata()
+
+    assert metadata.job_namespace == "context-namespace"
+    assert metadata.job_name == "context-job"
+
+
+def test_get_parent_run_metadata_falls_back_to_legacy_when_context_malformed(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_CONTEXT", "not valid dict")
+    monkeypatch.setenv(
+        "OPENLINEAGE_PARENT_ID", "legacy-namespace/legacy-job/f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+    )
+
+    metadata = get_parent_run_metadata()
+
+    assert metadata.job_namespace == "legacy-namespace"
+    assert metadata.job_name == "legacy-job"
 
 
 def serialize(inst, field, value):

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openlineage.client.DefaultConfigPathProvider;
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.transports.ConsoleConfig;
@@ -35,6 +36,7 @@ public class ArgumentParser {
       "spark.openlineage.parentJobNamespace";
   public static final String SPARK_CONF_PARENT_JOB_NAME = "spark.openlineage.parentJobName";
   public static final String SPARK_CONF_PARENT_RUN_ID = "spark.openlineage.parentRunId";
+  public static final String SPARK_CONF_CONTEXT = "spark.openlineage.context";
   public static final String SPARK_CONF_APP_NAME = "spark.openlineage.appName";
   public static final String SPARK_CONF_APP_RUN_ID = "spark.openlineage.applicationRunId";
   public static final String ARRAY_PREFIX_CHAR = "[";
@@ -124,10 +126,18 @@ public class ArgumentParser {
         .ifPresent(config::setOverriddenApplicationRunId);
 
     findSparkConfigKey(conf, SPARK_CONF_NAMESPACE).ifPresent(config::setNamespace);
-    findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAME).ifPresent(config::setParentJobName);
-    findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAMESPACE)
-        .ifPresent(config::setParentJobNamespace);
-    findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID).ifPresent(config::setParentRunId);
+
+    Optional<ParentRunContext.ParentRun> parentRunContext =
+        findSparkConfigKey(conf, SPARK_CONF_CONTEXT).flatMap(ArgumentParser::parseParentRunContext);
+    if (parentRunContext.isPresent()) {
+      applyContext(parentRunContext.get(), config);
+    } else {
+      findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAME).ifPresent(config::setParentJobName);
+      findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAMESPACE)
+          .ifPresent(config::setParentJobNamespace);
+      findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID).ifPresent(config::setParentRunId);
+    }
+
     findSparkConfigKey(conf, SPARK_TEST_EXTENSION_PROVIDER)
         .ifPresent(config::setTestExtensionProvider);
     findSparkConfigKey(conf, SPARK_CONF_JOB_NAME_APPEND_DATASET_NAME)
@@ -136,6 +146,44 @@ public class ArgumentParser {
     findSparkConfigKey(conf, SPARK_CONF_JOB_NAME_REPLACE_DOT_WITH_UNDERSCORE)
         .map(Boolean::valueOf)
         .ifPresent(v -> config.getJobName().setReplaceDotWithUnderscore(v));
+  }
+
+  /** Parses {@code spark.openlineage.context}, returning empty on any parsing/validation error. */
+  private static Optional<ParentRunContext.ParentRun> parseParentRunContext(String raw) {
+    ParentRunContext.ParentRun parentRun;
+    try {
+      parentRun =
+          OpenLineageClientUtils.newObjectMapper()
+              .readValue(raw, ParentRunContext.class)
+              .getParent();
+    } catch (Exception e) {
+      log.warn(
+          "Failed to parse spark.openlineage.context as JSON; falling back to legacy config", e);
+      return Optional.empty();
+    }
+    if (parentRun == null || parentRun.getRun() == null || parentRun.getJob() == null) {
+      log.warn("spark.openlineage.context is missing required parent.run/parent.job; ignoring");
+      return Optional.empty();
+    }
+    return Optional.of(parentRun);
+  }
+
+  private static void applyContext(
+      ParentRunContext.ParentRun parentRun, SparkOpenLineageConfig config) {
+    config.setParentRunId(parentRun.getRun().getRunId().toString());
+    config.setParentJobNamespace(parentRun.getJob().getNamespace());
+    config.setParentJobName(parentRun.getJob().getName());
+    config.setParentRunFacets(parentRun.getRun().getFacets());
+    config.setParentJobFacets(parentRun.getJob().getFacets());
+
+    OpenLineage.ParentRunFacetRoot root = parentRun.getRoot();
+    if (root != null) {
+      config.setRootParentRunId(root.getRun().getRunId().toString());
+      config.setRootParentJobNamespace(root.getJob().getNamespace());
+      config.setRootParentJobName(root.getJob().getName());
+      config.setRootParentRunFacets(root.getRun().getFacets());
+      config.setRootParentJobFacets(root.getJob().getFacets());
+    }
   }
 
   /**

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -36,6 +36,10 @@ public class EventEmitter {
   @Getter private Optional<String> rootParentJobName;
   @Getter private Optional<String> rootParentJobNamespace;
   @Getter private Optional<UUID> rootParentRunId;
+  @Getter private Optional<OpenLineage.ParentRunFacetJobFacets> parentJobFacets;
+  @Getter private Optional<OpenLineage.ParentRunFacetRunFacets> parentRunFacets;
+  @Getter private Optional<OpenLineage.RootJobFacets> rootParentJobFacets;
+  @Getter private Optional<OpenLineage.RootRunFacets> rootParentRunFacets;
   @Getter private UUID applicationRunId;
   @Getter @Setter private String applicationJobName;
   @Getter private Optional<List<String>> customEnvironmentVariables;
@@ -49,6 +53,10 @@ public class EventEmitter {
     this.rootParentJobName = Optional.ofNullable(config.getRootParentJobName());
     this.rootParentJobNamespace = Optional.ofNullable(config.getRootParentJobNamespace());
     this.rootParentRunId = convertToUUID(config.getRootParentRunId());
+    this.parentJobFacets = Optional.ofNullable(config.getParentJobFacets());
+    this.parentRunFacets = Optional.ofNullable(config.getParentRunFacets());
+    this.rootParentJobFacets = Optional.ofNullable(config.getRootParentJobFacets());
+    this.rootParentRunFacets = Optional.ofNullable(config.getRootParentRunFacets());
     this.overriddenAppName = Optional.ofNullable(config.getOverriddenAppName());
     this.overriddenApplicationRunId = Optional.ofNullable(config.getOverriddenApplicationRunId());
     this.customEnvironmentVariables =

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ParentRunContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ParentRunContext.java
@@ -1,0 +1,34 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.OpenLineage;
+import lombok.Getter;
+
+/**
+ * Deserialization target for the {@code spark.openlineage.context} config property: a JSON payload
+ * for propagating parent-run context, shaped as a values-only subset of {@link
+ * OpenLineage.ParentRunFacet} (no {@code _producer}/{@code _schemaURL} envelope), wrapped in a
+ * {@code parent} key.
+ */
+@Getter
+public class ParentRunContext {
+  @JsonProperty("parent")
+  private ParentRun parent;
+
+  @Getter
+  public static class ParentRun {
+    @JsonProperty("run")
+    private OpenLineage.ParentRunFacetRun run;
+
+    @JsonProperty("job")
+    private OpenLineage.ParentRunFacetJob job;
+
+    @JsonProperty("root")
+    private OpenLineage.ParentRunFacetRoot root;
+  }
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -360,6 +360,8 @@ class RddExecutionContext implements ExecutionContext {
         eventEmitter.getApplicationRunId(),
         eventEmitter.getApplicationJobName(),
         eventEmitter.getJobNamespace(),
+        null,
+        null,
         eventEmitter
             .getRootParentRunId()
             .orElse(eventEmitter.getParentRunId().orElse(eventEmitter.getApplicationRunId())),
@@ -368,7 +370,9 @@ class RddExecutionContext implements ExecutionContext {
             .orElse(eventEmitter.getParentJobName().orElse(eventEmitter.getApplicationJobName())),
         eventEmitter
             .getRootParentJobNamespace()
-            .orElse(eventEmitter.getParentJobNamespace().orElse(eventEmitter.getJobNamespace())));
+            .orElse(eventEmitter.getParentJobNamespace().orElse(eventEmitter.getJobNamespace())),
+        eventEmitter.getRootParentRunFacets().orElse(null),
+        eventEmitter.getRootParentJobFacets().orElse(null));
   }
 
   protected OpenLineage.JobFacets buildJobFacets(SparkListenerEvent sparkListenerEvent) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -134,22 +134,42 @@ class SparkApplicationExecutionContext implements ExecutionContext {
         && eventEmitter.getParentJobName().isPresent()
         && eventEmitter.getParentJobNamespace().isPresent()) {
       OpenLineage ol = olContext.getOpenLineage();
-      return ol.newParentRunFacet(
-          ol.newParentRunFacetRun(eventEmitter.getParentRunId().get(), null),
-          ol.newParentRunFacetJob(
-              eventEmitter.getParentJobNamespace().get(),
-              eventEmitter.getParentJobName().get(),
-              null),
-          ol.newParentRunFacetRoot(
-              ol.newRootRun(
-                  eventEmitter.getRootParentRunId().orElse(eventEmitter.getParentRunId().get()),
-                  null),
-              ol.newRootJob(
-                  eventEmitter
-                      .getRootParentJobNamespace()
-                      .orElse(eventEmitter.getParentJobNamespace().get()),
-                  eventEmitter.getRootParentJobName().orElse(eventEmitter.getParentJobName().get()),
-                  null)));
+      return ol.newParentRunFacetBuilder()
+          .run(
+              ol.newParentRunFacetRunBuilder()
+                  .runId(eventEmitter.getParentRunId().get())
+                  .facets(eventEmitter.getParentRunFacets().orElse(null))
+                  .build())
+          .job(
+              ol.newParentRunFacetJobBuilder()
+                  .namespace(eventEmitter.getParentJobNamespace().get())
+                  .name(eventEmitter.getParentJobName().get())
+                  .facets(eventEmitter.getParentJobFacets().orElse(null))
+                  .build())
+          .root(
+              ol.newParentRunFacetRootBuilder()
+                  .run(
+                      ol.newRootRunBuilder()
+                          .runId(
+                              eventEmitter
+                                  .getRootParentRunId()
+                                  .orElse(eventEmitter.getParentRunId().get()))
+                          .facets(eventEmitter.getRootParentRunFacets().orElse(null))
+                          .build())
+                  .job(
+                      ol.newRootJobBuilder()
+                          .namespace(
+                              eventEmitter
+                                  .getRootParentJobNamespace()
+                                  .orElse(eventEmitter.getParentJobNamespace().get()))
+                          .name(
+                              eventEmitter
+                                  .getRootParentJobName()
+                                  .orElse(eventEmitter.getParentJobName().get()))
+                          .facets(eventEmitter.getRootParentJobFacets().orElse(null))
+                          .build())
+                  .build())
+          .build();
     }
     return null;
   }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -368,6 +368,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
         eventEmitter.getApplicationRunId(),
         eventEmitter.getApplicationJobName(),
         eventEmitter.getJobNamespace(),
+        null,
+        null,
         eventEmitter
             .getRootParentRunId()
             .orElse(eventEmitter.getParentRunId().orElse(eventEmitter.getApplicationRunId())),
@@ -376,7 +378,9 @@ class SparkSQLExecutionContext implements ExecutionContext {
             .orElse(eventEmitter.getParentJobName().orElse(eventEmitter.getApplicationJobName())),
         eventEmitter
             .getRootParentJobNamespace()
-            .orElse(eventEmitter.getParentJobNamespace().orElse(eventEmitter.getJobNamespace())));
+            .orElse(eventEmitter.getParentJobNamespace().orElse(eventEmitter.getJobNamespace())),
+        eventEmitter.getRootParentRunFacets().orElse(null),
+        eventEmitter.getRootParentJobFacets().orElse(null));
   }
 
   protected OpenLineage.JobBuilder buildJob() {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -107,6 +107,146 @@ class ArgumentParserTest {
   }
 
   @Test
+  void testLoadingSparkConfigFromContext() {
+    String context =
+        "{\"parent\":{"
+            + "\"run\":{\"runId\":\""
+            + RUN_ID
+            + "\"},"
+            + "\"job\":{\"namespace\":\""
+            + JOB_NAMESPACE
+            + "\",\"name\":\""
+            + JOB_NAME
+            + "\"},"
+            + "\"root\":{"
+            + "\"run\":{\"runId\":\""
+            + ROOT_PARENT_RUN_ID
+            + "\"},"
+            + "\"job\":{\"namespace\":\""
+            + ROOT_PARENT_JOB_NAMESPACE
+            + "\",\"name\":\""
+            + ROOT_PARENT_JOB_NAME
+            + "\"}}}}";
+
+    SparkConf sparkConf = new SparkConf().set(ArgumentParser.SPARK_CONF_CONTEXT, context);
+
+    config = ArgumentParser.parse(sparkConf);
+    assertEquals(JOB_NAMESPACE, config.getParentJobNamespace());
+    assertEquals(JOB_NAME, config.getParentJobName());
+    assertEquals(RUN_ID, config.getParentRunId());
+    assertEquals(ROOT_PARENT_JOB_NAME, config.getRootParentJobName());
+    assertEquals(ROOT_PARENT_JOB_NAMESPACE, config.getRootParentJobNamespace());
+    assertEquals(ROOT_PARENT_RUN_ID, config.getRootParentRunId());
+  }
+
+  @Test
+  void testContextTakesPrecedenceOverLegacyKeys() {
+    String contextJobNamespace = "context-namespace";
+    String contextJobName = "context-job";
+    String context =
+        "{\"parent\":{"
+            + "\"run\":{\"runId\":\""
+            + RUN_ID
+            + "\"},"
+            + "\"job\":{\"namespace\":\""
+            + contextJobNamespace
+            + "\",\"name\":\""
+            + contextJobName
+            + "\"}}}";
+
+    SparkConf sparkConf =
+        new SparkConf()
+            .set(ArgumentParser.SPARK_CONF_PARENT_JOB_NAMESPACE, JOB_NAMESPACE)
+            .set(ArgumentParser.SPARK_CONF_PARENT_JOB_NAME, JOB_NAME)
+            .set(ArgumentParser.SPARK_CONF_PARENT_RUN_ID, RUN_ID)
+            .set(ArgumentParser.SPARK_CONF_CONTEXT, context);
+
+    config = ArgumentParser.parse(sparkConf);
+    assertEquals(contextJobNamespace, config.getParentJobNamespace());
+    assertEquals(contextJobName, config.getParentJobName());
+  }
+
+  @Test
+  void testMalformedContextFallsBackToLegacyKeys() {
+    SparkConf sparkConf =
+        new SparkConf()
+            .set(ArgumentParser.SPARK_CONF_PARENT_JOB_NAMESPACE, JOB_NAMESPACE)
+            .set(ArgumentParser.SPARK_CONF_PARENT_JOB_NAME, JOB_NAME)
+            .set(ArgumentParser.SPARK_CONF_PARENT_RUN_ID, RUN_ID)
+            .set(ArgumentParser.SPARK_CONF_CONTEXT, "not valid json");
+
+    config = ArgumentParser.parse(sparkConf);
+    assertEquals(JOB_NAMESPACE, config.getParentJobNamespace());
+    assertEquals(JOB_NAME, config.getParentJobName());
+    assertEquals(RUN_ID, config.getParentRunId());
+  }
+
+  @Test
+  void testContextWithoutRoot() {
+    String context =
+        "{\"parent\":{"
+            + "\"run\":{\"runId\":\""
+            + RUN_ID
+            + "\"},"
+            + "\"job\":{\"namespace\":\""
+            + JOB_NAMESPACE
+            + "\",\"name\":\""
+            + JOB_NAME
+            + "\"}}}";
+
+    SparkConf sparkConf = new SparkConf().set(ArgumentParser.SPARK_CONF_CONTEXT, context);
+
+    config = ArgumentParser.parse(sparkConf);
+    assertEquals(JOB_NAMESPACE, config.getParentJobNamespace());
+    assertEquals(JOB_NAME, config.getParentJobName());
+    assertEquals(RUN_ID, config.getParentRunId());
+    assertThat(config.getRootParentJobName()).isNull();
+    assertThat(config.getRootParentJobNamespace()).isNull();
+    assertThat(config.getRootParentRunId()).isNull();
+  }
+
+  @Test
+  void testContextWithFacets() {
+    String context =
+        "{\"parent\":{"
+            + "\"run\":{\"runId\":\""
+            + RUN_ID
+            + "\",\"facets\":{\"processing_engine\":{\"version\":\"2.10.0\"}}},"
+            + "\"job\":{\"namespace\":\""
+            + JOB_NAMESPACE
+            + "\",\"name\":\""
+            + JOB_NAME
+            + "\",\"facets\":{\"jobType\":{\"processingType\":\"BATCH\",\"integration\":\"AIRFLOW\"}}}}}";
+
+    SparkConf sparkConf = new SparkConf().set(ArgumentParser.SPARK_CONF_CONTEXT, context);
+
+    config = ArgumentParser.parse(sparkConf);
+    assertThat(config.getParentRunFacets().getAdditionalProperties())
+        .containsKey("processing_engine");
+    assertThat(config.getParentJobFacets().getAdditionalProperties()).containsKey("jobType");
+  }
+
+  @Test
+  void testContextWithUnknownTopLevelKeysTolerated() {
+    String context =
+        "{\"someFutureField\":{\"anything\":\"goes\"},\"parent\":{"
+            + "\"run\":{\"runId\":\""
+            + RUN_ID
+            + "\"},"
+            + "\"job\":{\"namespace\":\""
+            + JOB_NAMESPACE
+            + "\",\"name\":\""
+            + JOB_NAME
+            + "\"}}}";
+
+    SparkConf sparkConf = new SparkConf().set(ArgumentParser.SPARK_CONF_CONTEXT, context);
+
+    config = ArgumentParser.parse(sparkConf);
+    assertEquals(JOB_NAMESPACE, config.getParentJobNamespace());
+    assertEquals(JOB_NAME, config.getParentJobName());
+  }
+
+  @Test
   @SuppressWarnings("ConstantConditions")
   void testConfToHttpConfig() {
     SparkConf sparkConf =

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -233,21 +233,60 @@ public class PlanUtils {
       UUID rootParentRunId,
       String rootParentJobName,
       String rootParentJobNamespace) {
+    return parentRunFacet(
+        parentRunId,
+        parentJobName,
+        parentJobNamespace,
+        null,
+        null,
+        rootParentRunId,
+        rootParentJobName,
+        rootParentJobNamespace,
+        null,
+        null);
+  }
+
+  /**
+   * Construct a {@link OpenLineage.ParentRunFacet} given the parent job's parentRunId, job name,
+   * and namespace, along with any facets forwarded via {@code spark.openlineage.context} for the
+   * parent and root run/job.
+   */
+  public static OpenLineage.ParentRunFacet parentRunFacet(
+      UUID parentRunId,
+      String parentJobName,
+      String parentJobNamespace,
+      OpenLineage.ParentRunFacetRunFacets parentRunFacets,
+      OpenLineage.ParentRunFacetJobFacets parentJobFacets,
+      UUID rootParentRunId,
+      String rootParentJobName,
+      String rootParentJobNamespace,
+      OpenLineage.RootRunFacets rootRunFacets,
+      OpenLineage.RootJobFacets rootJobFacets) {
     return new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI)
         .newParentRunFacetBuilder()
-        .run(new OpenLineage.ParentRunFacetRunBuilder().runId(parentRunId).build())
+        .run(
+            new OpenLineage.ParentRunFacetRunBuilder()
+                .runId(parentRunId)
+                .facets(parentRunFacets)
+                .build())
         .job(
             new OpenLineage.ParentRunFacetJobBuilder()
                 .name(NameNormalizer.normalize(parentJobName))
                 .namespace(parentJobNamespace)
+                .facets(parentJobFacets)
                 .build())
         .root(
             new OpenLineage.ParentRunFacetRootBuilder()
-                .run(new OpenLineage.RootRunBuilder().runId(rootParentRunId).build())
+                .run(
+                    new OpenLineage.RootRunBuilder()
+                        .runId(rootParentRunId)
+                        .facets(rootRunFacets)
+                        .build())
                 .job(
                     new OpenLineage.RootJobBuilder()
                         .namespace(rootParentJobNamespace)
                         .name(rootParentJobName)
+                        .facets(rootJobFacets)
                         .build())
                 .build())
         .build();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.api;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.dataset.DatasetConfig;
@@ -43,6 +44,10 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
   private String rootParentJobName;
   private String rootParentJobNamespace;
   private String rootParentRunId;
+  private OpenLineage.ParentRunFacetJobFacets parentJobFacets;
+  private OpenLineage.ParentRunFacetRunFacets parentRunFacets;
+  private OpenLineage.RootJobFacets rootParentJobFacets;
+  private OpenLineage.RootRunFacets rootParentRunFacets;
   private String overriddenAppName;
   private String overriddenApplicationRunId;
   private String testExtensionProvider;
@@ -71,6 +76,10 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       String rootParentJobName,
       String rootParentJobNamespace,
       String rootParentRunId,
+      OpenLineage.ParentRunFacetJobFacets parentJobFacets,
+      OpenLineage.ParentRunFacetRunFacets parentRunFacets,
+      OpenLineage.RootJobFacets rootParentJobFacets,
+      OpenLineage.RootRunFacets rootParentRunFacets,
       String overriddenAppName,
       String overriddenApplicationRunId,
       String testExtensionProvider,
@@ -93,6 +102,10 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     this.rootParentJobName = rootParentJobName;
     this.rootParentJobNamespace = rootParentJobNamespace;
     this.rootParentRunId = rootParentRunId;
+    this.parentJobFacets = parentJobFacets;
+    this.parentRunFacets = parentRunFacets;
+    this.rootParentJobFacets = rootParentJobFacets;
+    this.rootParentRunFacets = rootParentRunFacets;
     this.overriddenAppName = overriddenAppName;
     this.overriddenApplicationRunId = overriddenApplicationRunId;
     this.testExtensionProvider = testExtensionProvider;
@@ -181,6 +194,10 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
         mergePropertyWith(rootParentJobName, other.rootParentJobName),
         mergePropertyWith(rootParentJobNamespace, other.rootParentJobNamespace),
         mergePropertyWith(rootParentRunId, other.rootParentRunId),
+        mergePropertyWith(parentJobFacets, other.parentJobFacets),
+        mergePropertyWith(parentRunFacets, other.parentRunFacets),
+        mergePropertyWith(rootParentJobFacets, other.rootParentJobFacets),
+        mergePropertyWith(rootParentRunFacets, other.rootParentRunFacets),
         mergePropertyWith(overriddenAppName, other.overriddenAppName),
         mergePropertyWith(overriddenApplicationRunId, other.overriddenApplicationRunId),
         mergePropertyWith(testExtensionProvider, other.testExtensionProvider),


### PR DESCRIPTION
### One-line summary for changelog:
Add a generic JSON context payload for propagating parent-run information — `OPENLINEAGE_CONTEXT` env var for dbt, `spark.openlineage.context` config property for Spark — replacing the fragmented slash-delimited env var / six separate config keys with one consistent, extensible format.

### Meaningful description
Followup to [#4680](https://github.com/OpenLineage/OpenLineage/pull/4680), which added the optional `facets` field to `ParentRunFacet`. This PR implements the other half of [#4412](https://github.com/OpenLineage/OpenLineage/issues/4412): a standardized JSON payload, delivered through each integration's own natural config channel instead of ad-hoc, integration-specific formats.

The payload is intentionally a generic, top-level container (`{"parent": {...}}`) rather than a bare parent-run object — `parent` is the only key it carries today, but the format tolerates and can grow additional top-level keys later without any breaking change, since unknown keys are already ignored on both the Java and Python sides.

- **dbt**: `OPENLINEAGE_CONTEXT` env var, parsed in `get_parent_run_metadata_from_context()`. Checked first; falls back to the legacy `OPENLINEAGE_PARENT_ID`/`OPENLINEAGE_ROOT_PARENT_ID` env vars if absent or invalid. `ParentRunMetadata` extended to carry forwarded `facets` through to the emitted `ParentRunFacet`.
- **Spark**: `spark.openlineage.context` config property, parsed via a new `ParentRunContext` DTO reusing the generated `ParentRunFacetRun`/`Job`/`Root` classes. Same priority/fallback behavior against the six legacy `spark.openlineage.parent*`/`rootParent*` keys. `PlanUtils.parentRunFacet` and the three `buildApplicationParentFacet()` call sites were switched from flat factory methods to the builder pattern so forwarded facets can be threaded through without another breaking signature change.
- Malformed JSON or missing required fields log a warning and fall back to the legacy mechanism rather than raising; unknown top-level JSON keys are tolerated for forward compatibility.

related: #4412

### Checklist
- [x] AI was used in creating this PR