### PR TITLE
fix(common): separate the default spark port from the host

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -969,9 +969,9 @@ class DbtArtifactProcessor:
                 SparkConnectionMethod.HTTP.value,
                 SparkConnectionMethod.ODBC.value,
             ]:
-                port = "443"
+                port = ":443"
             elif profile["method"] == SparkConnectionMethod.THRIFT.value:
-                port = "10001"
+                port = ":10001"
 
             if profile["method"] in SparkConnectionMethod.methods():
                 return f"spark://{profile['host']}{port}"

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -159,6 +159,35 @@ def test_fabric_warehouse_namespace_with_port(dbt_artifact_processor):
     )
 
 
+@pytest.mark.parametrize(
+    "profile, expected",
+    [
+        # port given: the branch that already separates it with a colon
+        (
+            {"method": "http", "host": "myhost.databricks.com", "port": 443},
+            "spark://myhost.databricks.com:443",
+        ),
+        (
+            {"method": "thrift", "host": "myhost.databricks.com", "port": 10001},
+            "spark://myhost.databricks.com:10001",
+        ),
+        # port omitted: dbt-spark defaults it, so the profile has no port key
+        ({"method": "http", "host": "myhost.databricks.com"}, "spark://myhost.databricks.com:443"),
+        ({"method": "odbc", "host": "myhost.databricks.com"}, "spark://myhost.databricks.com:443"),
+        (
+            {"method": "thrift", "host": "myhost.databricks.com"},
+            "spark://myhost.databricks.com:10001",
+        ),
+    ],
+)
+def test_spark_namespace_separates_the_port(dbt_artifact_processor, profile, expected):
+    dbt_artifact_processor.adapter_type = Adapter.SPARK
+
+    dbt_artifact_processor.extract_dataset_namespace(profile)
+
+    assert dbt_artifact_processor.dataset_namespace == expected
+
+
 def test_extract_adapter_type_fabric(dbt_artifact_processor):
     # dbt-fabric profiles use `type: fabric`; the enum name must match so
     # `Adapter[type.upper()]` resolves it without NotImplementedError.


### PR DESCRIPTION
### One-line summary for changelog:

Separate the default spark port from the host when a dbt-spark profile omits `port`, so the dataset namespace is `spark://host:443` rather than `spark://host443`.

### Meaningful description

The three branches that build the port fragment disagree — the first inserts the separator, the two default-port branches don't:

```python
port = ""
if "port" in profile:
    port = f":{profile['port']}"
elif profile["method"] in [SparkConnectionMethod.HTTP.value, SparkConnectionMethod.ODBC.value]:
    port = "443"
elif profile["method"] == SparkConnectionMethod.THRIFT.value:
    port = "10001"
...
return f"spark://{profile['host']}{port}"
```

So omitting the port glues it to the host:

```
method=http,   port=443 given    ->  spark://myhost.databricks.com:443
method=thrift, port=10001 given  ->  spark://myhost.databricks.com:10001

method=http    (no port)         ->  spark://myhost.databricks.com443
method=odbc    (no port)         ->  spark://myhost.databricks.com443
method=thrift  (no port)         ->  spark://myhost.databricks.com10001
```

The first two rows are the control: same function, same call, only the presence of `port` differs.

### Why the default-port branches actually run

Omitting `port` is ordinary usage — dbt-spark declares it with a default:

```python
# dbt/adapters/spark/connections.py
class SparkCredentials(Credentials):
    ...
    port: int = 443
```

and this code reads `profiles.yml` directly, before dbt fills that default in:

```python
# provider/dbt/local.py
profile = self.load_yaml_with_jinja(os.path.join(profile_dir, "profiles.yml"))[self.profile_name]
```

so the key really is absent here and those branches really do execute.

### Why it wasn't caught

Every existing spark fixture sets an explicit port (`tests/dbt/spark/odbc/profiles.yml` has `port: 443`, `thrift` has `port: 10000`), so only the branch that already had the colon was covered. The new test parametrizes both — the explicit-port cases pin the behaviour that already worked.

### Verification

- New test: 3 of the 5 parameters fail on `main` (the ones omitting `port`), all 5 pass with the fix.
- `tests/dbt`: 7 failed, 177 passed — the 7 are **identical to baseline** on unmodified `main` with the same command (172 passed there; the +5 here are this PR's parameters).
- `ruff check` clean.

### Checklist
- [x] AI was used in creating this PR

To be precise about the extent, since AGENTS.md asks: the bug was found, the fix written, the repro run, and this description written by an AI coding agent (Claude Code) running on this account — the commit carries `Co-Authored-By: Claude <noreply@anthropic.com>` per AGENTS.md and is signed off for DCO. Every figure above came from actually running the code rather than reading it, but the agent ran it, not a person.
