### PR TITLE
dbt: emit incremental-strategy config and run-wide full_refresh in OpenLineage facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.51.0...HEAD)
 
+### Added
+
+* **Dbt: Capture incremental-strategy config and run-wide full_refresh** [`#4716`](https://github.com/OpenLineage/OpenLineage/pull/4716) [@himakolavennu](https://github.com/himakolavennu)
+  *Capture how an incremental dbt model rebuilds data: a per-model `DbtIncrementalConfig` (strategy, unique key, incremental predicates, on-schema-change, microbatch parameters, partition_by, and a full_refresh override) on the `dbt_model` dataset facet, plus a run-wide `full_refresh` on `DbtRunRunFacet` read from `run_results.json` args (local/cloud) or the dbt command line (structured logs).*
+
 ## [1.51.0](https://github.com/OpenLineage/OpenLineage/compare/1.50.0...1.51.0)
 
 ### Added

--- a/integration/common/src/openlineage/common/provider/dbt/cloud.py
+++ b/integration/common/src/openlineage/common/provider/dbt/cloud.py
@@ -82,5 +82,6 @@ class DbtCloudArtifactProcessor(DbtArtifactProcessor):
                 profile_name=self.profile["name"],
                 dbt_runtime="cloud",
                 account_id=self.account_id,
+                full_refresh=self.full_refresh,
             )
         }

--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -55,10 +55,51 @@ class DbtRunRunFacet(BaseFacet):
     project_version: str | None = attr.field(default=None)
     profile_name: str | None = attr.field(default=None)
     account_id: str | None = attr.field(default=None)
+    # Run-wide --full-refresh flag for the invocation; None when it wasn't set.
+    full_refresh: bool | None = attr.field(default=None)
 
     @staticmethod
     def _get_schema() -> str:
         return GITHUB_LOCATION + "dbt-run-run-facet.json"
+
+
+@attr.define
+class DbtPartitionBy:
+    """A dbt ``partition_by`` config.
+
+    BigQuery expresses it as an object (``field``/``data_type``/``granularity``); Spark and
+    other adapters express it as a single column or a list of columns (``columns``).
+    Integer-range and ingestion-time partitioning details beyond these keys are not captured.
+    """
+
+    field: str | None = attr.field(default=None)
+    data_type: str | None = attr.field(default=None)
+    granularity: str | None = attr.field(default=None)
+    columns: list[str] | None = attr.field(default=None)
+
+
+@attr.define
+class DbtIncrementalConfig:
+    """How an incremental dbt model rebuilds data, from its resolved ``config``.
+
+    Populated only for ``materialized == "incremental"``; its presence marks the model
+    incremental even when no individual field is set.
+    """
+
+    # A None strategy means the adapter default; dbt omits it from the manifest.
+    strategy: str | None = attr.field(default=None)
+    unique_key: list[str] | None = attr.field(default=None)
+    # Config-declared SQL filters that bound the rows the merge scans
+    # (dbt ``incremental_predicates``, or the Spark ``predicates`` alias).
+    incremental_predicates: list[str] | None = attr.field(default=None)
+    on_schema_change: str | None = attr.field(default=None)
+    event_time: str | None = attr.field(default=None)
+    batch_size: str | None = attr.field(default=None)
+    begin: str | None = attr.field(default=None)
+    lookback: int | None = attr.field(default=None)
+    partition_by: DbtPartitionBy | None = attr.field(default=None)
+    # Per-model ``config.full_refresh`` override; the run-wide flag is a run-level concern.
+    full_refresh: bool | None = attr.field(default=None)
 
 
 @attr.define
@@ -73,6 +114,8 @@ class DbtModelConfig:
     access: str | None = attr.field(default=None)
     owner: str | None = attr.field(default=None)
     group: str | None = attr.field(default=None)
+    # Set only for materialized == "incremental"; presence marks the model incremental.
+    incremental: DbtIncrementalConfig | None = attr.field(default=None)
 
 
 @attr.define

--- a/integration/common/src/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/src/openlineage/common/provider/dbt/facets.py
@@ -65,11 +65,22 @@ class DbtRunRunFacet(BaseFacet):
 
 @attr.define
 class DbtPartitionBy:
-    """A dbt ``partition_by`` config.
+    """A dbt ``partition_by`` config for an incremental model.
 
-    BigQuery expresses it as an object (``field``/``data_type``/``granularity``); Spark and
-    other adapters express it as a single column or a list of columns (``columns``).
-    Integer-range and ingestion-time partitioning details beyond these keys are not captured.
+    Two mutually exclusive shapes, selected by adapter — a consumer should branch on
+    whichever group is present rather than expect both:
+
+    - **BigQuery** → ``field`` / ``data_type`` / ``granularity`` (object form); ``columns`` unset.
+    - **Spark / other adapters** → ``columns``; the BigQuery fields unset.
+
+    Integer-range and ingestion-time partitioning beyond these keys is not captured.
+
+    Fields:
+        field: BigQuery partition column. Example: ``"created_at"``.
+        data_type: BigQuery partition type — ``date``/``timestamp``/``datetime``/``int64``.
+            Example: ``"timestamp"``.
+        granularity: BigQuery time grain — ``hour``/``day``/``month``/``year``. Example: ``"day"``.
+        columns: Spark/other partition column(s). Example: ``["ds"]`` or ``["region", "ds"]``.
     """
 
     field: str | None = attr.field(default=None)
@@ -84,13 +95,39 @@ class DbtIncrementalConfig:
 
     Populated only for ``materialized == "incremental"``; its presence marks the model
     incremental even when no individual field is set.
+
+    Which fields are populated depends on ``strategy`` — a consumer should read them by
+    strategy:
+
+    - **all strategies:** ``strategy``, ``on_schema_change``, ``full_refresh``.
+    - **merge / delete+insert:** ``unique_key``, ``incremental_predicates``.
+    - **microbatch:** ``event_time``, ``batch_size``, ``begin``, ``lookback``.
+    - **insert_overwrite:** ``partition_by``.
+
+    Fields:
+        strategy: Incremental strategy — e.g. ``"merge"``, ``"append"``, ``"delete+insert"``,
+            ``"insert_overwrite"``, ``"microbatch"``. ``None`` means the adapter default
+            (dbt omits it from the manifest).
+        unique_key: Key column(s) used to match existing rows (merge / delete+insert).
+            Example: ``["id"]``.
+        incremental_predicates: Config-declared SQL filters that bound the rows the merge
+            scans (dbt ``incremental_predicates``, or the Spark ``predicates`` alias).
+            Example: ``["dbt_valid_to is null"]``.
+        on_schema_change: Reaction to source schema changes — ``ignore`` (default) /
+            ``append_new_columns`` / ``sync_all_columns`` / ``fail``.
+        event_time: (microbatch) timestamp column dbt batches on. Example: ``"event_ts"``.
+        batch_size: (microbatch) batch grain — ``hour``/``day``/``month``/``year``.
+        begin: (microbatch) lower bound for the first batch, ISO-8601 date or datetime.
+            Example: ``"2024-01-01"``.
+        lookback: (microbatch) number of prior batches to reprocess for late-arriving rows;
+            integer >= 0, default ``1``. Example: ``2``.
+        partition_by: (insert_overwrite) partition config; see ``DbtPartitionBy``.
+        full_refresh: Per-model ``config.full_refresh`` override. The run-wide
+            ``--full-refresh`` flag is a run-level concern on ``DbtRunRunFacet`` instead.
     """
 
-    # A None strategy means the adapter default; dbt omits it from the manifest.
     strategy: str | None = attr.field(default=None)
     unique_key: list[str] | None = attr.field(default=None)
-    # Config-declared SQL filters that bound the rows the merge scans
-    # (dbt ``incremental_predicates``, or the Spark ``predicates`` alias).
     incremental_predicates: list[str] | None = attr.field(default=None)
     on_schema_change: str | None = attr.field(default=None)
     event_time: str | None = attr.field(default=None)
@@ -98,7 +135,6 @@ class DbtIncrementalConfig:
     begin: str | None = attr.field(default=None)
     lookback: int | None = attr.field(default=None)
     partition_by: DbtPartitionBy | None = attr.field(default=None)
-    # Per-model ``config.full_refresh`` override; the run-wide flag is a run-level concern.
     full_refresh: bool | None = attr.field(default=None)
 
 

--- a/integration/common/src/openlineage/common/provider/dbt/local.py
+++ b/integration/common/src/openlineage/common/provider/dbt/local.py
@@ -304,5 +304,6 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
                 project_version=self.project_version,
                 profile_name=self.profile_name,
                 dbt_runtime="core",
+                full_refresh=self.full_refresh,
             )
         }

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -35,9 +35,11 @@ from openlineage.client.facet_v2 import (
 )
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import (
+    DbtIncrementalConfig,
     DbtModelConfig,
     DbtModelDatasetFacet,
     DbtNodeJobFacet,
+    DbtPartitionBy,
     DbtRunRunFacet,
     DbtVersionRunFacet,
     ParentRunMetadata,
@@ -185,6 +187,7 @@ class DbtArtifactProcessor:
         self.skip_errors = skip_errors
         self.run_metadata: dict[str, Any] = {}
         self.command = None
+        self.full_refresh: bool | None = None
         self.models = models or []
         self.selector = selector
         self.manifest_version = None
@@ -210,6 +213,7 @@ class DbtArtifactProcessor:
 
         self.run_metadata = run_result["metadata"]
         self.command = run_result["args"]["which"]
+        self.full_refresh = self._full_refresh_from_args(run_result["args"])
 
         self.extract_adapter_type(profile)
         self.extract_dataset_namespace(profile)
@@ -837,7 +841,8 @@ class DbtArtifactProcessor:
     def _create_dbt_model_dataset_facet(self, node: ModelNode) -> DbtModelDatasetFacet | None:
         """Build a DbtModelDatasetFacet from a dbt manifest node's resolved ``config``.
 
-        Reads ``materialized``/``access``/``owner``/``group`` from ``node.metadata_node["config"]``.
+        Reads ``materialized``/``access``/``owner``/``group`` from ``node.metadata_node["config"]``,
+        plus the incremental rebuild config for ``materialized == "incremental"`` models.
         Returns ``None`` when the node carries none of them, so we don't attach an empty facet.
         The node's ``meta`` map is emitted separately as tags (see ``_build_tags_run_facet``).
         """
@@ -848,10 +853,88 @@ class DbtArtifactProcessor:
             owner=raw_config.get("owner") or None,
             group=raw_config.get("group") or None,
         )
+        if model_config.materialized == "incremental":
+            model_config.incremental = self._build_incremental_config(raw_config)
         if not any(attr.astuple(model_config)):
             return None
 
         return DbtModelDatasetFacet(config=model_config)
+
+    def _build_incremental_config(self, raw_config: dict) -> DbtIncrementalConfig:
+        """Read the incremental rebuild config from a resolved dbt node ``config``.
+
+        Always returns a config object so the caller can use its presence to mark a model
+        incremental, even when no individual field is set.
+        """
+        strategy = raw_config.get("incremental_strategy") or None
+        incremental = DbtIncrementalConfig(
+            strategy=strategy,
+            unique_key=self._to_string_list(raw_config.get("unique_key")),
+            # incremental_predicates is the cross-adapter key; predicates is a Spark alias.
+            incremental_predicates=(
+                self._to_string_list(raw_config.get("incremental_predicates"))
+                or self._to_string_list(raw_config.get("predicates"))
+            ),
+            on_schema_change=raw_config.get("on_schema_change") or None,
+            partition_by=self._parse_partition_by(raw_config.get("partition_by")),
+        )
+        # Microbatch parameters apply only to the microbatch strategy. dbt resolves defaults
+        # (notably lookback=1) onto every model, so gate them to avoid emitting a phantom
+        # time window on merge/insert_overwrite models.
+        if strategy == "microbatch":
+            incremental.event_time = raw_config.get("event_time") or None
+            incremental.batch_size = raw_config.get("batch_size") or None
+            incremental.begin = raw_config.get("begin") or None
+            lookback = raw_config.get("lookback")
+            # bool is an int subclass; reject it so a stray true/false is not read as a count.
+            if isinstance(lookback, int) and not isinstance(lookback, bool):
+                incremental.lookback = lookback
+        full_refresh = raw_config.get("full_refresh")
+        if isinstance(full_refresh, bool):
+            incremental.full_refresh = full_refresh
+        return incremental
+
+    @staticmethod
+    def _full_refresh_from_args(args: dict) -> bool | None:
+        """Read the run-wide --full-refresh flag from run_results.json args.
+
+        Returns ``None`` when the flag is absent so the facet can omit it rather than
+        report a default the invocation never set.
+        """
+        value = args.get("full_refresh")
+        return value if isinstance(value, bool) else None
+
+    @staticmethod
+    def _to_string_list(raw: Any) -> list[str] | None:
+        """Normalize a dbt config value (single string, list, or None) into a list of strings.
+
+        Empty and non-string elements are dropped; returns ``None`` when nothing remains.
+        """
+        if isinstance(raw, str):
+            return [raw] if raw else None
+        if isinstance(raw, (list, tuple)):
+            values = [element for element in raw if isinstance(element, str) and element]
+            return values or None
+        return None
+
+    @staticmethod
+    def _parse_partition_by(raw: Any) -> DbtPartitionBy | None:
+        """Normalize dbt's polymorphic ``partition_by`` config.
+
+        BigQuery uses an object ({field, data_type, granularity}); Spark and other adapters use a
+        single column or a list of columns. Returns ``None`` when nothing is set.
+        """
+        if isinstance(raw, dict):
+            partition = DbtPartitionBy(
+                field=raw.get("field") or None,
+                data_type=raw.get("data_type") or None,
+                granularity=raw.get("granularity") or None,
+            )
+            if not any(attr.astuple(partition)):
+                return None
+            return partition
+        columns = DbtArtifactProcessor._to_string_list(raw)
+        return DbtPartitionBy(columns=columns) if columns else None
 
     @staticmethod
     def _meta_tag_value(value: Any) -> str:

--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -122,6 +122,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         super().__init__(*args, **kwargs)
 
         self.dbt_command_line: list[str] = dbt_command_line
+        # No run_results.json on the log-driven path; read the flag off the command line instead.
+        self.full_refresh = self._full_refresh_from_command_line(self.dbt_command_line)
         self.profiles_dir: str = get_dbt_profiles_dir(command=self.dbt_command_line)
         self.dbt_log_file_path: str = get_dbt_log_path(command=self.dbt_command_line)
         self.is_random_logfile: bool = is_random_logfile(command=self.dbt_command_line)
@@ -148,6 +150,22 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         self.processed_bytes = 0
 
         self.dbt_command_return_code = 0
+
+    @staticmethod
+    def _full_refresh_from_command_line(command_line: list[str]) -> bool | None:
+        """Detect the --full-refresh flag on the dbt command line.
+
+        dbt resolves --full-refresh / --no-full-refresh last-occurrence-wins, so the last
+        matching token decides. Returns ``None`` when neither is present so the facet omits
+        the flag rather than assuming a default.
+        """
+        full_refresh: bool | None = None
+        for token in command_line:
+            if token in ("--full-refresh", "-f"):
+                full_refresh = True
+            elif token == "--no-full-refresh":
+                full_refresh = False
+        return full_refresh
 
     @cached_property
     def dbt_command(self) -> str | None:
@@ -795,6 +813,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
                 project_version=self.project_version,
                 profile_name=self.profile_name,
                 dbt_runtime="core",
+                full_refresh=self.full_refresh,
             )
         }
 

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -2266,3 +2266,60 @@ class TestTestRunFacet:
         result = ol_event_to_dict(processor.parse_node_finished_event(event))
 
         assert "test" not in result["run"]["facets"]
+
+
+class TestFullRefreshFromCommandLine:
+    """Covers detecting the run-wide --full-refresh flag on the dbt command line,
+    the log-driven path's substitute for run_results.json args."""
+
+    def test_full_refresh(self):
+        assert (
+            DbtStructuredLogsProcessor._full_refresh_from_command_line(["dbt", "run", "--full-refresh"])
+            is True
+        )
+
+    def test_full_refresh_short_flag(self):
+        assert DbtStructuredLogsProcessor._full_refresh_from_command_line(["dbt", "run", "-f"]) is True
+
+    def test_no_full_refresh(self):
+        assert (
+            DbtStructuredLogsProcessor._full_refresh_from_command_line(["dbt", "run", "--no-full-refresh"])
+            is False
+        )
+
+    def test_last_flag_wins_no_then_full(self):
+        # dbt resolves the flag last-occurrence-wins
+        assert (
+            DbtStructuredLogsProcessor._full_refresh_from_command_line(
+                ["dbt", "run", "--no-full-refresh", "--full-refresh"]
+            )
+            is True
+        )
+
+    def test_last_flag_wins_full_then_no(self):
+        assert (
+            DbtStructuredLogsProcessor._full_refresh_from_command_line(
+                ["dbt", "run", "--full-refresh", "--no-full-refresh"]
+            )
+            is False
+        )
+
+    def test_absent(self):
+        assert DbtStructuredLogsProcessor._full_refresh_from_command_line(["dbt", "run"]) is None
+
+    def test_flag_flows_to_run_facet(self):
+        # end-to-end: the CLI flag is wired through to the emitted DbtRunRunFacet
+        processor = DbtStructuredLogsProcessor(
+            producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+            job_namespace="dbt-test-namespace",
+            project_dir=CURRENT_DIR,
+            target="postgres",
+            dbt_command_line=["dbt", "run", "--full-refresh"],
+        )
+        processor._dbt_invocation_id = "test-invocation-id"
+        processor.project_name = "jaffle_shop"
+        processor.project_version = "1.0.0"
+        processor.profile_name = "jaffle_shop"
+
+        facet = processor.dbt_run_run_facet()["dbt_run"]
+        assert facet.full_refresh is True

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -596,6 +596,135 @@ class TestDbtModelDatasetFacet:
         assert facets["dbt_model"].config.materialized == "table"
 
 
+class TestDbtIncrementalConfig:
+    """Covers the incremental rebuild config attached to the dbt_model facet for
+    ``materialized == "incremental"`` models."""
+
+    def _node(self, config):
+        from openlineage.common.provider.dbt.processor import ModelNode
+
+        base = {"database": "db", "schema": "sch", "alias": "orders", "columns": {}, "config": config}
+        return ModelNode(type="model", metadata_node=base)
+
+    def test_none_for_non_incremental_models(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(self._node({"materialized": "table"}))
+        assert facet.config.incremental is None
+
+    def test_present_even_when_no_fields_set(self, dbt_artifact_processor):
+        # presence alone marks the model incremental, mirroring the manifest
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node({"materialized": "incremental"})
+        )
+        incremental = facet.config.incremental
+        assert incremental is not None
+        assert incremental.strategy is None
+        assert incremental.unique_key is None
+
+    def test_extracts_merge_config(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node(
+                {
+                    "materialized": "incremental",
+                    "incremental_strategy": "merge",
+                    "unique_key": "id",
+                    "incremental_predicates": ["dbt_valid_to is null"],
+                    "on_schema_change": "append_new_columns",
+                }
+            )
+        )
+        incremental = facet.config.incremental
+        assert incremental.strategy == "merge"
+        assert incremental.unique_key == ["id"]
+        assert incremental.incremental_predicates == ["dbt_valid_to is null"]
+        assert incremental.on_schema_change == "append_new_columns"
+
+    def test_unique_key_list_preserved(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node({"materialized": "incremental", "unique_key": ["a", "", "b"]})
+        )
+        assert facet.config.incremental.unique_key == ["a", "b"]
+
+    def test_predicates_alias_fallback(self, dbt_artifact_processor):
+        # the Spark ``predicates`` alias is used only when incremental_predicates is absent
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node({"materialized": "incremental", "predicates": ["ds >= '2024-01-01'"]})
+        )
+        assert facet.config.incremental.incremental_predicates == ["ds >= '2024-01-01'"]
+
+    def test_microbatch_params_gated_to_microbatch(self, dbt_artifact_processor):
+        # a non-microbatch model with a resolved lookback default must not emit it
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node({"materialized": "incremental", "incremental_strategy": "merge", "lookback": 1})
+        )
+        assert facet.config.incremental.lookback is None
+        assert facet.config.incremental.event_time is None
+
+    def test_microbatch_params_captured(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node(
+                {
+                    "materialized": "incremental",
+                    "incremental_strategy": "microbatch",
+                    "event_time": "event_ts",
+                    "batch_size": "day",
+                    "begin": "2024-01-01",
+                    "lookback": 2,
+                }
+            )
+        )
+        incremental = facet.config.incremental
+        assert incremental.event_time == "event_ts"
+        assert incremental.batch_size == "day"
+        assert incremental.begin == "2024-01-01"
+        assert incremental.lookback == 2
+
+    def test_partition_by_bigquery_object(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node(
+                {
+                    "materialized": "incremental",
+                    "partition_by": {"field": "created_at", "data_type": "timestamp", "granularity": "day"},
+                }
+            )
+        )
+        partition = facet.config.incremental.partition_by
+        assert partition.field == "created_at"
+        assert partition.data_type == "timestamp"
+        assert partition.granularity == "day"
+        assert partition.columns is None
+
+    def test_partition_by_column_list(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node({"materialized": "incremental", "partition_by": ["ds", "region"]})
+        )
+        partition = facet.config.incremental.partition_by
+        assert partition.columns == ["ds", "region"]
+        assert partition.field is None
+
+    def test_full_refresh_override(self, dbt_artifact_processor):
+        facet = dbt_artifact_processor._create_dbt_model_dataset_facet(
+            self._node({"materialized": "incremental", "full_refresh": False})
+        )
+        assert facet.config.incremental.full_refresh is False
+
+
+class TestFullRefreshFromArgs:
+    """Covers the run-wide --full-refresh flag read from run_results.json args."""
+
+    def test_true(self, dbt_artifact_processor):
+        assert dbt_artifact_processor._full_refresh_from_args({"full_refresh": True}) is True
+
+    def test_false(self, dbt_artifact_processor):
+        assert dbt_artifact_processor._full_refresh_from_args({"full_refresh": False}) is False
+
+    def test_absent(self, dbt_artifact_processor):
+        assert dbt_artifact_processor._full_refresh_from_args({}) is None
+
+    def test_non_bool_ignored(self, dbt_artifact_processor):
+        # a stray non-boolean value must not be reported as a flag
+        assert dbt_artifact_processor._full_refresh_from_args({"full_refresh": "true"}) is None
+
+
 class TestDbtMetaTags:
     """Covers dbt ``tags`` (source DBT) and ``meta`` (source DBT_META) -> TagsRunFacet."""
 


### PR DESCRIPTION
## Problem

The `dbt_model` dataset facet captures per-model `config`/`meta`, but nothing about how an **incremental** model rebuilds data. Lineage consumers therefore can't tell whether a run rebuilt the whole table or just an incremental slice — which matters for scoping downstream work (e.g. data-quality checks) to what actually changed.

## Description

Adds incremental rebuild info to the dbt facets, in two parts:

**Per-model** — a new `DbtIncrementalConfig` on the `dbt_model` dataset facet, populated for `materialized == "incremental"` models (its presence marks the model incremental):
- `strategy`, `unique_key`, `incremental_predicates` (with the Spark `predicates` alias), `on_schema_change`
- microbatch params (`event_time`, `batch_size`, `begin`, `lookback`), gated to the `microbatch` strategy so a resolved default `lookback` isn't emitted on merge/insert_overwrite models
- `partition_by` (`DbtPartitionBy`: BigQuery `{field, data_type, granularity}` object, or Spark column list)
- a per-model `full_refresh` config override

**Run-wide** — a `full_refresh` field on `DbtRunRunFacet`, capturing the invocation's `--full-refresh` flag:
- `local` / `cloud`: read from `run_results.json` args
- `structured_logs`: detected from the dbt command line (no `run_results.json` on that path)

Unknown fields are ignored by existing consumers, so the change is additive.

## How was this patch tested?

Added unit tests in `test_processor.py` (per-model config extraction, `full_refresh` from args) and `structured_logs/test_structured_logs.py` (CLI flag detection, plus an end-to-end assertion that the flag reaches the emitted `DbtRunRunFacet`). Full `integration/common/tests/dbt/` suite passes; ruff check + format clean.