### PR TITLE
python: match tag keys case-insensitively in both directions

### DIFF
--- a/client/python/src/openlineage/client/client.py
+++ b/client/python/src/openlineage/client/client.py
@@ -555,7 +555,7 @@ class OpenLineageClient:
         """
 
         # Get tags from the facet that will not be updated (Do not have the same key as a user tag)
-        user_tag_keys = [tag.key for tag in user_tags]
+        user_tag_keys = [tag.key.lower() for tag in user_tags]
         keep_tags = []
         if tags_facet.tags is not None:
             keep_tags = [tag for tag in tags_facet.tags if tag.key.lower() not in user_tag_keys]
@@ -567,8 +567,8 @@ class OpenLineageClient:
             facet_tag_keys = {tag.key.lower(): tag.key for tag in tags_facet.tags}
 
         for user_tag in user_tags:
-            if user_tag.key in facet_tag_keys:
-                facet_tag_key = facet_tag_keys[user_tag.key]
+            if user_tag.key.lower() in facet_tag_keys:
+                facet_tag_key = facet_tag_keys[user_tag.key.lower()]
                 if user_tag.source == "USER":
                     log.info("Overriding integration-supplied tag `%s` with user-supplied tag", facet_tag_key)
                 user_tag.key = facet_tag_key

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -1436,6 +1436,33 @@ def test_client_keeps_key_case_for_existing_tags(transport, run_event_multi):
         assert event_tags == expected_tags
 
 
+def test_client_keeps_key_case_for_existing_tags_with_uppercase_user_key(transport, run_event_multi):
+    """
+    Tags set through config keep their case, so a user key can reach _update_tag_facet
+    uppercased. Matching against the facet must stay case-insensitive in that direction
+    too, otherwise the integration tag is neither dropped nor overridden and both end up
+    on the event.
+    """
+    config = {"tags": {"run": {"ENVIRONMENT": "PRODUCTION"}}}
+
+    run_event_multi.run.facets["tags"] = tags_run.TagsRunFacet(
+        tags=[tags_run.TagsRunFacetFields("environment", "STAGING", "INTEGRATION")]
+    )
+
+    expected_tags = [
+        tags_run.TagsRunFacetFields("environment", "PRODUCTION", "USER"),
+        tags_run.TagsRunFacetFields(
+            "openlineage_client_version", OPENLINEAGE_CLIENT_VERSION, "OPENLINEAGE_CLIENT"
+        ),
+    ]
+
+    client = OpenLineageClient(transport=transport, config=config)
+    client.emit(run_event_multi)
+
+    event_tags = sorted(transport.event.run.facets["tags"].tags, key=lambda x: x.key)
+    assert event_tags == sorted(expected_tags, key=lambda x: x.key)
+
+
 def test_client_creates_tag_facets_for_job_events(transport, job_event_multi):
     """
     Same code is used for run and job events to update facets. This just verifies


### PR DESCRIPTION
### One-line summary for changelog:

Fix tag key matching so a user tag supplied through config or `openlineage.yml` with a different case still overrides the integration-supplied tag instead of duplicating it.

### Meaningful description

`_update_tag_facet` lowercases only the facet side of the key comparison. Both checks read `tag.key.lower()` for the facet tags but compare against the user key as-is:

```python
user_tag_keys = [tag.key for tag in user_tags]
keep_tags = [t for t in tags_facet.tags if t.key.lower() not in user_tag_keys]

facet_tag_keys = {tag.key.lower(): tag.key for tag in tags_facet.tags}
for user_tag in user_tags:
    if user_tag.key in facet_tag_keys:
```

So the matching only works when the user's key already happens to be lowercase. With an uppercase user key both checks miss: the facet tag is not dropped from `keep_tags`, and the override loop never fires. The event ends up carrying two tags for the same logical key, with the stale integration value still among them.

```
facet 'ENVIRONMENT' + user 'environment'
    -> [('ENVIRONMENT', 'PRODUCTION')]

facet 'environment' + user 'ENVIRONMENT'
    -> [('environment', 'STAGING'), ('ENVIRONMENT', 'PRODUCTION')]
```

Same code, same input — only the casing differs. The first line is the control: that direction already behaves correctly.

**Why the existing coverage doesn't catch it.** Tags set through `OPENLINEAGE__TAGS__*` never reach this state, because `_insert_into_config` lowercases every key on that path. Tags set through `config=` or `openlineage.yml` keep their case, since `TagsConfig` stores the mapping as given — so an uppercase key reaches `_update_tag_facet` unchanged and then flows into `emit()`.

**The intended behaviour is already stated in the code.** The comment above the loop says *"This preserves case of the facet tag key while updating value and source"*, and `test_client_keeps_key_case_for_existing_tags` pins it: a facet tag keyed `PIPELINE` keeps its case when the user supplies `pipeline`. This change makes the opposite direction behave the same way. That test stays green.

The fix lowercases the user side in both places, matching the `tag.key.lower()` already used on the adjacent lines.

**Verification**

- New test fails on `main` and passes with the fix; the existing `test_client_keeps_key_case_for_existing_tags` passes both ways.
- `client/python`: 113 passed. One failure, `test_kafka_transport_configured_with_aliased_message_key`, is pre-existing — it fails identically on unmodified `main` with the same command (`confluent_kafka` isn't installed locally).
- `ruff check` and `ruff format --check` clean.

### Checklist
- [x] AI was used in creating this PR

To be precise about the extent, since AGENTS.md asks for disclosure and it helps you calibrate how closely to read this: the bug was found, the fix written, the repro run, and this description written by an AI coding agent (Claude Code) running on this account — the commit carries `Co-Authored-By: Claude <noreply@anthropic.com>` per AGENTS.md. Every figure above came from actually running the code rather than reading it, but the agent ran it, not a person. If this isn't the kind of contribution you want, say so and I'll close it.
