### PR TITLE
dbt: emit exposures as a dataset facet on dbt model datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * **Dbt: Capture incremental-strategy config and run-wide full_refresh** [`#4716`](https://github.com/OpenLineage/OpenLineage/pull/4716) [@himakolavennu](https://github.com/himakolavennu)
   *Capture how an incremental dbt model rebuilds data: a per-model `DbtIncrementalConfig` (strategy, unique key, incremental predicates, on-schema-change, microbatch parameters, partition_by, and a full_refresh override) on the `dbt_model` dataset facet, plus a run-wide `full_refresh` on `DbtRunRunFacet` read from `run_results.json` args (local/cloud) or the dbt command line (structured logs).*
+* **dbt: Emit exposures as a dataset facet on dbt model datasets** [`#4705`](https://github.com/OpenLineage/OpenLineage/pull/4705) [@himakolavennu](https://github.com/himakolavennu)
+  *Adds a `DbtExposuresDatasetFacet` attached to a built model's output and input datasets, listing the exposures that consume each (the input case covers source-backed exposures). Attached in both the classic (manifest/run_results) and structured-logs paths, on successful models only, letting consumers build TABLE → EXPOSURE lineage for dbt Core. Addresses [#926](https://github.com/OpenLineage/OpenLineage/issues/926).*
 
 ## [1.51.0](https://github.com/OpenLineage/OpenLineage/compare/1.50.0...1.51.0)
 

--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -171,6 +171,36 @@ class DbtModelDatasetFacet(DatasetFacet):
 
 
 @attr.define
+class DbtExposure:
+    """A single dbt exposure that depends on a dbt model.
+
+    Exposures are declared in dbt ``.yml`` files and describe downstream consumers of dbt
+    models (dashboards, notebooks, ML applications, ...). See
+    https://docs.getdbt.com/docs/build/exposures.
+    """
+
+    unique_id: str
+    name: str
+    type: str | None = attr.field(default=None)
+    url: str | None = attr.field(default=None)
+
+
+@attr.define
+class DbtExposuresDatasetFacet(DatasetFacet):
+    """Dataset facet listing the exposures that consume a dbt model's output dataset.
+
+    Attached to a model's output dataset when the model builds successfully, so consumers
+    can build TABLE -> EXPOSURE lineage without needing access to the manifest.
+    """
+
+    exposures: list[DbtExposure] = attr.field(factory=list)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return GITHUB_LOCATION + "dbt-exposures-dataset-facet.json"
+
+
+@attr.define
 class DbtNodeJobFacet(JobFacet):
     """Job facet containing dbt node metadata.
 

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -9,6 +9,7 @@ import logging
 from abc import abstractmethod
 from collections.abc import Sequence
 from enum import Enum
+from functools import cached_property
 from typing import Any
 
 import attr
@@ -35,6 +36,8 @@ from openlineage.client.facet_v2 import (
 )
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import (
+    DbtExposure,
+    DbtExposuresDatasetFacet,
     DbtIncrementalConfig,
     DbtModelConfig,
     DbtModelDatasetFacet,
@@ -192,6 +195,9 @@ class DbtArtifactProcessor:
         self.selector = selector
         self.manifest_version = None
         self.adapter_type: Adapter | None = None
+        # Populated by parse(); retained so manifest-declared exposures can be indexed
+        # and attached to the datasets they depend on.
+        self.manifest: dict[str, Any] = {}
 
     @property
     def dbt_run_metadata(self):
@@ -209,6 +215,7 @@ class DbtArtifactProcessor:
         Parse dbt manifest and run_result and produce OpenLineage events.
         """
         manifest, run_result, profile, catalog = self.get_dbt_metadata()
+        self.manifest = manifest
         self.manifest_version = self.get_schema_version(manifest)
 
         self.run_metadata = run_result["metadata"]
@@ -299,22 +306,29 @@ class DbtArtifactProcessor:
             output_node = nodes[name]
             started_at, completed_at = self.get_timings(run["timing"])
 
-            inputs = []
+            # (node_id, node) so exposures depending on an input can be looked up below.
+            inputs: list[tuple[str, ModelNode]] = []
             for node in context.manifest["parent_map"][run["unique_id"]]:
                 if node.startswith("model."):
                     inputs.append(
-                        ModelNode(
-                            type="model",
-                            metadata_node=nodes[node],
-                            catalog_node=get_from_nullable_chain(context.catalog, ["nodes", node]),
+                        (
+                            node,
+                            ModelNode(
+                                type="model",
+                                metadata_node=nodes[node],
+                                catalog_node=get_from_nullable_chain(context.catalog, ["nodes", node]),
+                            ),
                         )
                     )
                 elif node.startswith("source."):
                     inputs.append(
-                        ModelNode(
-                            type="source",
-                            metadata_node=context.manifest["sources"][node],
-                            catalog_node=get_from_nullable_chain(context.catalog, ["sources", node]),
+                        (
+                            node,
+                            ModelNode(
+                                type="source",
+                                metadata_node=context.manifest["sources"][node],
+                                catalog_node=get_from_nullable_chain(context.catalog, ["sources", node]),
+                            ),
                         )
                     )
 
@@ -377,6 +391,19 @@ class DbtArtifactProcessor:
                 if column_lineage:
                     output_dataset.facets["columnLineage"] = column_lineage  # type: ignore
 
+            # Attach exposures only for successful builds (FAIL emits no outputs, skipped
+            # nodes are filtered above).
+            succeeded = run["status"] == "success"
+            input_datasets = []
+            for node_id, input_node in inputs:
+                input_dataset = self.node_to_dataset(input_node, has_facets=True)
+                if succeeded:
+                    input_dataset.facets.update(self._exposures_facets(node_id))  # type: ignore
+                input_datasets.append(input_dataset)
+
+            if succeeded:
+                output_dataset.facets.update(self._exposures_facets(run["unique_id"]))  # type: ignore
+
             events.add(
                 self.to_openlineage_events(
                     run["status"],
@@ -384,7 +411,7 @@ class DbtArtifactProcessor:
                     completed_at,
                     self.get_run(run_id=run_id, query_id=query_id, run_facets=run_facets),
                     Job(namespace=self.job_namespace, name=job_name, facets=job_facets),
-                    [self.node_to_dataset(node, has_facets=True) for node in inputs],
+                    input_datasets,
                     output_dataset,
                 )
             )
@@ -1112,6 +1139,38 @@ class DbtArtifactProcessor:
 
     @abstractmethod
     def dbt_run_run_facet(self) -> dict[str, DbtRunRunFacet]: ...
+
+    def _exposures_manifest(self) -> dict:
+        """Manifest to read ``exposures`` from (overridden where it lives elsewhere)."""
+        return self.manifest
+
+    @cached_property
+    def _exposures_by_node_id(self) -> dict[str, list[DbtExposure]]:
+        """Exposures indexed by each node id in their ``depends_on.nodes``.
+
+        Lets a model's input/output datasets look up the exposures that consume them.
+        """
+        raw_exposures = self._exposures_manifest().get("exposures") or {}
+        index: dict[str, list[DbtExposure]] = collections.defaultdict(list)
+        for raw_exposure in raw_exposures.values():
+            exposure = DbtExposure(
+                unique_id=raw_exposure.get("unique_id"),
+                name=raw_exposure.get("name"),
+                type=raw_exposure.get("type"),
+                url=raw_exposure.get("url"),
+            )
+            for node_id in get_from_nullable_chain(raw_exposure, ["depends_on", "nodes"]) or []:
+                index[node_id].append(exposure)
+        return dict(index)
+
+    def _exposures_facets(self, node_id: str | None) -> dict[str, DbtExposuresDatasetFacet]:
+        """Exposures dataset facet for the dataset with this node id, or empty if none.
+
+        Applies to both a model's output and its inputs; the input case covers
+        source-backed exposures, since a source only ever appears as an input.
+        """
+        exposures = self._exposures_by_node_id.get(node_id) if node_id else None
+        return {"dbt_exposures": DbtExposuresDatasetFacet(exposures=exposures)} if exposures else {}
 
     def processing_engine_facet(self) -> dict[str, processing_engine_run.ProcessingEngineRunFacet]:
         dbt_version = self.run_metadata.get("dbt_version")

--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -227,6 +227,9 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         else:
             return {}
 
+    def _exposures_manifest(self) -> dict:
+        return self.compiled_manifest
+
     def parse(self) -> Generator[RunEvent, None, None]:  # type: ignore[override]
         """
         This executes the dbt command and parses the structured log events emitted.
@@ -506,10 +509,16 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         else:
             self.logger.info("Node %s has an unknown node status %s", node_unique_id, node_status)
 
-        inputs = [
-            self.node_to_dataset(node=model_input, has_facets=True)
-            for model_input in self._get_model_inputs(node_unique_id)
-        ]
+        # Attach exposures only on a successful (COMPLETE) build.
+        succeeded = event_type == RunState.COMPLETE
+        inputs = []
+        for model_input in self._get_model_inputs(node_unique_id):
+            input_dataset = self.node_to_dataset(node=model_input, has_facets=True)
+            if succeeded:
+                input_dataset.facets.update(  # type: ignore
+                    self._exposures_facets(model_input.metadata_node.get("unique_id"))
+                )
+            inputs.append(input_dataset)
         outputs = []
         if node := self._get_model_node(node_unique_id):
             output_dataset = self.node_to_output_dataset(node=node, has_facets=True)
@@ -521,6 +530,9 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
                     column_lineage = self.get_column_lineage(output_dataset.namespace, compiled_sql)
                     if column_lineage:
                         output_dataset.facets["columnLineage"] = column_lineage  # type: ignore
+
+                if succeeded:
+                    output_dataset.facets.update(self._exposures_facets(node_unique_id))  # type: ignore
             outputs = [output_dataset]
 
         if resource_type == "test":

--- a/integration/common/src/openlineage/common/schema/dbt-exposures-dataset-facet.json
+++ b/integration/common/src/openlineage/common/schema/dbt-exposures-dataset-facet.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/integration/common/openlineage/common/schema/dbt-exposures-dataset-facet.json",
+  "$defs": {
+    "DbtExposuresDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exposures": {
+              "type": "array",
+              "description": "The exposures that consume this dataset",
+              "items": {
+                "$ref": "#/$defs/DbtExposure"
+              }
+            }
+          },
+          "required": ["exposures"]
+        }
+      ],
+      "type": "object"
+    },
+    "DbtExposure": {
+      "type": "object",
+      "properties": {
+        "unique_id": {
+          "type": "string",
+          "description": "Unique identifier for the dbt exposure",
+          "example": "exposure.my_project.weekly_report"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the dbt exposure",
+          "example": "weekly_report"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the exposure as declared in dbt",
+          "example": "dashboard"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the downstream consumer the exposure points to",
+          "example": "https://bi.tool/dashboards/1"
+        }
+      },
+      "required": ["unique_id", "name"]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "dbt_exposures": {
+      "$ref": "#/$defs/DbtExposuresDatasetFacet"
+    }
+  }
+}

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -2323,3 +2323,152 @@ class TestFullRefreshFromCommandLine:
 
         facet = processor.dbt_run_run_facet()["dbt_run"]
         assert facet.full_refresh is True
+def _command_completed_event(path):
+    """Return the CommandCompleted dbt log event from a fixture list."""
+    events = yaml.safe_load(open(path))
+    return next(event for event in events if event["info"]["name"] == "CommandCompleted")
+
+
+def test_command_completed_no_longer_carries_exposures():
+    """Exposures used to be attached to the run wrapper COMPLETE event; they now live on
+    the model's output dataset instead (see test_node_finished_attaches_exposures_on_success_only
+    below), so CommandCompleted events must never carry a dbt_exposures run facet."""
+    processor = DbtStructuredLogsProcessor(
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="dbt-test-namespace",
+        project_dir=CURRENT_DIR,
+        target="postgres",
+        dbt_command_line=["dbt", "run"],
+    )
+    processor.dataset_namespace = "postgres://the-namespace"
+    processor.dbt_run_metadata = ParentRunMetadata(
+        run_id=DUMMY_UUID_4,
+        job_name="dbt-run-my-project",
+        job_namespace="dbt-test-namespace",
+    )
+    processor._compiled_manifest = {
+        "nodes": {
+            "model.p.orders": {"database": "db", "schema": "public", "name": "orders"},
+        },
+        "exposures": {
+            "exposure.p.dash": {
+                "unique_id": "exposure.p.dash",
+                "name": "dash",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["model.p.orders"]},
+            },
+        },
+    }
+
+    success_event = processor._parse_command_completed_event(
+        _command_completed_event(CURRENT_DIR + "/postgres/events/logs/successful_CommandCompleted.yaml")
+    )
+    assert "dbt_exposures" not in success_event.run.facets
+
+    failed_event = processor._parse_command_completed_event(
+        _command_completed_event(CURRENT_DIR + "/postgres/events/logs/failed_CommandCompleted.yaml")
+    )
+    assert "dbt_exposures" not in failed_event.run.facets
+
+
+def test_node_finished_attaches_exposures_on_success_only():
+    """The dbt_exposures dataset facet is attached to a model's output dataset when the
+    model builds successfully (COMPLETE), and omitted when it fails (FAIL)."""
+    processor = node_finished_processor()
+    processor._compiled_manifest["exposures"] = {
+        "exposure.jaffle_shop.dash": {
+            "unique_id": "exposure.jaffle_shop.dash",
+            "name": "dash",
+            "type": "dashboard",
+            "depends_on": {"nodes": ["model.jaffle_shop.orders"]},
+        },
+    }
+
+    success_event = processor.parse_node_finished_event(
+        node_finished_event(
+            unique_id="model.jaffle_shop.orders", resource_type="model", node_status="success"
+        )
+    )
+    success_output_facets = ol_event_to_dict(success_event)["outputs"][0]["facets"]
+    assert "dbt_exposures" in success_output_facets
+    facet = success_event.outputs[0].facets["dbt_exposures"]
+    assert [exposure.unique_id for exposure in facet.exposures] == ["exposure.jaffle_shop.dash"]
+
+    fail_event = processor.parse_node_finished_event(
+        node_finished_event(unique_id="model.jaffle_shop.orders", resource_type="model", node_status="fail")
+    )
+    fail_output_facets = ol_event_to_dict(fail_event)["outputs"][0]["facets"]
+    assert "dbt_exposures" not in fail_output_facets
+
+
+def test_node_finished_no_exposures_has_no_exposures_facet():
+    processor = node_finished_processor()
+
+    event = processor.parse_node_finished_event(
+        node_finished_event(
+            unique_id="model.jaffle_shop.orders", resource_type="model", node_status="success"
+        )
+    )
+    output_facets = ol_event_to_dict(event)["outputs"][0]["facets"]
+    assert "dbt_exposures" not in output_facets
+
+
+def test_node_finished_attaches_source_backed_exposure_to_input_on_success_only():
+    """A source-backed exposure (depends_on a source() the model reads) lands on the model's
+    INPUT dataset when the model builds successfully, and is omitted on failure. A
+    model-backed exposure still lands on the output."""
+    processor = node_finished_processor()
+    processor._compiled_manifest["sources"] = {
+        "source.jaffle_shop.raw.events": {
+            "database": "RAW",
+            "schema": "INGEST",
+            "alias": "events",
+            "name": "events",
+            "unique_id": "source.jaffle_shop.raw.events",
+            "columns": {},
+            "meta": {},
+            "tags": [],
+        },
+    }
+    processor._compiled_manifest["parent_map"]["model.jaffle_shop.orders"] = ["source.jaffle_shop.raw.events"]
+    processor._compiled_manifest["exposures"] = {
+        "exposure.jaffle_shop.model_dash": {
+            "unique_id": "exposure.jaffle_shop.model_dash",
+            "name": "model_dash",
+            "type": "dashboard",
+            "depends_on": {"nodes": ["model.jaffle_shop.orders"]},
+        },
+        "exposure.jaffle_shop.source_dash": {
+            "unique_id": "exposure.jaffle_shop.source_dash",
+            "name": "source_dash",
+            "type": "dashboard",
+            "depends_on": {"nodes": ["source.jaffle_shop.raw.events"]},
+        },
+    }
+
+    success_event = processor.parse_node_finished_event(
+        node_finished_event(
+            unique_id="model.jaffle_shop.orders", resource_type="model", node_status="success"
+        )
+    )
+
+    # Source-backed exposure lands on the input dataset.
+    assert len(success_event.inputs) == 1
+    input_facets = success_event.inputs[0].facets
+    assert "dbt_exposures" in input_facets
+    assert [e.unique_id for e in input_facets["dbt_exposures"].exposures] == [
+        "exposure.jaffle_shop.source_dash"
+    ]
+
+    # Model-backed exposure still lands on the output dataset.
+    output_facets = success_event.outputs[0].facets
+    assert [e.unique_id for e in output_facets["dbt_exposures"].exposures] == [
+        "exposure.jaffle_shop.model_dash"
+    ]
+
+    # On a failed build, nothing is attached to the input.
+    processor.node_id_to_inputs = {}
+    fail_event = processor.parse_node_finished_event(
+        node_finished_event(unique_id="model.jaffle_shop.orders", resource_type="model", node_status="fail")
+    )
+    assert "dbt_exposures" not in fail_event.inputs[0].facets

--- a/integration/common/tests/dbt/test_dbt_exposures.py
+++ b/integration/common/tests/dbt/test_dbt_exposures.py
@@ -1,0 +1,467 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from openlineage.client import set_producer
+from openlineage.client.serde import Serde
+from openlineage.common.provider.dbt.processor import DbtArtifactProcessor
+
+PRODUCER = "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_producer():
+    set_producer(PRODUCER)
+
+
+class _ConcreteDbtArtifactProcessor(DbtArtifactProcessor):
+    """Minimal concrete subclass so tests can exercise parse_execution().
+
+    ``dbt_run_run_facet`` and ``get_dbt_metadata`` are abstract on the base class (though
+    unenforced, since it's not an ABC); provide trivial implementations.
+    """
+
+    def dbt_run_run_facet(self):
+        return {}
+
+    def get_dbt_metadata(self):
+        raise NotImplementedError
+
+
+def _processor(manifest: dict) -> DbtArtifactProcessor:
+    processor = _ConcreteDbtArtifactProcessor(producer=PRODUCER, job_namespace="job-namespace")
+    processor.dataset_namespace = "snowflake://account"
+    processor.manifest = manifest
+    return processor
+
+
+def test_exposures_index_happy_path():
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "orders",
+                "alias": "orders_v2",
+            },
+            "model.proj.customers": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "customers",
+            },
+        },
+        "exposures": {
+            "exposure.proj.growth_dashboard": {
+                "unique_id": "exposure.proj.growth_dashboard",
+                "name": "growth_dashboard",
+                "type": "dashboard",
+                "url": "https://bi.tool/1",
+                "depends_on": {"nodes": ["model.proj.orders", "model.proj.customers"]},
+            },
+        },
+    }
+
+    index = _processor(manifest)._exposures_by_node_id
+
+    assert set(index) == {"model.proj.orders", "model.proj.customers"}
+
+    for node_id in ("model.proj.orders", "model.proj.customers"):
+        exposures = index[node_id]
+        assert len(exposures) == 1
+        exposure = exposures[0]
+        assert exposure.unique_id == "exposure.proj.growth_dashboard"
+        assert exposure.name == "growth_dashboard"
+        assert exposure.type == "dashboard"
+        assert exposure.url == "https://bi.tool/1"
+
+
+def test_exposures_index_indexes_source_dependencies_too():
+    # An exposure can depend directly on a source(), whose id lives under
+    # manifest["sources"] rather than manifest["nodes"]. We only need the raw node id
+    # to index by -- source-backed exposures are out of scope for attachment (sources
+    # only ever appear as inputs), but they must not break indexing of model deps.
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {"database": "mydb", "schema": "public", "name": "orders"},
+        },
+        "sources": {
+            "source.proj.raw.events": {"database": "rawdb", "schema": "ingest", "name": "events"},
+        },
+        "exposures": {
+            "exposure.proj.growth_dashboard": {
+                "unique_id": "exposure.proj.growth_dashboard",
+                "name": "growth_dashboard",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["model.proj.orders", "source.proj.raw.events"]},
+            },
+        },
+    }
+
+    index = _processor(manifest)._exposures_by_node_id
+    assert set(index) == {"model.proj.orders", "source.proj.raw.events"}
+    assert index["model.proj.orders"][0].unique_id == "exposure.proj.growth_dashboard"
+    assert index["source.proj.raw.events"][0].unique_id == "exposure.proj.growth_dashboard"
+
+
+def test_exposures_index_missing_nodes_are_still_indexed_by_id():
+    # An upstream node absent from the manifest (e.g. an ephemeral model) still gets
+    # indexed by its raw id -- we no longer need to resolve it to manifest metadata.
+    manifest = {
+        "nodes": {},
+        "exposures": {
+            "exposure.proj.e": {
+                "unique_id": "exposure.proj.e",
+                "name": "e",
+                "depends_on": {"nodes": ["model.proj.ephemeral"]},
+            },
+        },
+    }
+
+    index = _processor(manifest)._exposures_by_node_id
+    assert set(index) == {"model.proj.ephemeral"}
+    assert index["model.proj.ephemeral"][0].name == "e"
+
+
+def test_exposures_index_missing_depends_on():
+    manifest = {
+        "nodes": {},
+        "exposures": {
+            "exposure.proj.e": {"unique_id": "exposure.proj.e", "name": "e"},
+        },
+    }
+
+    index = _processor(manifest)._exposures_by_node_id
+    assert index == {}
+
+
+@pytest.mark.parametrize("manifest", [{"exposures": {}}, {"nodes": {}}, {}])
+def test_exposures_index_no_exposures_returns_empty(manifest):
+    assert _processor(manifest)._exposures_by_node_id == {}
+
+
+def test_exposures_index_type_and_url_are_optional():
+    manifest = {
+        "exposures": {
+            "exposure.proj.e": {
+                "unique_id": "exposure.proj.e",
+                "name": "e",
+                "depends_on": {"nodes": ["model.proj.orders"]},
+            },
+        },
+    }
+
+    exposure = _processor(manifest)._exposures_by_node_id["model.proj.orders"][0]
+    assert exposure.type is None
+    assert exposure.url is None
+
+
+def test_exposures_dataset_facet_serializes_to_expected_wire_shape():
+    from openlineage.common.provider.dbt.facets import DbtExposure, DbtExposuresDatasetFacet
+
+    facet = DbtExposuresDatasetFacet(
+        exposures=[
+            DbtExposure(
+                unique_id="exposure.proj.e",
+                name="e",
+                type="dashboard",
+            )
+        ]
+    )
+    serialized = Serde.to_dict(facet)
+
+    # _producer is always present; optional None fields (here: url) are dropped.
+    assert serialized["_producer"] == PRODUCER
+    assert serialized["exposures"] == [
+        {
+            "unique_id": "exposure.proj.e",
+            "name": "e",
+            "type": "dashboard",
+        }
+    ]
+
+
+def test_exposures_attached_to_output_dataset_on_successful_model():
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "orders",
+                "alias": "orders",
+                "resource_type": "model",
+                "columns": {},
+            },
+        },
+        "parent_map": {"model.proj.orders": []},
+        "exposures": {
+            "exposure.proj.growth_dashboard": {
+                "unique_id": "exposure.proj.growth_dashboard",
+                "name": "growth_dashboard",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["model.proj.orders"]},
+            },
+        },
+    }
+
+    context = _FakeRunContext(
+        manifest=manifest,
+        run_results={
+            "results": [
+                {
+                    "unique_id": "model.proj.orders",
+                    "status": "success",
+                    "timing": [],
+                    "adapter_response": {},
+                }
+            ]
+        },
+        catalog={},
+    )
+
+    processor = _processor(manifest)
+    processor.manifest_version = 12
+    events = processor.parse_execution(context, manifest["nodes"])
+
+    complete_event = events.completes[0]
+    output = complete_event.outputs[0]
+    assert "dbt_exposures" in output.facets
+    exposures = output.facets["dbt_exposures"].exposures
+    assert len(exposures) == 1
+    assert exposures[0].unique_id == "exposure.proj.growth_dashboard"
+
+
+def test_exposures_not_attached_when_model_has_no_exposures():
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "orders",
+                "alias": "orders",
+                "resource_type": "model",
+                "columns": {},
+            },
+        },
+        "parent_map": {"model.proj.orders": []},
+        "exposures": {},
+    }
+
+    context = _FakeRunContext(
+        manifest=manifest,
+        run_results={
+            "results": [
+                {
+                    "unique_id": "model.proj.orders",
+                    "status": "success",
+                    "timing": [],
+                    "adapter_response": {},
+                }
+            ]
+        },
+        catalog={},
+    )
+
+    processor = _processor(manifest)
+    processor.manifest_version = 12
+    events = processor.parse_execution(context, manifest["nodes"])
+
+    complete_event = events.completes[0]
+    output = complete_event.outputs[0]
+    assert "dbt_exposures" not in output.facets
+
+
+def test_source_backed_exposure_attached_to_input_dataset():
+    # A source-backed exposure depends on a source() that a model reads. The source only
+    # ever appears as an INPUT, so the facet must land on the input dataset (and NOT on the
+    # output, which the source-backed exposure does not depend on).
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "orders",
+                "alias": "orders",
+                "resource_type": "model",
+                "columns": {},
+            },
+        },
+        "sources": {
+            "source.proj.raw.events": {
+                "database": "rawdb",
+                "schema": "ingest",
+                "name": "events",
+                "resource_type": "source",
+                "columns": {},
+            },
+        },
+        "parent_map": {"model.proj.orders": ["source.proj.raw.events"]},
+        "exposures": {
+            "exposure.proj.source_dashboard": {
+                "unique_id": "exposure.proj.source_dashboard",
+                "name": "source_dashboard",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["source.proj.raw.events"]},
+            },
+        },
+    }
+
+    context = _FakeRunContext(
+        manifest=manifest,
+        run_results={
+            "results": [
+                {
+                    "unique_id": "model.proj.orders",
+                    "status": "success",
+                    "timing": [],
+                    "adapter_response": {},
+                }
+            ]
+        },
+        catalog={},
+    )
+
+    processor = _processor(manifest)
+    processor.manifest_version = 12
+    events = processor.parse_execution(context, manifest["nodes"])
+
+    complete_event = events.completes[0]
+
+    # The source-backed exposure lands on the input dataset.
+    assert len(complete_event.inputs) == 1
+    input_dataset = complete_event.inputs[0]
+    assert "dbt_exposures" in input_dataset.facets
+    input_exposures = input_dataset.facets["dbt_exposures"].exposures
+    assert [e.unique_id for e in input_exposures] == ["exposure.proj.source_dashboard"]
+
+    # The output dataset carries no exposures (nothing depends on the model itself).
+    assert "dbt_exposures" not in complete_event.outputs[0].facets
+
+
+def test_model_and_source_backed_exposures_split_across_output_and_input():
+    # A model-backed exposure lands on the output; a source-backed exposure lands on the
+    # input -- both for the same successful model build.
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "orders",
+                "alias": "orders",
+                "resource_type": "model",
+                "columns": {},
+            },
+        },
+        "sources": {
+            "source.proj.raw.events": {
+                "database": "rawdb",
+                "schema": "ingest",
+                "name": "events",
+                "resource_type": "source",
+                "columns": {},
+            },
+        },
+        "parent_map": {"model.proj.orders": ["source.proj.raw.events"]},
+        "exposures": {
+            "exposure.proj.model_dashboard": {
+                "unique_id": "exposure.proj.model_dashboard",
+                "name": "model_dashboard",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["model.proj.orders"]},
+            },
+            "exposure.proj.source_dashboard": {
+                "unique_id": "exposure.proj.source_dashboard",
+                "name": "source_dashboard",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["source.proj.raw.events"]},
+            },
+        },
+    }
+
+    context = _FakeRunContext(
+        manifest=manifest,
+        run_results={
+            "results": [
+                {
+                    "unique_id": "model.proj.orders",
+                    "status": "success",
+                    "timing": [],
+                    "adapter_response": {},
+                }
+            ]
+        },
+        catalog={},
+    )
+
+    processor = _processor(manifest)
+    processor.manifest_version = 12
+    events = processor.parse_execution(context, manifest["nodes"])
+
+    complete_event = events.completes[0]
+
+    output_exposures = complete_event.outputs[0].facets["dbt_exposures"].exposures
+    assert [e.unique_id for e in output_exposures] == ["exposure.proj.model_dashboard"]
+
+    input_exposures = complete_event.inputs[0].facets["dbt_exposures"].exposures
+    assert [e.unique_id for e in input_exposures] == ["exposure.proj.source_dashboard"]
+
+
+def test_source_backed_exposure_not_attached_on_failed_model():
+    manifest = {
+        "nodes": {
+            "model.proj.orders": {
+                "database": "mydb",
+                "schema": "public",
+                "name": "orders",
+                "alias": "orders",
+                "resource_type": "model",
+                "columns": {},
+            },
+        },
+        "sources": {
+            "source.proj.raw.events": {
+                "database": "rawdb",
+                "schema": "ingest",
+                "name": "events",
+                "resource_type": "source",
+                "columns": {},
+            },
+        },
+        "parent_map": {"model.proj.orders": ["source.proj.raw.events"]},
+        "exposures": {
+            "exposure.proj.source_dashboard": {
+                "unique_id": "exposure.proj.source_dashboard",
+                "name": "source_dashboard",
+                "type": "dashboard",
+                "depends_on": {"nodes": ["source.proj.raw.events"]},
+            },
+        },
+    }
+
+    context = _FakeRunContext(
+        manifest=manifest,
+        run_results={
+            "results": [
+                {
+                    "unique_id": "model.proj.orders",
+                    "status": "error",
+                    "timing": [],
+                    "adapter_response": {},
+                }
+            ]
+        },
+        catalog={},
+    )
+
+    processor = _processor(manifest)
+    processor.manifest_version = 12
+    events = processor.parse_execution(context, manifest["nodes"])
+
+    fail_event = events.fails[0]
+    assert "dbt_exposures" not in fail_event.inputs[0].facets
+
+
+class _FakeRunContext:
+    def __init__(self, manifest, run_results, catalog):
+        self.manifest = manifest
+        self.run_results = run_results
+        self.catalog = catalog


### PR DESCRIPTION
## Summary

Makes the OpenLineage dbt integration emit **exposures** — dbt's declared downstream
consumers (dashboards, notebooks, ML applications, …) — as a new `dbt_exposures`
**dataset facet**, attached to the model datasets each exposure depends on.

Addresses #926.

## What changed

- **`facets.py`** — new `DbtExposuresDatasetFacet(DatasetFacet)` listing the exposures
  (`unique_id`, `name`, optional `type`/`url`) that consume a dataset, mirroring the existing
  `DbtModelDatasetFacet`.
- **`schema/dbt-exposures-dataset-facet.json`** — JSON schema for the facet.
- **`processor.py`** — builds an inverse index (`node_id → exposures`) from
  `manifest["exposures"]` and attaches the facet, on a **successful build only**, to a model's
  **output** dataset and its **input** datasets. Attaching to inputs captures **source-backed**
  exposures (an exposure depending directly on a dbt `source`, which only ever appears as an
  input, never as a built output).
- **classic (`dbt/__init__.py`) & structured-logs (`structured_logs.py`) paths** — attach per
  model as it completes successfully.

## Why a dataset facet

Exposures describe a relationship to specific datasets, and lineage should reflect observed
data flow. Attaching per-dataset — only for datasets that participate in a successful run —
expresses `TABLE → EXPOSURE` as real lineage consumers accumulate across runs, rather than
dumping the whole manifest's exposure list on every run regardless of what executed.

## Tests

- `tests/dbt/test_dbt_exposures.py` — inverse-index construction; attachment to output
  (model-backed) and input (source-backed) datasets; success-only; absent when a model has no
  exposures or fails.
- `tests/dbt/structured_logs/test_structured_logs.py` — wiring: facet on the model's
  output/input on a successful `NodeFinished`, absent on failure, no longer on `CommandCompleted`.
