### PR TITLE
correctly exclude spark bumps that break the build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
     ignore:
       - dependency-name: "org.slf4j.slf4j-api"
       - dependency-name: "org.openapi.generator"
+      - dependency-name: "gradle-wrapper"
     # https://til.simonwillison.net/github/dependabot-python-setup
     groups:
       client/java:
@@ -85,10 +86,18 @@ updates:
       - dependency-name: "com.google.guava*"
       - dependency-name: "org.junit.jupiter:junit-jupiter"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter-api"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "org.junit:junit-bom"
         update-types: ["version-update:semver-major"]
       - dependency-name: "org.testcontainers:testcontainers-bom"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "gradle-wrapper"
+      - dependency-name: "com.google.cloud.spark:*bigquery*"
+      - dependency-name: "org.apache.kafka:kafka-clients"
+      - dependency-name: "org.jetbrains.kotlinx:kotlinx-serialization-json"
+      - dependency-name: "org.javassist:javassist"
+      - dependency-name: "plugin.serialization"
     groups:
       integration/spark:
         patterns:


### PR DESCRIPTION
## Summary
- The `integration/spark` and `client/java` Dependabot ignore blocks used `dependency-name: "gradle"` to suppress Gradle wrapper bumps, but Dependabot's actual dependency name for wrapper updates is `gradle-wrapper` — the rule never matched, so #4687 re-proposed the same gradle-wrapper 8.9 -> 9.x bump already reverted in #4658.
- Adds ignore rules matching the exclusions documented for #4658: `org.junit.jupiter:junit-jupiter-api` (semver-major), the bigquery connector artifacts, `kafka-clients`, and the Kotlin toolchain trio (`kotlinx-serialization-json`, `javassist`, `plugin.serialization`) that only compile against the newer Gradle-embedded Kotlin runtime.

## Test plan
- [ ] Confirm the next `integration/spark` Dependabot PR no longer includes gradle-wrapper, junit 6, bigquery 0.44.x, kafka-clients 4.3.x, or the Kotlin toolchain bumps