### PR TITLE
feat(python): Add new Datadog DCs

### DIFF
--- a/client/python/src/openlineage/client/transport/datadog.py
+++ b/client/python/src/openlineage/client/transport/datadog.py
@@ -25,6 +25,7 @@ SITE_MAPPING = {
     "us5.datadoghq.com": "https://data-obs-intake.us5.datadoghq.com",
     "datadoghq.eu": "https://data-obs-intake.datadoghq.eu",
     "ddog-gov.com": "https://data-obs-intake.ddog-gov.com",
+    "us2.ddog-gov.com": "https://data-obs-intake.us2.ddog-gov.com",
     "ap1.datadoghq.com": "https://data-obs-intake.ap1.datadoghq.com",
     "ap2.datadoghq.com": "https://data-obs-intake.ap2.datadoghq.com",
     "uk1.datadoghq.com": "https://data-obs-intake.uk1.datadoghq.com",

--- a/client/python/src/openlineage/client/transport/datadog.py
+++ b/client/python/src/openlineage/client/transport/datadog.py
@@ -27,6 +27,7 @@ SITE_MAPPING = {
     "ddog-gov.com": "https://data-obs-intake.ddog-gov.com",
     "ap1.datadoghq.com": "https://data-obs-intake.ap1.datadoghq.com",
     "ap2.datadoghq.com": "https://data-obs-intake.ap2.datadoghq.com",
+    "uk1.datadoghq.com": "https://data-obs-intake.uk1.datadoghq.com",
     "datad0g.com": "https://data-obs-intake.datad0g.com",
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->

Adds new UK1 and US2Fed Datadog DCs to available site list.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->

New Datadog sites (https://uk1.datadoghq.com/ and https://us2.ddog-gov.com/) have been turned-up recently. This adds them to the acceptable site list.