### PR TITLE
RFC: SemanticModelDatasetFacet — carry semantic-layer (OSI) metadata on datasets

### DIFF
--- a/spec/facets/SemanticModelDatasetFacet.json
+++ b/spec/facets/SemanticModelDatasetFacet.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/SemanticModelDatasetFacet.json",
+  "$defs": {
+    "SemanticModelDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "spec": {
+              "description": "Identifier of the semantic specification this model conforms to.",
+              "type": "string",
+              "example": "osi"
+            },
+            "specVersion": {
+              "description": "Version of the semantic specification the model conforms to.",
+              "type": "string",
+              "example": "0.1.0"
+            },
+            "modelUri": {
+              "description": "Reference to the source semantic model document. Full-fidelity definitions (including multi-dialect expressions) live here; the inline fields below are lightweight hints for consumers that do not resolve the model.",
+              "type": "string",
+              "example": "https://github.com/apache/ossie/blob/main/examples/tpcds/tpcds.osi.yaml"
+            },
+            "entity": {
+              "description": "Name of the logical entity/dataset in the semantic model that this physical dataset backs.",
+              "type": "string",
+              "example": "store_sales"
+            },
+            "metrics": {
+              "description": "Metrics defined on this entity. A lightweight projection of the semantic model for inline display; see modelUri for authoritative, dialect-aware definitions.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "total_sales"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "description": "Display-only expression. Not dialect-qualified; resolve modelUri for the full expression set.",
+                    "type": "string",
+                    "example": "SUM(ss_sales_price)"
+                  }
+                },
+                "required": ["name"]
+              }
+            },
+            "dimensions": {
+              "description": "Dimensions defined on this entity. A lightweight projection of the semantic model for inline display; see modelUri for authoritative, dialect-aware definitions.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "sold_date"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "isTime": {
+                    "description": "Whether this dimension is a time dimension.",
+                    "type": "boolean"
+                  },
+                  "expression": {
+                    "description": "Display-only expression. Not dialect-qualified; resolve modelUri for the full expression set.",
+                    "type": "string"
+                  }
+                },
+                "required": ["name"]
+              }
+            }
+          },
+          "required": ["spec", "entity"]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "semanticModel": {
+      "$ref": "#/$defs/SemanticModelDatasetFacet"
+    }
+  }
+}


### PR DESCRIPTION
> **Draft / RFC** — opened to seed cross-community discussion between OpenLineage and [Apache Ossie / Open Semantic Interchange (OSI)](https://github.com/apache/ossie). Not intended to merge as-is. Per `CONTRIBUTING.md`, adding a facet warrants prior discussion — this draft exists to make that discussion concrete. Happy to convert to / pair with a `proposal` issue.

## Motivation

OSI defines a vendor-neutral **semantic layer** (entities, dimensions, metrics, relationships) over physical tables. OpenLineage already names those same physical tables in its dataset identity. Today the two never meet: lineage consumers see the physical dataset but not what it *means*.

This facet lets an OpenLineage event attach OSI-style semantic definitions — or a reference to them — to the physical dataset it already names, so consumers can surface business meaning inline and, eventually, trace **metric-level lineage** down to raw sources.

## The identity tie-in

OSI identifies a physical asset via a dataset's `source` as `database.schema.table`, with **no** concept of the system/instance (which Snowflake account, which Postgres host). OpenLineage deliberately splits identity into `namespace` (the system/instance) + `name` (`database.schema.table`) — see the [naming spec](https://openlineage.io/docs/spec/naming). So OSI's `source` maps cleanly onto OpenLineage's `name`, and OpenLineage supplies the missing `namespace` half. This facet rides on a dataset that already carries both, which is exactly the identity gap worth aligning on across the two communities.

## Design notes / open questions

- **`modelUri` vs. inline** — OSI expressions are multi-dialect (`dialects: [{dialect, expression}]`). Rather than duplicate that fidelity in the facet, `modelUri` points at the authoritative model and the inline `metrics`/`dimensions` are lightweight, display-only projections. Open question: inline-only, ref-only, or both (current choice)?
- **`spec` field** — generalized beyond OSI (`spec: "osi"`) so the facet isn't locked to one semantic standard. Worth it, or over-generalized?
- **Versioning** — tagged `1-0-0` per SchemaVer but expect churn while under discussion.
- **Follow-ups if this direction lands** — client codegen (Java/Python) and website docs; omitted from this draft on purpose.

## Related

Cross-community thread on the Apache Ossie dev list: _(link to be added)_
