### PR TITLE
fix(common): let the ~/.dbt profiles directory fallback run

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/local.py
+++ b/integration/common/src/openlineage/common/provider/dbt/local.py
@@ -289,8 +289,11 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
         """
         from_command = parse_single_arg(command, ["--profiles-dir"])
         from_env_var = os.getenv("DBT_PROFILES_DIR")
-        default_dir = "~/.dbt/"
-        current_working_directory = os.getcwd()
+        default_dir = os.path.expanduser("~/.dbt/")
+        # dbt only falls back to the working directory when it actually holds a
+        # profiles.yml, otherwise it uses default_dir.
+        cwd = os.getcwd()
+        current_working_directory = cwd if os.path.exists(os.path.join(cwd, "profiles.yml")) else None
         return from_command or from_env_var or current_working_directory or default_dir
 
     def dbt_run_run_facet(self) -> dict[str, DbtRunRunFacet]:

--- a/integration/common/src/openlineage/common/provider/dbt/utils.py
+++ b/integration/common/src/openlineage/common/provider/dbt/utils.py
@@ -84,8 +84,11 @@ def get_dbt_profiles_dir(command: list[str]) -> str:
     """
     from_command = parse_single_arg(command, ["--profiles-dir"])
     from_env_var = os.getenv("DBT_PROFILES_DIR")
-    default_dir = "~/.dbt/"
-    current_working_directory = os.getcwd()
+    default_dir = os.path.expanduser("~/.dbt/")
+    # dbt only falls back to the working directory when it actually holds a
+    # profiles.yml, otherwise it uses default_dir.
+    cwd = os.getcwd()
+    current_working_directory = cwd if os.path.exists(os.path.join(cwd, "profiles.yml")) else None
     return from_command or from_env_var or current_working_directory or default_dir
 
 

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +11,7 @@ from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import DbtRunRunFacet, DbtVersionRunFacet
 from openlineage.common.provider.dbt.processor import Adapter, DbtArtifactProcessor, DbtRunContext
 from openlineage.common.provider.dbt.utils import __version__ as openlineage_version
+from openlineage.common.provider.dbt.utils import get_dbt_profiles_dir
 
 DBT_VERSION = "0.0.1"
 JOB_NAMESPACE = "job-namespace"
@@ -186,6 +188,41 @@ def test_spark_namespace_separates_the_port(dbt_artifact_processor, profile, exp
     dbt_artifact_processor.extract_dataset_namespace(profile)
 
     assert dbt_artifact_processor.dataset_namespace == expected
+class TestGetDbtProfilesDir:
+    """dbt looks in the working directory only if it holds a profiles.yml, then ~/.dbt."""
+
+    def test_command_line_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DBT_PROFILES_DIR", str(tmp_path / "from_env"))
+        monkeypatch.chdir(tmp_path)
+
+        got = get_dbt_profiles_dir(["dbt", "run", "--profiles-dir", "/from/command"])
+
+        assert got == "/from/command"
+
+    def test_env_var_wins_over_working_directory(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DBT_PROFILES_DIR", "/from/env")
+        monkeypatch.chdir(tmp_path)
+
+        got = get_dbt_profiles_dir(["dbt", "run"])
+
+        assert got == "/from/env"
+
+    def test_working_directory_when_it_holds_a_profile(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DBT_PROFILES_DIR", raising=False)
+        (tmp_path / "profiles.yml").write_text("")
+        monkeypatch.chdir(tmp_path)
+
+        got = get_dbt_profiles_dir(["dbt", "run"])
+
+        assert got == str(tmp_path)
+
+    def test_default_directory_when_working_directory_has_no_profile(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DBT_PROFILES_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        got = get_dbt_profiles_dir(["dbt", "run"])
+
+        assert got == os.path.expanduser("~/.dbt/")
 
 
 def test_extract_adapter_type_fabric(dbt_artifact_processor):

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -188,6 +188,8 @@ def test_spark_namespace_separates_the_port(dbt_artifact_processor, profile, exp
     dbt_artifact_processor.extract_dataset_namespace(profile)
 
     assert dbt_artifact_processor.dataset_namespace == expected
+
+
 class TestGetDbtProfilesDir:
     """dbt looks in the working directory only if it holds a profiles.yml, then ~/.dbt."""
 


### PR DESCRIPTION
### One-line summary for changelog:

Let the `~/.dbt/` profiles-directory fallback actually run — it was unreachable because the working directory was returned unconditionally.

### Meaningful description

`get_dbt_profiles_dir` computes `default_dir` and then throws it away:

```python
from_command = parse_single_arg(command, ["--profiles-dir"])
from_env_var = os.getenv("DBT_PROFILES_DIR")
default_dir = "~/.dbt/"
current_working_directory = os.getcwd()
return from_command or from_env_var or current_working_directory or default_dir
```

`os.getcwd()` never returns an empty string, so the last term is unreachable:

```
cwd holds no profiles.yml   ->  '/tmp/tmpf48x1yxe'    <- never ~/.dbt
--profiles-dir given        ->  '/from/command'        <- fine
DBT_PROFILES_DIR set        ->  '/from/env'            <- fine
```

The first two terms do work, which is why this reads as the `or` chain's ordering rather than a deliberate decision to always use the cwd. The docstring points at [dbt's own rules](https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles#advanced-customizing-a-profile-directory), and dbt uses the working directory only when it actually holds a `profiles.yml` — otherwise `~/.dbt`.

### Why this matters for the case the fallback was added for

#4320 wired this up to *"find `profiles.yml` in a default fashion outlined by dbt"*, closing #4253 — dbt Fusion, whose `run_results.json` has no `profiles_dir` key. `local.py` only reaches this fallback when that key is missing, which for classic dbt it isn't, so the shadowing hides the problem there. For Fusion it isn't shadowed: a user with the standard `~/.dbt/profiles.yml` layout, running from anywhere else, still gets a `FileNotFoundError` even though dbt itself ran fine. `structured_logs.py` calls it unconditionally.

### The expanduser detail

`default_dir` is expanded at the source rather than at the call site, because `structured_logs.py` wraps the result in `os.path.expanduser` but `local.py` does not — returning a literal `"~"` would open nothing there. (That existing `expanduser` is also a hint that `~`-prefixed values were expected to come out of this function.)

The same function is duplicated in `local.py`; both are updated.

### Verification

- New `TestGetDbtProfilesDir` pins all four precedence rules. Three pass on `main` (the flag, the env var, and cwd-when-it-holds-a-profile) — they're the control; only the `~/.dbt` one fails, and passes with the fix.
- `tests/dbt`: 7 failed, 176 passed — the 7 are **identical to baseline** on unmodified `main` with the same command (172 passed there; the +4 here are this PR's tests).
- `ruff check` clean.

### Checklist
- [x] AI was used in creating this PR

To be precise about the extent, since AGENTS.md asks: the bug was found, the fix written, the repro run, and this description written by an AI coding agent (Claude Code) running on this account — the commit carries `Co-Authored-By: Claude <noreply@anthropic.com>` per AGENTS.md and is signed off for DCO. Every figure above came from running the code, not reading it, but the agent ran it, not a person. I haven't tested against a real dbt Fusion install — that part rests on #4253's description of its `run_results.json`.
