### PR TITLE
Skip dataset-version catalog lookup when facet is disabled

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.api;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.util.FacetUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +45,15 @@ public abstract class AbstractQueryPlanOutputDatasetBuilder<P extends LogicalPla
   }
 
   protected boolean includeDatasetVersion(SparkListenerEvent event) {
-    return event instanceof SparkListenerSQLExecutionEnd;
+    // Computing the dataset version can require an extra catalog lookup (for example, Iceberg's
+    // IcebergHandler#getDatasetVersion calls TableCatalog#loadTable()). When the datasetVersion
+    // facet is disabled, skip that lookup entirely instead of computing it and discarding the
+    // result at emit time - the extra load is not just wasted work, it can also race with a
+    // concurrent, not-yet-committed write and repopulate a catalog-side table cache with a stale
+    // pre-commit reference (see https://github.com/apache/iceberg/issues/10493 and
+    // https://github.com/OpenLineage/OpenLineage/issues/4040).
+    return event instanceof SparkListenerSQLExecutionEnd
+        && !FacetUtils.isFacetDisabled(context, "datasetVersion");
   }
 
   @Override


### PR DESCRIPTION
## What

`AbstractQueryPlanOutputDatasetBuilder#includeDatasetVersion(event)` currently only checks the Spark listener event type (`event instanceof SparkListenerSQLExecutionEnd`). It does not check `spark.openlineage.facets.disabled` before deciding whether to compute the `datasetVersion` facet. Every output-dataset builder that calls it (`AppendDataDatasetBuilder`, `DataSourceV2RelationOutputDatasetBuilder`, `CreateReplaceDatasetBuilder`, `TableContentChangeDatasetBuilder`, etc.) unconditionally pays the cost of computing the facet, which for catalog-backed tables (e.g. Iceberg via `IcebergHandler#getDatasetVersion`) means an extra `TableCatalog#loadTable()` call. `spark.openlineage.facets.disabled` only strips the already-computed facet at emit time, so disabling the facet today does not skip this extra catalog lookup.

This PR makes `includeDatasetVersion()` also check `FacetUtils.isFacetDisabled(context, "datasetVersion")`, mirroring the pattern already used for the `spark_unknown` facet in `AbstractQueryPlanDatasetBuilder`. When the facet is disabled, the lookup is skipped entirely instead of computed-then-discarded.

## Why

For catalogs that keep an in-memory table cache with a TTL (e.g. Iceberg's `CachingCatalog`), an extra `loadTable()` call issued while a write is in flight can race the write's commit: if the cache entry expires mid-write, the extra load reloads a pre-commit table reference and refills the cache, and because the commit doesn't invalidate the cache, a subsequent read in the same session can be served that stale pre-commit reference. This is a known Iceberg cache race (apache/iceberg#10493, closed `not_planned`) and a known OpenLineage issue (OpenLineage/OpenLineage#4040, open). Skipping the lookup when the resulting facet is disabled removes one trigger for that race without requiring a fix to the underlying cache itself.

## Trade-off worth flagging in review

This does not fix the root cache race — it only avoids one avoidable trigger for it (the lookup used solely to populate a facet nobody asked for). Users who explicitly disable the `datasetVersion` facet lose that facet's data entirely (they already do today, functionally, since it's stripped at emit — this PR just also removes the now-pointless lookup). This is scoped to the output-dataset path; input-side dataset-version lookups (if any exist) are not touched here.

## Testing

Not yet run locally in this environment — opening as a draft to get early feedback on the approach (gate the lookup on the disabled-facets config vs. an alternative like sourcing the version from the already-resolved plan `Table` instead of re-calling `loadTable()`, which would avoid data loss but touches more call sites). Happy to add a unit test on `AbstractQueryPlanOutputDatasetBuilder`/`IcebergHandlerTest` covering the disabled-facet case before this is ready for real review.