### PR TITLE
fix(dbt): consume --openlineage-dbt-job-name in its `--opt=value` form

### DIFF
--- a/integration/common/src/openlineage/common/utils.py
+++ b/integration/common/src/openlineage/common/utils.py
@@ -143,7 +143,9 @@ def add_or_replace_command_line_option(
 
 
 def has_command_line_option(command_line: list[str], command_option: str) -> bool:
-    return command_option in command_line
+    # parse_single_arg accepts both `{key} {value}` and `{key}={value}`, so an
+    # option present in the inline form must be reported here too.
+    return any(arg == command_option or arg.startswith(f"{command_option}=") for arg in command_line)
 
 
 def remove_command_line_option(
@@ -153,14 +155,23 @@ def remove_command_line_option(
         return command_line
 
     command_line = list(command_line)
-    command_option_index = command_line.index(command_option)
+    command_option_index = next(
+        i
+        for i, arg in enumerate(command_line)
+        if arg == command_option or arg.startswith(f"{command_option}=")
+    )
+
+    # The inline `{key}={value}` form carries its value in the same token, so
+    # popping the option already removes the value.
+    inline_value = command_line[command_option_index].startswith(f"{command_option}=")
 
     # Remove the option itself
     command_line.pop(command_option_index)
 
-    # Optionally remove the value if requested and it exists
+    # Optionally remove the value if requested and it exists (space-separated form only)
     if (
         remove_value
+        and not inline_value
         and command_option_index < len(command_line)
         and not command_line[command_option_index].startswith("-")
     ):

--- a/integration/common/tests/test_utils.py
+++ b/integration/common/tests/test_utils.py
@@ -7,6 +7,7 @@ from openlineage.common.utils import (
     add_command_line_arg,
     add_or_replace_command_line_option,
     get_from_nullable_chain,
+    has_command_line_option,
     parse_multiple_args,
     parse_single_arg,
     remove_command_line_option,
@@ -166,6 +167,42 @@ def test_add_or_replace_command_line_option(command_line, option, replace_option
 def test_remove_command_line_option(command_line, command_option, expected_command_line):
     actual_command_line = remove_command_line_option(command_line, command_option)
     assert actual_command_line == expected_command_line
+
+
+@pytest.mark.parametrize(
+    "command_line, command_option, expected_command_line",
+    [
+        (
+            ["dbt", "run", "--openlineage-dbt-job-name", "myjob", "--select", "orders"],
+            "--openlineage-dbt-job-name",
+            ["dbt", "run", "--select", "orders"],
+        ),
+        (
+            ["dbt", "run", "--openlineage-dbt-job-name=myjob", "--select", "orders"],
+            "--openlineage-dbt-job-name",
+            ["dbt", "run", "--select", "orders"],
+        ),
+    ],
+    ids=["space_form", "equals_form"],
+)
+def test_remove_command_line_option_with_value(command_line, command_option, expected_command_line):
+    # parse_single_arg accepts both `{key} {value}` and `{key}={value}`, so the
+    # matching removal must strip the option in either form.
+    actual_command_line = remove_command_line_option(command_line, command_option, remove_value=True)
+    assert actual_command_line == expected_command_line
+
+
+@pytest.mark.parametrize(
+    "command_line, command_option, expected",
+    [
+        (["dbt", "run", "--openlineage-dbt-job-name", "myjob"], "--openlineage-dbt-job-name", True),
+        (["dbt", "run", "--openlineage-dbt-job-name=myjob"], "--openlineage-dbt-job-name", True),
+        (["dbt", "run", "--select", "orders"], "--openlineage-dbt-job-name", False),
+    ],
+    ids=["space_form", "equals_form", "absent"],
+)
+def test_has_command_line_option(command_line, command_option, expected):
+    assert has_command_line_option(command_line, command_option) is expected
 
 
 @pytest.mark.parametrize(

--- a/integration/dbt/tests/test_main.py
+++ b/integration/dbt/tests/test_main.py
@@ -34,6 +34,29 @@ def test_structured_logs(command_line: str, number_of_calls: int, monkeypatch):
 
 
 @pytest.mark.parametrize(
+    "job_name_args",
+    [
+        ["--openlineage-dbt-job-name", "myjob"],
+        ["--openlineage-dbt-job-name=myjob"],
+    ],
+    ids=["space_form", "equals_form"],
+)
+def test_main_strips_openlineage_job_name_before_dbt(job_name_args, monkeypatch):
+    # The dbt-ol-only --openlineage-dbt-job-name option must be consumed by the
+    # wrapper: whether it is passed as `--opt value` or `--opt=value`, it must not
+    # leak into the args handed to dbt (dbt exits non-zero on an unknown option).
+    mock_consume_local_artifacts = mock.MagicMock()
+    monkeypatch.setattr("openlineage.dbt.consume_local_artifacts", mock_consume_local_artifacts)
+    monkeypatch.setattr("sys.argv", ["dbt-ol", "run", *job_name_args, "--select", "orders"])
+
+    main()
+
+    passed_args = mock_consume_local_artifacts.call_args.kwargs["args"]
+    assert not any(arg.startswith("--openlineage-dbt-job-name") for arg in passed_args)
+    assert mock_consume_local_artifacts.call_args.kwargs["openlineage_job_name"] == "myjob"
+
+
+@pytest.mark.parametrize(
     "command_line, os_envs, function_kwargs",
     [
         (


### PR DESCRIPTION
### Problem

`parse_single_arg` documents and accepts an option in two forms — `--key value` and `--key=value`:

```python
def parse_single_arg(args, keys, default=None):
    """Values can be passed either as one argument {key}={value}, or two: {key} {value}"""
```

So `dbt-ol run --openlineage-dbt-job-name=myjob` is a valid way to set the job name, and `parse_single_arg` reads it correctly. But the removal side does not agree:

```python
def has_command_line_option(command_line, command_option):
    return command_option in command_line          # exact list-membership

def remove_command_line_option(command_line, command_option, remove_value=False):
    if not has_command_line_option(command_line, command_option):
        return command_line                        # ← returns args unchanged
```

`'--openlineage-dbt-job-name' in ['--openlineage-dbt-job-name=myjob', ...]` is `False`, so `remove_command_line_option(args, OPENLINEAGE_DBT_JOB_NAME_OPTION, remove_value=True)` in `openlineage/dbt/__init__.py` returns the args untouched. The dbt-ol-only option then survives into the command line handed to dbt, and dbt aborts:

```
Error: No such option '--openlineage-dbt-job-name'.
```

i.e. a job name passed in the inline form breaks the whole run, while the space-separated form works.

### Fix

Make `has_command_line_option` and `remove_command_line_option` recognize both `--opt` and `--opt=value`, matching the contract `parse_single_arg` already implements. For the inline form the value lives in the same token, so popping the option removes the value as well.

### Verification

- `test_has_command_line_option` / `test_remove_command_line_option_with_value` (in `integration/common`) cover both forms; the `equals_form` cases fail before this change and pass after.
- `test_main_strips_openlineage_job_name_before_dbt` (in `integration/dbt`) drives the real `main()` entry point and asserts the option no longer reaches the args passed downstream to dbt — this is the production path, and it fails on the `equals_form` case before the fix.
- `integration/common` suite: 286 passed, plus 7 pre-existing failures in `tests/dbt/test_dbt_local.py` that are unrelated to this change (facet-version drift in the checked-in event snapshots — they fail identically on `main`). `integration/dbt/tests/test_main.py`: 9 passed.
- End-to-end against the pinned `dbt-core`: `dbt run --openlineage-dbt-job-name=myjob` exits `2` with `Error: No such option '--openlineage-dbt-job-name'.`, confirming the leaked option does abort the run.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, wrote and ran the repro and the tests, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff — it was just done by the AI, not a person. If this isn't the kind of contribution you want, say so and I'll close it.*

