### PR TITLE
fix(client): do not recurse deep_merge_dicts into a non-dict value

### DIFF
--- a/client/python/src/openlineage/client/utils.py
+++ b/client/python/src/openlineage/client/utils.py
@@ -41,14 +41,12 @@ def deep_merge_dicts(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, 
 
     This function merges two dictionaries while handling nested dictionaries.
     For keys that exist in both dictionaries, the values from dict2 take precedence.
-    If a key exists in both dictionaries and the values are dictionaries themselves,
-    they are merged recursively.
-    This function merges only dictionaries. If key is of different type, e.g. list
-    it does not work properly.
+    Two values are merged recursively only when both of them are dictionaries;
+    otherwise the value from dict2 replaces the one from dict1.
     """
     merged = dict1.copy()
     for k, v in dict2.items():
-        if k in merged and isinstance(v, dict):
+        if k in merged and isinstance(v, dict) and isinstance(merged.get(k), dict):
             merged[k] = deep_merge_dicts(merged.get(k, {}), v)
         else:
             merged[k] = v

--- a/client/python/tests/test_utils.py
+++ b/client/python/tests/test_utils.py
@@ -58,6 +58,15 @@ def test_deep_merge_dicts_non_dict_values():
     assert deep_merge_dicts(dict1, dict2) == expected
 
 
+def test_deep_merge_dicts_scalar_replaced_by_dict():
+    # dict2's value takes precedence when the two sides are not both dicts;
+    # a scalar in dict1 must not be recursed into (it raised AttributeError).
+    dict1 = {"transport": "http"}
+    dict2 = {"transport": {"type": "console"}}
+    expected = {"transport": {"type": "console"}}
+    assert deep_merge_dicts(dict1, dict2) == expected
+
+
 def test_deep_merge_dicts_empty_dicts():
     dict1 = {}
     dict2 = {"a": 1}


### PR DESCRIPTION
### Problem

`deep_merge_dicts` recurses when the **dict2** value is a dict, but never checks that the **dict1** value is one too:

```python
if k in merged and isinstance(v, dict):
    merged[k] = deep_merge_dicts(merged.get(k, {}), v)
```

So when a key is a scalar in one config source and a mapping in another, it calls `deep_merge_dicts(scalar, dict)` → `scalar.copy()`:

```python
deep_merge_dicts({"transport": "http"}, {"transport": {"type": "console"}})
# AttributeError: 'str' object has no attribute 'copy'
```

This is reachable from `OpenLineageClient` config loading (`client.py`), which merges the YAML config file, the constructor-supplied dict, and the env-var config. A misconfiguration like `transport: http` in `openlineage.yml` (instead of `transport: {type: http}`) combined with an overlapping mapping from another source raises this opaque `AttributeError` — and it happens *before* the `try/except` that is meant to turn config problems into a clean `ValueError("Failed to parse OpenLineage config.")`, so the user sees the raw crash.

### Fix

Recurse only when **both** sides are dicts; otherwise dict2's value replaces dict1's, which is exactly the documented "values from dict2 take precedence" behavior. The docstring is updated accordingly (it previously said keys of a different type "do not work properly").

`test_deep_merge_dicts_scalar_replaced_by_dict` covers the crash case; the existing `test_utils.py` cases and the `test_client.py` config-loading tests stay green (123 passed; the one unrelated failure needs the optional kafka extra).

An identical copy of `deep_merge_dicts` lives in `client/generator/base.py` (build-time codegen over trusted spec files — not reachable with this input); I left it untouched to keep the change scoped, but happy to sync it if you'd prefer.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, on this account) — an AI found the bug, wrote the fix and test, and ran the verification; the human account holder reviews every change and is accountable for it. It is real and re-runnable from the diff.*

