### PR TITLE
fix(common): use the dataset namespace for the SQL query externalQuery facet

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -694,7 +694,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
 
             if query_id := get_from_nullable_chain(event, ["data", "query_id"]):
                 run_facets["externalQuery"] = external_query_run.ExternalQueryRunFacet(
-                    externalQueryId=query_id, source="source"
+                    externalQueryId=query_id, source=self.dataset_namespace
                 )
 
         return generate_run_event(

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
@@ -180,7 +180,7 @@
         },
         "externalQuery": {
           "externalQueryId": "01bdd1f2-020e-223c-0046-e4070065a01a",
-          "source": "source"
+          "source": "postgres://postgres:5432"
         }
       }
     },


### PR DESCRIPTION
### One-line summary for changelog:

Use the dataset namespace for the SQL-query-level `externalQuery` facet in the dbt structured-logs processor, instead of a placeholder string.

### Meaningful description

#3953 settled that the dbt `externalQuery` facet's `source` is the **dataset** namespace rather than the job namespace, and changed `processor.py` accordingly. #4591 later added the same facet to the structured-logs processor. Its node-level site got the right value:

```python
# structured_logs.py:445
ExternalQueryRunFacet(externalQueryId=query_id, source=self.dataset_namespace)
```

but the SQL-query-level site kept a placeholder:

```python
# structured_logs.py:697
ExternalQueryRunFacet(externalQueryId=query_id, source="source")
```

That literal is neither namespace — it's the parameter's own name.

A single dbt run emits both facets, disagreeing with each other:

```
dataset_namespace = 'snowflake://mysnowflakeaccount.us-east-1.aws'

job='model.jaffle_shop.orders'        source = 'snowflake://mysnowflakeaccount.us-east-1.aws'   <- :445
job='model.jaffle_shop.orders.sql.1'  source = 'source'                                        <- :697
```

Both `processor.py:1010` and `structured_logs.py:445` pass `self.dataset_namespace`; `:697` was the odd one out.

### The fixture

The placeholder had been baked into the expected events, so this updates it to what the code now emits (`postgres://postgres:5432`). It's the only `"source": "source"` in the tree — the sibling fixtures hold `"bigquery"` and `"snowflake://mysnowflakeaccount.us-east-1.aws"`.

That fixture is also what pins this fix: reverting `source` back to `"source"` turns `test_parse_dbt_events[successful_SQLQueryStatus]` red again, so no extra test is needed.

### Verification

- Changing only the source (not the fixture) makes exactly one test fail, and it prints the real value: `expected 'source' → got 'postgres://postgres:5432'`.
- `tests/dbt`: 7 failed, 172 passed — **identical to baseline** on unmodified `main` with the same command; those 7 are pre-existing and unrelated.
- `tests/dbt/structured_logs`: 102 passed with the fix; 1 failed if I revert the source, which is the regression check above.
- `ruff check` clean.

### Checklist
- [x] AI was used in creating this PR

To be precise about the extent, since AGENTS.md asks: the bug was found, the fix written, the repro run, and this description written by an AI coding agent (Claude Code) running on this account — the commit carries `Co-Authored-By: Claude <noreply@anthropic.com>` per AGENTS.md and is signed off for DCO. Every figure above came from actually running the code rather than reading it, but the agent ran it, not a person.
