### PR TITLE
fix: make with_additional_properties() facets picklable (#4216)

### DIFF
--- a/client/python/src/openlineage/client/generated/base.py
+++ b/client/python/src/openlineage/client/generated/base.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar, cast
 
 import attr
 from openlineage.client.constants import DEFAULT_PRODUCER
-from openlineage.client.utils import RedactMixin
+from openlineage.client.utils import RedactMixin, add_additional_properties, reduce_with_additional_properties
 
 PRODUCER = DEFAULT_PRODUCER
 
@@ -88,23 +88,15 @@ class BaseFacet(RedactMixin):
 
     def with_additional_properties(self, **kwargs: Any) -> "BaseFacet":
         """Add additional properties to updated class instance."""
-        current_attrs = [a.name for a in attr.fields(self.__class__)]
+        return cast(BaseFacet, add_additional_properties(self, **kwargs))
 
-        new_class = attr.make_class(
-            self.__class__.__name__,
-            {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
-            bases=(self.__class__,),
-        )
-        new_class.__module__ = self.__class__.__module__
-        attrs = attr.fields(self.__class__)
-        for a in attrs:
-            if not a.init:
-                continue
-            attr_name = a.name  # To deal with private attributes.
-            init_name = a.alias
-            if init_name not in kwargs:
-                kwargs[init_name] = getattr(self, attr_name)
-        return cast(BaseFacet, new_class(**kwargs))
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Support pickling instances created via `with_additional_properties`.
+
+        `with_additional_properties` builds a new class at runtime, which the default pickling
+        mechanism can't resolve back to by name; see `reduce_with_additional_properties`.
+        """
+        return reduce_with_additional_properties(self)
 
     @staticmethod
     def _get_schema() -> str:

--- a/client/python/src/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/src/openlineage/client/generated/column_lineage_dataset.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, cast
 
 import attr
 from openlineage.client.generated.base import DatasetFacet
-from openlineage.client.utils import RedactMixin
+from openlineage.client.utils import RedactMixin, add_additional_properties, reduce_with_additional_properties
 
 
 @attr.define
@@ -40,23 +40,15 @@ class Fields(RedactMixin):
 
     def with_additional_properties(self, **kwargs: Any) -> "Fields":
         """Add additional properties to updated class instance."""
-        current_attrs = [a.name for a in attr.fields(self.__class__)]
+        return cast(Fields, add_additional_properties(self, **kwargs))
 
-        new_class = attr.make_class(
-            self.__class__.__name__,
-            {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
-            bases=(self.__class__,),
-        )
-        new_class.__module__ = self.__class__.__module__
-        attrs = attr.fields(self.__class__)
-        for a in attrs:
-            if not a.init:
-                continue
-            attr_name = a.name  # To deal with private attributes.
-            init_name = a.alias
-            if init_name not in kwargs:
-                kwargs[init_name] = getattr(self, attr_name)
-        return cast(Fields, new_class(**kwargs))
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Support pickling instances created via `with_additional_properties`.
+
+        `with_additional_properties` builds a new class at runtime, which the default pickling
+        mechanism can't resolve back to by name; see `reduce_with_additional_properties`.
+        """
+        return reduce_with_additional_properties(self)
 
 
 @attr.define
@@ -77,23 +69,15 @@ class InputField(RedactMixin):
 
     def with_additional_properties(self, **kwargs: Any) -> "InputField":
         """Add additional properties to updated class instance."""
-        current_attrs = [a.name for a in attr.fields(self.__class__)]
+        return cast(InputField, add_additional_properties(self, **kwargs))
 
-        new_class = attr.make_class(
-            self.__class__.__name__,
-            {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
-            bases=(self.__class__,),
-        )
-        new_class.__module__ = self.__class__.__module__
-        attrs = attr.fields(self.__class__)
-        for a in attrs:
-            if not a.init:
-                continue
-            attr_name = a.name  # To deal with private attributes.
-            init_name = a.alias
-            if init_name not in kwargs:
-                kwargs[init_name] = getattr(self, attr_name)
-        return cast(InputField, new_class(**kwargs))
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Support pickling instances created via `with_additional_properties`.
+
+        `with_additional_properties` builds a new class at runtime, which the default pickling
+        mechanism can't resolve back to by name; see `reduce_with_additional_properties`.
+        """
+        return reduce_with_additional_properties(self)
 
     @staticmethod
     def _get_schema() -> str:
@@ -118,20 +102,12 @@ class Transformation(RedactMixin):
 
     def with_additional_properties(self, **kwargs: Any) -> "Transformation":
         """Add additional properties to updated class instance."""
-        current_attrs = [a.name for a in attr.fields(self.__class__)]
+        return cast(Transformation, add_additional_properties(self, **kwargs))
 
-        new_class = attr.make_class(
-            self.__class__.__name__,
-            {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
-            bases=(self.__class__,),
-        )
-        new_class.__module__ = self.__class__.__module__
-        attrs = attr.fields(self.__class__)
-        for a in attrs:
-            if not a.init:
-                continue
-            attr_name = a.name  # To deal with private attributes.
-            init_name = a.alias
-            if init_name not in kwargs:
-                kwargs[init_name] = getattr(self, attr_name)
-        return cast(Transformation, new_class(**kwargs))
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Support pickling instances created via `with_additional_properties`.
+
+        `with_additional_properties` builds a new class at runtime, which the default pickling
+        mechanism can't resolve back to by name; see `reduce_with_additional_properties`.
+        """
+        return reduce_with_additional_properties(self)

--- a/client/python/src/openlineage/client/generated/job_dependencies_run.py
+++ b/client/python/src/openlineage/client/generated/job_dependencies_run.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, cast
 
 import attr
 from openlineage.client.generated.base import RunFacet
-from openlineage.client.utils import RedactMixin
+from openlineage.client.utils import RedactMixin, add_additional_properties, reduce_with_additional_properties
 
 
 @attr.define
@@ -63,23 +63,15 @@ class JobDependency(RedactMixin):
 
     def with_additional_properties(self, **kwargs: Any) -> "JobDependency":
         """Add additional properties to updated class instance."""
-        current_attrs = [a.name for a in attr.fields(self.__class__)]
+        return cast(JobDependency, add_additional_properties(self, **kwargs))
 
-        new_class = attr.make_class(
-            self.__class__.__name__,
-            {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
-            bases=(self.__class__,),
-        )
-        new_class.__module__ = self.__class__.__module__
-        attrs = attr.fields(self.__class__)
-        for a in attrs:
-            if not a.init:
-                continue
-            attr_name = a.name  # To deal with private attributes.
-            init_name = a.alias
-            if init_name not in kwargs:
-                kwargs[init_name] = getattr(self, attr_name)
-        return cast(JobDependency, new_class(**kwargs))
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Support pickling instances created via `with_additional_properties`.
+
+        `with_additional_properties` builds a new class at runtime, which the default pickling
+        mechanism can't resolve back to by name; see `reduce_with_additional_properties`.
+        """
+        return reduce_with_additional_properties(self)
 
     @staticmethod
     def _get_schema() -> str:

--- a/client/python/src/openlineage/client/generator/base.py
+++ b/client/python/src/openlineage/client/generator/base.py
@@ -152,6 +152,8 @@ def parse_and_generate(
                 "typing.Any",
                 "typing.cast",
                 "openlineage.client.constants.DEFAULT_PRODUCER",
+                "openlineage.client.utils.add_additional_properties",
+                "openlineage.client.utils.reduce_with_additional_properties",
             ],
         )
 

--- a/client/python/src/openlineage/client/generator/templates/dataclass.jinja2
+++ b/client/python/src/openlineage/client/generator/templates/dataclass.jinja2
@@ -163,23 +163,15 @@ class {{ class_name }}:
 {%- if additionalProperties == True %}
     def with_additional_properties(self, **kwargs: Any) -> "{{ class_name }}":
         """Add additional properties to updated class instance."""
-        current_attrs = [a.name for a in attr.fields(self.__class__)]
+        return cast({{ class_name }}, add_additional_properties(self, **kwargs))
 
-        new_class = attr.make_class(
-                self.__class__.__name__,
-                {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
-                bases=(self.__class__,),
-            )
-        new_class.__module__ = self.__class__.__module__
-        attrs = attr.fields(self.__class__)
-        for a in attrs:
-            if not a.init:
-                continue
-            attr_name = a.name  # To deal with private attributes.
-            init_name = a.alias
-            if init_name not in kwargs:
-                kwargs[init_name] = getattr(self, attr_name)
-        return cast({{ class_name }}, new_class(**kwargs))
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Support pickling instances created via `with_additional_properties`.
+
+        `with_additional_properties` builds a new class at runtime, which the default pickling
+        mechanism can't resolve back to by name; see `reduce_with_additional_properties`.
+        """
+        return reduce_with_additional_properties(self)
 {%- endif -%}
 {#- staticmethod serves as placeholder for static fields in child classes -#}
 {%- if _schemaURL %}

--- a/client/python/src/openlineage/client/utils.py
+++ b/client/python/src/openlineage/client/utils.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import importlib
 import logging
+import sys
 from typing import Any, ClassVar, cast
 
 import attr
 
 log = logging.getLogger(__name__)
+
+# Classes created by `add_additional_properties` via `attr.make_class`, keyed by the class they
+# extend and the set of extra field names added. Reusing the same class object for a given
+# (base class, extra fields) pair keeps repeated calls cheap and, more importantly, lets
+# pickled/unpickled instances (see `reduce_with_additional_properties`) compare equal to one
+# another.
+_DYNAMIC_ADDITIONAL_PROPERTIES_CLASSES: dict[tuple[type, frozenset[str]], type] = {}
 
 
 def import_from_string(path: str) -> type[Any]:
@@ -53,6 +61,84 @@ def deep_merge_dicts(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, 
         else:
             merged[k] = v
     return merged
+
+
+def _is_importable_class(cls: type) -> bool:
+    """Return whether `cls` can be found by pickle via its `__module__`/`__qualname__`."""
+    return getattr(sys.modules.get(cls.__module__), cls.__qualname__, None) is cls
+
+
+def add_additional_properties(instance: Any, **kwargs: Any) -> Any:
+    """Return a copy of ``instance`` with extra attributes added.
+
+    Backs the generated ``with_additional_properties`` methods. Builds (and caches, per class
+    and set of extra field names) a new ``attrs`` subclass at runtime via `attr.make_class` to
+    hold any keyword that isn't an existing field.
+    """
+    current_attrs = [a.name for a in attr.fields(instance.__class__)]
+    new_attr_names = frozenset(k for k in kwargs if k not in current_attrs)
+
+    cache_key = (instance.__class__, new_attr_names)
+    new_class = _DYNAMIC_ADDITIONAL_PROPERTIES_CLASSES.get(cache_key)
+    if new_class is None:
+        new_class = attr.make_class(
+            instance.__class__.__name__,
+            {k: attr.field(default=None) for k in new_attr_names},
+            bases=(instance.__class__,),
+        )
+        new_class.__module__ = instance.__class__.__module__
+        _DYNAMIC_ADDITIONAL_PROPERTIES_CLASSES[cache_key] = new_class
+
+    for a in attr.fields(instance.__class__):
+        if not a.init:
+            continue
+        attr_name = a.name  # To deal with private attributes.
+        init_name = a.alias
+        if init_name not in kwargs:
+            kwargs[init_name] = getattr(instance, attr_name)
+    return new_class(**kwargs)
+
+
+def reduce_with_additional_properties(instance: Any) -> tuple[Any, ...]:
+    """Generic ``__reduce__`` for classes generated with a ``with_additional_properties`` method.
+
+    That method builds a new class at runtime via `attr.make_class`. The new class shares its
+    name with the original, importable class but is never bound to it in the module namespace,
+    so pickle's default class lookup resolves to the original class instead and raises a
+    ``PicklingError``. When that's the case, reduce to a call that rebuilds the dynamic class
+    instead of referencing it directly.
+    """
+    cls = instance.__class__
+    if _is_importable_class(cls):
+        return cast("tuple[Any, ...]", object.__reduce__(instance))
+
+    base_cls = next(c for c in cls.__mro__[1:] if _is_importable_class(c))
+
+    # Walk back from `cls` to `base_cls`, recording the field names each dynamic class added
+    # on top of its parent, so they can be replayed in the same order on unpickling.
+    levels: list[frozenset[str]] = []
+    c = cls
+    while c is not base_cls:
+        parent = c.__bases__[0]
+        own_names = frozenset(a.name for a in attr.fields(c))
+        own_names -= frozenset(a.name for a in attr.fields(parent))
+        levels.append(own_names)
+        c = parent
+    levels.reverse()
+
+    kwargs = {a.alias: getattr(instance, a.name) for a in attr.fields(cls) if a.init}
+    return (_rebuild_with_additional_properties, (base_cls, kwargs, tuple(levels)))
+
+
+def _rebuild_with_additional_properties(
+    base_cls: type, kwargs: dict[str, Any], levels: tuple[frozenset[str], ...]
+) -> Any:
+    """Reconstruct an instance built by ``with_additional_properties``, used when unpickling."""
+    base_field_aliases = {a.alias for a in attr.fields(base_cls) if a.init}
+    instance = base_cls(**{k: v for k, v in kwargs.items() if k in base_field_aliases})
+    for level_names in levels:
+        instance = instance.with_additional_properties(**{k: kwargs[k] for k in level_names})
+    return instance
 
 
 class RedactMixin:

--- a/client/python/tests/test_facet_v2.py
+++ b/client/python/tests/test_facet_v2.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import pickle
 from unittest import mock
 
 from attr import asdict, define
@@ -258,6 +259,31 @@ def test_with_additional_properties_isinstance_works():
 
     assert isinstance(changed_facet, documentation_job.DocumentationJobFacet)
     assert isinstance(changed_facet, BaseFacet)
+
+
+def test_with_additional_properties_is_picklable():
+    """Regression test for https://github.com/OpenLineage/OpenLineage/issues/4216."""
+    documentation_facet = documentation_job.DocumentationJobFacet(description="desc")
+    changed_facet = documentation_facet.with_additional_properties(new_prop="new_value")
+
+    pickled = pickle.loads(pickle.dumps(changed_facet))  # noqa: S301
+
+    assert pickled == changed_facet
+    assert pickled.new_prop == "new_value"
+    assert isinstance(pickled, documentation_job.DocumentationJobFacet)
+
+
+def test_with_additional_properties_chained_is_picklable():
+    """Pickling should also work after multiple chained `with_additional_properties` calls."""
+    documentation_facet = documentation_job.DocumentationJobFacet(description="desc")
+    changed_facet = documentation_facet.with_additional_properties(new_prop="new_value")
+    changed_facet = changed_facet.with_additional_properties(other_prop="other_value")
+
+    pickled = pickle.loads(pickle.dumps(changed_facet))  # noqa: S301
+
+    assert pickled == changed_facet
+    assert pickled.new_prop == "new_value"
+    assert pickled.other_prop == "other_value"
 
 
 def test_facet_copy_serialization_base_facet():


### PR DESCRIPTION
closes: #4216

### One-line summary for changelog:
Fix `PicklingError` when pickling facets created via `with_additional_properties()`.

### Meaningful description

**Root cause:** `BaseFacet.with_additional_properties()` (and the identical pattern generated
for `Fields`/`InputField`/`Transformation` in `column_lineage_dataset.py` and `JobDependency` in
`job_dependencies_run.py`) builds a brand-new class at runtime via `attr.make_class(...)`. That
class shares its `__name__`/`__module__` with the original, importable class but is never bound
to that name in the module's namespace. When `pickle` tries to serialize an instance, it looks
the class up by `module.__dict__[qualname]`, finds the *original* class instead, and raises
`PicklingError: ... it's not the same object as ...`.

**What changed and why:**
- Added two small, generic helpers to `client/utils.py`: `add_additional_properties()` (the
  class-creation logic, now cached per `(base class, extra field names)` pair so repeated calls
  with the same extra fields reuse the same class object instead of creating a new one every
  time) and `reduce_with_additional_properties()` (a generic `__reduce__` implementation that,
  for these dynamically-created classes, reduces to a call which rebuilds the same dynamic class
  chain via `with_additional_properties()` on unpickling instead of referencing the
  non-importable class directly).
- Updated the code generator template (`generator/templates/dataclass.jinja2`) so every
  generated `with_additional_properties()` method delegates to `add_additional_properties()` and
  every such class also gets a `__reduce__` delegating to `reduce_with_additional_properties()`.
  This is templated/generated code (confirmed by actually running
  `client/python/src/openlineage/client/generator/generate.py`), so the fix is in the generator,
  not hand-patched into the generated output — the generated files
  (`generated/base.py`, `generated/column_lineage_dataset.py`, `generated/job_dependencies_run.py`)
  were regenerated from the updated template and are included in this PR.
- Because the dynamic class is now cached by `(class, extra-field-names)`, two facets built with
  the same additional properties compare `==` again after a pickle round-trip (attrs equality
  checks exact class identity), including through chained `with_additional_properties()` calls.

**Test evidence:**
- Added `test_with_additional_properties_is_picklable` and
  `test_with_additional_properties_chained_is_picklable` to
  `client/python/tests/test_facet_v2.py`, doing a `pickle.dumps`/`pickle.loads` round-trip on a
  facet built via `with_additional_properties()` (including a chained/nested call) and asserting
  equality with the original instance and no exception.
- Ran the full local test suite: `uv run pytest tests/` → **638 passed**.
- Ran `uv run ruff check .` and `uv run ruff format --check .` on the whole `client/python`
  package → all clean.
- Ran `uv run mypy src/` → same 19 pre-existing errors as on `main` (verified via `git stash`),
  none introduced by this change; the touched files (`utils.py`, `generated/base.py`) are clean.
- Manually verified `pickle.dumps`/`pickle.loads` round-trips (including nested
  `with_additional_properties()` calls and `copy.deepcopy`) for `JobFacet`, `DocumentationJobFacet`,
  and `column_lineage_dataset.Fields`.

### Checklist
- [x] AI was used in creating this PR

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.