### PR TITLE
python: wait for all async HTTP events

### DIFF
--- a/client/python/src/openlineage/client/transport/async_http.py
+++ b/client/python/src/openlineage/client/transport/async_http.py
@@ -516,7 +516,7 @@ class AsyncHttpTransport(Transport):
 
     def _all_processed(self) -> bool:
         with self.event_lock:
-            return len(self.events) == 0
+            return self.event_stats["pending"] == 0
 
     def emit(self, event: Event) -> None:
         event_str = Serde.to_json(event)

--- a/client/python/tests/test_async_http.py
+++ b/client/python/tests/test_async_http.py
@@ -621,11 +621,16 @@ class TestAsyncHttpTransport:
         with closing_immediately(transport) as transport:
             assert transport._all_processed()  # No events
             request = Request("event-1", "", {})
+            duplicate = Request("event-1", "", {})
 
             transport._add_event(request)
+            transport._add_event(duplicate)
             assert not transport._all_processed()  # Pending event
 
             transport._mark_success(request)
+            assert not transport._all_processed()  # Duplicate event still pending
+
+            transport._mark_success(duplicate)
             assert transport._all_processed()  # All processed
 
 


### PR DESCRIPTION
### One-line summary for changelog:

Fix async HTTP transport shutdown so it waits for every queued event when multiple events share the same derived ID.

### Meaningful description

`AsyncHttpTransport` increments its pending counter for every queued request, but its event map stores only one entry per derived event ID. Multiple valid events can share an ID, such as repeated `RUNNING` events for the same run. When the first such event completed, it removed the shared map entry, causing `wait_for_completion()` to report success while another request was still pending.

Use the per-request pending counter as the completion invariant. Extend the existing completion test with two requests sharing an event ID to verify that processing only the first does not report completion.

This prevents graceful shutdown from finishing early and potentially abandoning an in-flight lineage event.

### Validation

- `uv run pytest tests/test_async_http.py -q` — 46 passed
- `uv run pytest tests/ --ignore=tests/test_http_integration.py` — 602 passed
- `uv run mypy src/openlineage/client/transport/async_http.py`
- `prek run --files client/python/src/openlineage/client/transport/async_http.py client/python/tests/test_async_http.py`

The Docker-backed HTTP integration test module was excluded locally because `docker-compose` is unavailable.

### Checklist

- [x] AI was used in creating this PR
