### PR TITLE
fix(great-expectations): restore data-quality metrics on Great Expectations 1.x

### DIFF
--- a/integration/common/src/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/src/openlineage/common/provider/great_expectations/action.py
@@ -506,7 +506,7 @@ class OpenLineageValidationAction(ValidationAction):
             for expectation in validation_result.results:
                 assertions.append(
                     GreatExpectationsAssertion(
-                        expectationType=expectation["expectation_config"]["expectation_type"],
+                        expectationType=expectation["expectation_config"]["type"],
                         success=expectation["success"],
                         column=expectation["expectation_config"]["kwargs"].get("column", None),
                     )

--- a/integration/common/src/openlineage/common/provider/great_expectations/results.py
+++ b/integration/common/src/openlineage/common/provider/great_expectations/results.py
@@ -38,9 +38,7 @@ class ExpectationsParser:
 
     @classmethod
     def can_accept(cls, expectation_result: ExpectationValidationResult) -> Any | None:
-        expectation_type = get_from_nullable_chain(
-            expectation_result, ["expectation_config", "expectation_type"]
-        )
+        expectation_type = get_from_nullable_chain(expectation_result, ["expectation_config", "type"])
         return expectation_type and expectation_type == cls.expectation_key
 
     @staticmethod
@@ -68,7 +66,7 @@ class EqualRowCountExpectationsParser(BetweenRowCountExpectationsParser):
 
 class FileSizeExpectationsParser(ExpectationsParser):
     expectation_key = "expect_file_size_to_be_between"
-    facet_key = "fileSize"
+    facet_key = "bytes"
 
     @staticmethod
     def parse_expectation_result(expectation_result: dict) -> ExpectationsParserResult:  # type: ignore # noqa
@@ -87,9 +85,7 @@ class ColumnExpectationsParser(ExpectationsParser):
 
     @classmethod
     def can_accept(cls, expectation_result: ExpectationValidationResult) -> Any | None:
-        expectation_type = get_from_nullable_chain(
-            expectation_result, ["expectation_config", "expectation_type"]
-        )
+        expectation_type = get_from_nullable_chain(expectation_result, ["expectation_config", "type"])
         extracted_column = get_from_nullable_chain(
             expectation_result, ["expectation_config", "kwargs", "column"]
         )

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -380,7 +380,7 @@ def test_file_size_expectations_parser():
 
     assert FileSizeExpectationsParser.can_accept(result)
     parsed = FileSizeExpectationsParser.parse_expectation_result(result)
-    assert parsed.facet_key == "fileSize"
+    assert parsed.facet_key == "bytes"
     assert parsed.value == 512
     assert parsed.column_id is None
 
@@ -400,5 +400,21 @@ def test_file_size_expectations_parser_null_result():
     )
 
     parsed = FileSizeExpectationsParser.parse_expectation_result(result)
-    assert parsed.facet_key == "fileSize"
+    assert parsed.facet_key == "bytes"
     assert parsed.value is None
+
+
+def test_data_quality_facet_and_assertions_on_ge_1x():
+    # Great Expectations 1.0 renamed ExpectationConfiguration.expectation_type to
+    # `type`; the parsers must read the new key so metrics are still emitted and
+    # assertion parsing does not raise on any supported (>=1.0) release.
+    facet = OpenLineageValidationAction.parse_data_quality_facet(None, result_suite)
+    assert facet is not None
+    assert facet.rowCount == 10
+
+    assertions = OpenLineageValidationAction.parse_assertions(None, result_suite)
+    assert assertions is not None
+    assert {a.expectationType for a in assertions.assertions} == {
+        "expect_table_row_count_to_equal",
+        "expect_column_sum_to_be_between",
+    }


### PR DESCRIPTION
## Problem

Great Expectations 1.0 renamed `ExpectationConfiguration.expectation_type` to `type`, and `integration/common` requires `great_expectations>=1.0.0`. The GE provider still reads the old key in three places, so on **every supported GE release**:

- `ExpectationsParser.can_accept` and `ColumnExpectationsParser.can_accept` (`results.py`) resolve the expectation type to `None` via `get_from_nullable_chain(..., ["expectation_config", "expectation_type"])`, so **no** parser accepts any expectation and `DataQualityMetricsInputDatasetFacet` comes out empty — data-quality metrics are silently dropped.
- `parse_assertions` (`action.py`) reads `expectation["expectation_config"]["expectation_type"]`, which raises `AttributeError`. Only `ValueError` is caught, so assertion-facet parsing fails outright.

A second, coupled defect: `FileSizeExpectationsParser.facet_key` is `"fileSize"`, which is not a field of `DataQualityMetricsInputDatasetFacet` (the size field is `bytes`). It is currently masked by the first bug (the parser never fires), but once `can_accept` works the parser fires and building the facet with `fileSize=...` raises an uncaught `TypeError`.

## Fix

- Read `type` instead of `expectation_type` in the two `can_accept` methods and in `parse_assertions`.
- Change `FileSizeExpectationsParser.facet_key` to `"bytes"`, keeping the file-size intent from #4698 while producing a valid facet.

## Verification

Reproduced against `great_expectations==1.19.0` with real `ExpectationValidationResult` objects. Before the change, `parse_data_quality_facet` returns a facet with `rowCount=None` and `parse_assertions` raises `AttributeError: 'ExpectationConfiguration' object has no attribute 'expectation_type'`; after it, `rowCount` is populated and assertions parse. A `expect_file_size_to_be_between` result goes from an uncaught `TypeError` to `bytes=<size>`. Added a regression test and updated the two `FileSizeExpectationsParser` assertions.

Note on CI: the GE test suite is suspended (`--ignore=tests/great_expectations`, #3078) and `great_expectations` is not installed in the common CI env, so a green CI here does **not** exercise this change and the new test won't run in CI. Verification above was done locally with GE installed. Happy to adjust the framing if you'd prefer the file-size field handled differently.

## Disclosure

This contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro against real Great Expectations objects, wrote the fix and tests, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff — it was done by the AI, not a person. If this isn't the kind of contribution you want, say so and I'll close it.

