### PR TITLE
fix: apply removePath.pattern to RDD job datasets (#4719)

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -29,6 +29,7 @@ import io.openlineage.spark.agent.util.DatasetReducerUtils;
 import io.openlineage.spark.agent.util.FacetUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.RemovePathPatternUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.agent.util.StreamingContextUtils;
 import io.openlineage.spark.agent.vendor.gcp.facets.builder.GcpJobFacetBuilder;
@@ -425,16 +426,18 @@ class RddExecutionContext implements ExecutionContext {
 
   protected List<OpenLineage.OutputDataset> buildOutputs(
       List<URI> outputs, boolean withOutputStatistics) {
-    return DatasetReducerUtils.outputs(
+    return RemovePathPatternUtils.removeOutputsPathPattern(
         olContext,
-        outputs.stream()
-            .map(
-                d ->
-                    buildOutputDataset(
-                        d,
-                        withOutputStatistics
-                            && outputs.size() == 1)) // output statistics only for single output
-            .collect(Collectors.toList()));
+        DatasetReducerUtils.outputs(
+            olContext,
+            outputs.stream()
+                .map(
+                    d ->
+                        buildOutputDataset(
+                            d,
+                            withOutputStatistics
+                                && outputs.size() == 1)) // output statistics only for single output
+                .collect(Collectors.toList())));
   }
 
   protected OpenLineage.InputDataset buildInputDataset(
@@ -535,11 +538,13 @@ class RddExecutionContext implements ExecutionContext {
 
   protected List<OpenLineage.InputDataset> buildInputs(
       List<DatasetIdentifier> inputs, boolean withInputStatistics) {
-    return DatasetReducerUtils.inputs(
+    return RemovePathPatternUtils.removeInputsPathPattern(
         olContext,
-        inputs.stream()
-            .map(d -> buildInputDataset(d, withInputStatistics && inputs.size() == 1))
-            .collect(Collectors.toList()));
+        DatasetReducerUtils.inputs(
+            olContext,
+            inputs.stream()
+                .map(d -> buildInputDataset(d, withInputStatistics && inputs.size() == 1))
+                .collect(Collectors.toList())));
   }
 
   protected List<URI> findOutputs(RDD<?> rdd, JobConf jobConf) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -29,6 +29,7 @@ import io.openlineage.spark.agent.util.DatasetReducerUtils;
 import io.openlineage.spark.agent.util.FacetUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.RemovePathPatternUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.agent.util.StreamingContextUtils;
 import io.openlineage.spark.agent.vendor.gcp.facets.builder.GcpJobFacetBuilder;
@@ -429,16 +430,18 @@ class RddExecutionContext implements ExecutionContext {
 
   protected List<OpenLineage.OutputDataset> buildOutputs(
       List<URI> outputs, boolean withOutputStatistics) {
-    return DatasetReducerUtils.outputs(
+    return RemovePathPatternUtils.removeOutputsPathPattern(
         olContext,
-        outputs.stream()
-            .map(
-                d ->
-                    buildOutputDataset(
-                        d,
-                        withOutputStatistics
-                            && outputs.size() == 1)) // output statistics only for single output
-            .collect(Collectors.toList()));
+        DatasetReducerUtils.outputs(
+            olContext,
+            outputs.stream()
+                .map(
+                    d ->
+                        buildOutputDataset(
+                            d,
+                            withOutputStatistics
+                                && outputs.size() == 1)) // output statistics only for single output
+                .collect(Collectors.toList())));
   }
 
   protected OpenLineage.InputDataset buildInputDataset(
@@ -539,11 +542,13 @@ class RddExecutionContext implements ExecutionContext {
 
   protected List<OpenLineage.InputDataset> buildInputs(
       List<DatasetIdentifier> inputs, boolean withInputStatistics) {
-    return DatasetReducerUtils.inputs(
+    return RemovePathPatternUtils.removeInputsPathPattern(
         olContext,
-        inputs.stream()
-            .map(d -> buildInputDataset(d, withInputStatistics && inputs.size() == 1))
-            .collect(Collectors.toList()));
+        DatasetReducerUtils.inputs(
+            olContext,
+            inputs.stream()
+                .map(d -> buildInputDataset(d, withInputStatistics && inputs.size() == 1))
+                .collect(Collectors.toList())));
   }
 
   protected List<URI> findOutputs(RDD<?> rdd, JobConf jobConf) {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/RddExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/RddExecutionContextTest.java
@@ -1,0 +1,99 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link RddExecutionContext} applies {@code
+ * spark.openlineage.dataset.removePath.pattern} to inputs/outputs of RDD jobs, same as {@link
+ * OpenLineageRunEventBuilder} already does for non-RDD jobs. See
+ * https://github.com/OpenLineage/OpenLineage/issues/4719
+ */
+class RddExecutionContextTest {
+
+  private static final String REMOVE_PATH_PATTERN = "spark.openlineage.dataset.removePath.pattern";
+
+  private final OpenLineageContext olContext = mock(OpenLineageContext.class);
+  private final OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+  private final EventEmitter eventEmitter = mock(EventEmitter.class);
+  private final OpenLineageRunEventBuilder runEventBuilder =
+      new OpenLineageRunEventBuilder(olContext, mock(OpenLineageEventHandlerFactory.class));
+  private final RddExecutionContext context =
+      new RddExecutionContext(olContext, eventEmitter, runEventBuilder);
+
+  private SparkConf sparkConf;
+
+  @BeforeEach
+  void setup() {
+    sparkConf = mock(SparkConf.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(olContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(olContext.getOpenLineage()).thenReturn(openLineage);
+    when(olContext.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
+  }
+
+  @Test
+  void buildInputsRemovesConfiguredPathPatternForRddJobs() {
+    when(sparkConf.contains(REMOVE_PATH_PATTERN)).thenReturn(true);
+    when(sparkConf.get(REMOVE_PATH_PATTERN)).thenReturn("(?<remove>tmp)");
+
+    List<DatasetIdentifier> inputs =
+        Collections.singletonList(new DatasetIdentifier("/tmp/input.csv", "file"));
+
+    List<InputDataset> result = context.buildInputs(inputs, false);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getName()).isEqualTo("//input.csv");
+  }
+
+  @Test
+  void buildOutputsRemovesConfiguredPathPatternForRddJobs() {
+    when(sparkConf.contains(REMOVE_PATH_PATTERN)).thenReturn(true);
+    when(sparkConf.get(REMOVE_PATH_PATTERN)).thenReturn("(?<remove>tmp)");
+
+    List<URI> outputs = Collections.singletonList(URI.create("file:///tmp/output.csv"));
+
+    List<OutputDataset> result = context.buildOutputs(outputs, false);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getName()).isEqualTo("//output.csv");
+  }
+
+  @Test
+  void buildInputsLeavesNameUnchangedWhenPatternNotConfigured() {
+    when(sparkConf.contains(REMOVE_PATH_PATTERN)).thenReturn(false);
+
+    List<DatasetIdentifier> inputs =
+        Collections.singletonList(new DatasetIdentifier("/tmp/input.csv", "file"));
+
+    List<InputDataset> result = context.buildInputs(inputs, false);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getName()).isEqualTo("/tmp/input.csv");
+  }
+}


### PR DESCRIPTION
Fixes #4719

### One-line summary for changelog:
Apply `spark.openlineage.dataset.removePath.pattern` to datasets emitted for RDD jobs, matching behavior already present for SQL/DataFrame jobs.

### Meaningful description

**Root cause:** `RemovePathPatternUtils.removeInputsPathPattern`/`removeOutputsPathPattern` is only invoked from `OpenLineageRunEventBuilder.buildRun()` (`integration/spark/shared/.../lifecycle/OpenLineageRunEventBuilder.java`). `RddExecutionContext` (`integration/spark/app/.../lifecycle/RddExecutionContext.java`), which handles `RDD_JOB` events, builds its own inputs/outputs directly via `DatasetReducerUtils` in `buildInputs()`/`buildOutputs()` and never calls into `OpenLineageRunEventBuilder`, so it bypassed pattern removal entirely. This meant `spark.openlineage.dataset.removePath.pattern` had no effect for RDD-based jobs (e.g. `rdd().count()`), even though it worked correctly for SQL/DataFrame jobs, as reported in #4719.

**What changed:** Wrapped the return values of `RddExecutionContext.buildInputs()` and `buildOutputs()` with `RemovePathPatternUtils.removeInputsPathPattern(...)` / `removeOutputsPathPattern(...)`, mirroring the exact call pattern already used in `OpenLineageRunEventBuilder.buildRun()`. No other behavior was changed and no unrelated formatting/refactors were included.

**Test:** Added `integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/RddExecutionContextTest.java`, which instantiates `RddExecutionContext` directly (mocking `OpenLineageContext`/`SparkConf` with `spark.openlineage.dataset.removePath.pattern` configured) and asserts the pattern is applied to both inputs and outputs, plus a control case verifying names are left unchanged when the pattern isn't configured. I confirmed the new test fails against the pre-fix code (2 of 3 assertions fail, reproducing the bug) and passes after the fix.

**Test command + evidence:**

Pre-fix (temporarily reverted the source change, keeping only the new test):
```
$ ./gradlew :app:test --tests "io.openlineage.spark.agent.lifecycle.RddExecutionContextTest" --console=plain

RddExecutionContextTest > buildInputsRemovesConfiguredPathPatternForRddJobs() FAILED
    org.opentest4j.AssertionFailedError at RddExecutionContextTest.java:71
RddExecutionContextTest > buildInputsLeavesNameUnchangedWhenPatternNotConfigured() PASSED
RddExecutionContextTest > buildOutputsRemovesConfiguredPathPatternForRddJobs() FAILED
    org.opentest4j.AssertionFailedError at RddExecutionContextTest.java:84
3 tests completed, 2 failed
BUILD FAILED in 11s
```

Post-fix:
```
$ ./gradlew :app:test --tests "io.openlineage.spark.agent.lifecycle.RddExecutionContextTest" --console=plain

RddExecutionContextTest > buildInputsRemovesConfiguredPathPatternForRddJobs() PASSED
RddExecutionContextTest > buildInputsLeavesNameUnchangedWhenPatternNotConfigured() PASSED
RddExecutionContextTest > buildOutputsRemovesConfiguredPathPatternForRddJobs() PASSED
BUILD SUCCESSFUL in 18s
```

Full module unit test suite and linter, both green after the fix:
```
$ ./gradlew :app:test --console=plain
...
BUILD SUCCESSFUL in 3m 49s
76 actionable tasks: 3 executed, 73 up-to-date
(54 tests, 0 failed)

$ ./gradlew :app:spotlessJavaCheck --console=plain
...
BUILD SUCCESSFUL in 6s
```

### Checklist
- [x] AI was used in creating this PR

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.
