### PR TITLE
fix(common): resolve dbt test seed inputs by alias, not logical name

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -540,7 +540,7 @@ class DbtArtifactProcessor:
                 continue
             parent_node = manifest_nodes.get(parent_id)
             if parent_node:
-                ptype = "model" if parent_id.startswith("model.") else "source"
+                ptype = "source" if parent_id.startswith("source.") else "model"
                 ns, nm, _, _ = self.extract_dataset_data(
                     ModelNode(type=ptype, metadata_node=parent_node), None, has_facets=False
                 )

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -417,6 +417,21 @@ class TestParseSingularTests:
         assert assertion.success is True
         assert assertion.column is None
 
+    def test_seed_parent_resolves_to_alias_not_name(self, processor):
+        """A seed materializes as a real table addressed by its alias, like a
+        model -- only true sources are addressed by their logical name."""
+        manifest_nodes = {
+            "seed.project.raw_customers": {
+                "name": "raw_customers",
+                "alias": "customers_physical",
+                "database": "db",
+                "schema": "public",
+            },
+        }
+        parent_map = {"test.project.assert_seed": ["seed.project.raw_customers"]}
+        inputs = processor._resolve_test_inputs("test.project.assert_seed", parent_map, manifest_nodes)
+        assert [i.name for i in inputs] == ["db.public.customers_physical"]
+
 
 class TestParseFailures:
     """Tests for failure-count extraction in parse_assertions (generic tests)."""


### PR DESCRIPTION
### Problem

`_resolve_test_inputs` (added in #4449) resolves the input datasets for a singular dbt test. It admits `model.`/`source.`/`seed.` parents but then classifies every non-`model.` parent as `"source"`:

```python
ptype = "model" if parent_id.startswith("model.") else "source"
```

`extract_dataset_data` reads `metadata_node["name"]` when `type == "source"` and `["alias"]` otherwise. A **seed** materializes as a real warehouse table addressed by its **alias** (like a model) — only true `source.` nodes are addressed by their logical `name` (and in every real manifest, source nodes carry no `alias` key at all, which is exactly why that branch reads `name`). So a singular test that `ref()`s a seed with a custom alias emits an input dataset pointing at the seed's logical name instead of its physical table.

Driving the real method:

```
seed parent (name=raw_customers, alias=customers_physical)
  -> db.public.raw_customers        # before (logical name)
  -> db.public.customers_physical   # after  (physical table)
model parent  -> db.public.<alias>  # unchanged
source parent -> db.public.<name>   # unchanged
```

### Fix

Classify only `source.` as `"source"`; `model.` and `seed.` resolve by alias. This lines up with the sibling classifiers in `parse_test` and the classic `parse_execution` input path, which already keep seeds out of the `source` branch.

### Reachability & scope

Reachable via `dbt-ol test` when a singular test (plain-SQL test, no `test_metadata`) `ref()`s a seed that has a custom `alias`. Seed dependencies do land in a test's `parent_map` — verified against this repo's own postgres/jaffle_shop manifests, where the `stg_*` models list `seed.jaffle_shop.raw_*` parents — and seed aliasing is a documented dbt feature. When `alias == name` (the default) there's no observable difference, so this is a wrong-lineage-node fix for the aliased-seed case, not a crash or a universal change. (`dbt-ol test` against seeds is a scenario users actually hit, cf. the old #1648.)

### Tests

Added `TestParseSingularTests::test_seed_parent_resolves_to_alias_not_name` (red before this change, green after). The full `integration/common` suite stays green: `289 passed, 2 skipped`. `ruff` lint + format and `mypy` are clean.

---
Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro against the real method, wrote the fix and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.

