### PR TITLE
build(deps): bump sqlparser, jni, and pyo3 in integration/sql

### DIFF
--- a/integration/sql/iface-java/Cargo.toml
+++ b/integration/sql/iface-java/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 [dependencies]
 openlineage_sql = {path = "../impl"}
 anyhow = {workspace = true}
-jni = "0.20.0"
+jni = "0.22.4"

--- a/integration/sql/iface-java/src/lib.rs
+++ b/integration/sql/iface-java/src/lib.rs
@@ -6,26 +6,27 @@ extern crate openlineage_sql as rust_impl;
 
 use anyhow::Result;
 use jni::errors::Error;
-use jni::objects::{JClass, JList, JObject, JString, JValue};
+use jni::objects::{JClass, JList, JObject, JString, JValue, JValueOwned};
+use jni::signature::{MethodSignature, RuntimeMethodSignature};
+use jni::strings::JNIString;
 use jni::sys::{jobject, jstring};
-use jni::JNIEnv;
+use jni::{Env, EnvUnowned, Outcome};
 
 use rust_impl::{get_generic_dialect, parse_multiple_statements};
 
 trait AsJavaObject {
-    fn as_java_object<'a>(&self, env: &'a JNIEnv) -> Result<JObject<'a>> {
-        let classname = Self::java_class_name();
-        let java_class = env.find_class(classname)?;
-        let signature = Self::ctor_signature();
-        let args = self.ctor_arguments(env)?;
-
-        let obj = env.new_object(java_class, signature, &args)?;
+    fn as_java_object<'local>(&self, env: &mut Env<'local>) -> Result<JObject<'local>> {
+        let rt_sig = RuntimeMethodSignature::from_str(Self::ctor_signature())?;
+        let sig = MethodSignature::from(&rt_sig);
+        let args_owned = self.ctor_arguments(env)?;
+        let args: Vec<JValue<'_>> = args_owned.iter().map(|v| v.borrow()).collect();
+        let obj = env.new_object(JNIString::from(Self::java_class_name()), sig, &args)?;
         Ok(obj)
     }
 
     fn java_class_name() -> &'static str;
     fn ctor_signature() -> &'static str;
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>>;
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>>;
 }
 
 impl AsJavaObject for rust_impl::SqlMeta {
@@ -37,48 +38,44 @@ impl AsJavaObject for rust_impl::SqlMeta {
         "(Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V"
     }
 
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
-        let array_list_class = env
-            .find_class("java/util/ArrayList")
-            .expect("Couldn't find the ArrayList class");
-        let ins = env
-            .new_object(array_list_class, "()V", &[])
-            .expect("Coudln't create a new ArrayList");
-        let outs = env
-            .new_object(array_list_class, "()V", &[])
-            .expect("Coudln't create a new ArrayList");
-        let columns = env
-            .new_object(array_list_class, "()V", &[])
-            .expect("Coudln't create a new ArrayList");
-        let errors = env
-            .new_object(array_list_class, "()V", &[])
-            .expect("Coudln't create a new ArrayList");
-        let ins = JList::from_env(env, ins).unwrap();
-        let outs = JList::from_env(env, outs).unwrap();
-        let columns = JList::from_env(env, columns).unwrap();
-        let errors = JList::from_env(env, errors).unwrap();
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>> {
+        let empty_sig = RuntimeMethodSignature::from_str("()V")?;
+        let empty = MethodSignature::from(&empty_sig);
+        let array_list = JNIString::from("java/util/ArrayList");
+
+        let ins_raw = env.new_object(array_list.clone(), &empty, &[])?;
+        let outs_raw = env.new_object(array_list.clone(), &empty, &[])?;
+        let columns_raw = env.new_object(array_list.clone(), &empty, &[])?;
+        let errors_raw = env.new_object(array_list, &empty, &[])?;
+
+        let ins = env.cast_local::<JList>(ins_raw)?;
+        let outs = env.cast_local::<JList>(outs_raw)?;
+        let columns = env.cast_local::<JList>(columns_raw)?;
+        let errors = env.cast_local::<JList>(errors_raw)?;
 
         for e in &self.table_lineage.in_tables {
-            ins.add(e.as_java_object(env)?)?;
+            let obj = e.as_java_object(env)?;
+            ins.add(env, &obj)?;
         }
         for e in &self.table_lineage.out_tables {
-            outs.add(e.as_java_object(env)?)?;
+            let obj = e.as_java_object(env)?;
+            outs.add(env, &obj)?;
         }
-
         for e in &self.column_lineage {
-            columns.add(e.as_java_object(env)?)?;
+            let obj = e.as_java_object(env)?;
+            columns.add(env, &obj)?;
         }
-
         for e in &self.errors {
-            errors.add(e.as_java_object(env)?)?;
+            let obj = e.as_java_object(env)?;
+            errors.add(env, &obj)?;
         }
 
-        Ok(Box::new([
-            JValue::Object(ins.into()),
-            JValue::Object(outs.into()),
-            JValue::Object(columns.into()),
-            JValue::Object(errors.into()),
-        ]))
+        Ok(vec![
+            JValueOwned::Object(ins.into()),
+            JValueOwned::Object(outs.into()),
+            JValueOwned::Object(columns.into()),
+            JValueOwned::Object(errors.into()),
+        ])
     }
 }
 
@@ -91,25 +88,25 @@ impl AsJavaObject for rust_impl::QuoteStyle {
         "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"
     }
 
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
-        let arg1 = match &self.database {
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>> {
+        let arg1: JObject<'local> = match &self.database {
             Some(n) => env.new_string(n.to_string())?.into(),
             None => JObject::null(),
         };
-        let arg2 = match &self.schema {
+        let arg2: JObject<'local> = match &self.schema {
             Some(n) => env.new_string(n.to_string())?.into(),
             None => JObject::null(),
         };
-        let arg3 = match &self.name {
+        let arg3: JObject<'local> = match &self.name {
             Some(n) => env.new_string(n.to_string())?.into(),
             None => JObject::null(),
         };
 
-        Ok(Box::new([
-            JValue::Object(arg1),
-            JValue::Object(arg2),
-            JValue::Object(arg3),
-        ]))
+        Ok(vec![
+            JValueOwned::Object(arg1),
+            JValueOwned::Object(arg2),
+            JValueOwned::Object(arg3),
+        ])
     }
 }
 
@@ -122,28 +119,28 @@ impl AsJavaObject for rust_impl::DbTableMeta {
         "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/openlineage/sql/QuoteStyle;)V"
     }
 
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
-        let arg1 = match &self.database {
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>> {
+        let arg1: JObject<'local> = match &self.database {
             Some(d) => env.new_string(d)?.into(),
             None => JObject::null(),
         };
-        let arg2 = match &self.schema {
+        let arg2: JObject<'local> = match &self.schema {
             Some(s) => env.new_string(s)?.into(),
             None => JObject::null(),
         };
-        let arg3 = env.new_string(&self.name)?.into();
+        let arg3: JObject<'local> = env.new_string(&self.name)?.into();
 
-        let arg4 = match &self.quote_style {
-            Some(q) => q.as_java_object(env).unwrap(),
+        let arg4: JObject<'local> = match &self.quote_style {
+            Some(q) => q.as_java_object(env)?,
             None => JObject::null(),
         };
 
-        Ok(Box::new([
-            JValue::Object(arg1),
-            JValue::Object(arg2),
-            JValue::Object(arg3),
-            JValue::Object(arg4),
-        ]))
+        Ok(vec![
+            JValueOwned::Object(arg1),
+            JValueOwned::Object(arg2),
+            JValueOwned::Object(arg3),
+            JValueOwned::Object(arg4),
+        ])
     }
 }
 
@@ -156,14 +153,14 @@ impl AsJavaObject for rust_impl::ColumnMeta {
         "(Lio/openlineage/sql/DbTableMeta;Ljava/lang/String;)V"
     }
 
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
-        let arg1 = match &self.origin {
-            Some(d) => d.as_java_object(env).unwrap(),
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>> {
+        let arg1: JObject<'local> = match &self.origin {
+            Some(d) => d.as_java_object(env)?,
             None => JObject::null(),
         };
-        let arg2 = env.new_string(&self.name)?.into();
+        let arg2: JObject<'local> = env.new_string(&self.name)?.into();
 
-        Ok(Box::new([JValue::Object(arg1), JValue::Object(arg2)]))
+        Ok(vec![JValueOwned::Object(arg1), JValueOwned::Object(arg2)])
     }
 }
 
@@ -176,26 +173,24 @@ impl AsJavaObject for rust_impl::ColumnLineage {
         "(Lio/openlineage/sql/ColumnMeta;Ljava/util/List;)V"
     }
 
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
-        let array_list_class = env
-            .find_class("java/util/ArrayList")
-            .expect("Couldn't find the ArrayList class");
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>> {
+        let empty_sig = RuntimeMethodSignature::from_str("()V")?;
+        let empty = MethodSignature::from(&empty_sig);
 
-        let lineage = env
-            .new_object(array_list_class, "()V", &[])
-            .expect("Coudln't create a new ArrayList");
-        let lineage = JList::from_env(env, lineage).unwrap();
+        let lineage_raw = env.new_object(JNIString::from("java/util/ArrayList"), &empty, &[])?;
+        let lineage = env.cast_local::<JList>(lineage_raw)?;
 
         for e in &self.lineage {
-            lineage.add(e.as_java_object(env)?)?;
+            let obj = e.as_java_object(env)?;
+            lineage.add(env, &obj)?;
         }
 
         let descendant = self.descendant.as_java_object(env)?;
 
-        Ok(Box::new([
-            JValue::Object(descendant),
-            JValue::Object(lineage.into()),
-        ]))
+        Ok(vec![
+            JValueOwned::Object(descendant),
+            JValueOwned::Object(lineage.into()),
+        ])
     }
 }
 
@@ -208,67 +203,90 @@ impl AsJavaObject for rust_impl::ExtractionError {
         "(JLjava/lang/String;Ljava/lang/String;)V"
     }
 
-    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
-        let message = env.new_string(&self.message)?.into();
-        let origin_statement = env.new_string(&self.origin_statement)?.into();
+    fn ctor_arguments<'local>(&self, env: &mut Env<'local>) -> Result<Vec<JValueOwned<'local>>> {
+        let message: JObject<'local> = env.new_string(&self.message)?.into();
+        let origin_statement: JObject<'local> = env.new_string(&self.origin_statement)?.into();
 
-        Ok(Box::new([
-            JValue::Long(self.index as i64),
-            JValue::Object(message),
-            JValue::Object(origin_statement),
-        ]))
+        Ok(vec![
+            JValueOwned::Long(self.index as i64),
+            JValueOwned::Object(message),
+            JValueOwned::Object(origin_statement),
+        ])
     }
+}
+
+fn throw_anyhow(env: &mut Env<'_>, err: anyhow::Error) {
+    let _ = env.throw_new(
+        JNIString::from("java/lang/RuntimeException"),
+        JNIString::from(err.to_string()),
+    );
 }
 
 #[no_mangle]
 pub extern "system" fn Java_io_openlineage_sql_OpenLineageSql_parse(
-    env: JNIEnv,
+    mut env: EnvUnowned,
     _class: JClass,
     sql: JObject,
     dialect: JString,
     default_schema: JString,
 ) -> jobject {
-    let f = || -> Result<jobject> {
-        let sql = env.get_list(sql)?;
-        let mut vec_sql: Vec<String> = vec![];
-        let size = sql.size()?;
-        for i in 0..size {
-            let item = sql.get(i)?;
-            if let Some(i) = item {
-                let s: String = env.get_string(i.into())?.into();
+    let outcome = env.with_env(move |env| -> Result<jobject, Error> {
+        let result: anyhow::Result<jobject> = (|| {
+            let sql_list = env.cast_local::<JList>(sql)?;
+            let mut vec_sql: Vec<String> = vec![];
+            let size = sql_list.size(env)?;
+            for i in 0..size {
+                let item = sql_list.get(env, i)?;
+                if item.is_null() {
+                    continue;
+                }
+                let jstr = env.cast_local::<JString>(item)?;
+                let s = jstr.try_to_string(env)?;
                 vec_sql.push(s);
             }
+
+            let dialect_str: Option<String> = if dialect.as_raw().is_null() {
+                None
+            } else {
+                Some(dialect.try_to_string(env)?)
+            };
+            let dialect_obj = get_generic_dialect(dialect_str);
+
+            let default_schema_str: Option<String> = if default_schema.as_raw().is_null() {
+                None
+            } else {
+                Some(default_schema.try_to_string(env)?)
+            };
+
+            let parsed = parse_multiple_statements(vec_sql, dialect_obj, default_schema_str)?;
+            Ok(parsed.as_java_object(env)?.into_raw())
+        })();
+
+        match result {
+            Ok(obj) => Ok(obj),
+            Err(err) => {
+                throw_anyhow(env, err);
+                Ok(JObject::null().into_raw())
+            }
         }
+    });
 
-        let dialect: Option<String> = match env.get_string(dialect) {
-            Err(Error::NullPtr(_)) => None,
-            s => Some(s?.into()),
-        };
-        let dialect = get_generic_dialect(dialect);
-
-        let default_schema: Option<String> = match env.get_string(default_schema) {
-            Err(Error::NullPtr(_)) => None,
-            s => Some(s?.into()),
-        };
-
-        let parsed = parse_multiple_statements(vec_sql, dialect, default_schema)?;
-        Ok(parsed.as_java_object(&env)?.into_raw())
-    };
-
-    match f() {
-        Ok(obj) => obj,
-        Err(err) => {
-            let _ = env.throw(err.to_string());
-            JObject::null().into_raw()
-        }
+    match outcome.into_outcome() {
+        Outcome::Ok(obj) => obj,
+        Outcome::Err(_) | Outcome::Panic(_) => JObject::null().into_raw(),
     }
 }
 
 #[no_mangle]
 pub extern "system" fn Java_io_openlineage_sql_OpenLineageSql_provider(
-    env: JNIEnv,
+    mut env: EnvUnowned,
     _class: JClass,
 ) -> jstring {
-    let output = env.new_string("rust").unwrap();
-    output.into_raw()
+    match env
+        .with_env(|env| -> Result<jstring, Error> { Ok(env.new_string("rust")?.into_raw()) })
+        .into_outcome()
+    {
+        Outcome::Ok(s) => s,
+        Outcome::Err(_) | Outcome::Panic(_) => JObject::null().into_raw() as jstring,
+    }
 }

--- a/integration/sql/iface-py/Cargo.toml
+++ b/integration/sql/iface-py/Cargo.toml
@@ -14,10 +14,10 @@ crate-type = ["cdylib"]
 [dependencies]
 openlineage_sql = {path = "../impl"}
 anyhow = {workspace = true}
-pyo3 = {version = "0.27.2", features = ["extension-module", "abi3", "abi3-py310", "anyhow"]}
+pyo3 = {version = "0.29.0", features = ["extension-module", "abi3", "abi3-py310", "anyhow"]}
 
 [build-dependencies]
-pyo3-build-config = {version = "0.27.2"}
+pyo3-build-config = {version = "0.29.0"}
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/integration/sql/iface-py/src/lib.rs
+++ b/integration/sql/iface-py/src/lib.rs
@@ -12,7 +12,7 @@ use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use rust_impl::{get_generic_dialect, parse_multiple_statements};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct QuoteStyle(rust_impl::QuoteStyle);
 
@@ -55,11 +55,11 @@ impl QuoteStyle {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct DbTableMeta(rust_impl::DbTableMeta);
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Ident(rust_impl::ident_wrapper::IdentWrapper);
 
@@ -144,7 +144,7 @@ impl DbTableMeta {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ColumnMeta(rust_impl::ColumnMeta);
 
@@ -185,7 +185,7 @@ impl ColumnMeta {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ColumnLineage {
     pub descendant: ColumnMeta,
@@ -268,7 +268,7 @@ impl ColumnLineage {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExtractionError(rust_impl::ExtractionError);
 
@@ -340,7 +340,7 @@ impl ExtractionError {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SqlMeta {
     #[pyo3(get)]

--- a/integration/sql/impl/Cargo.toml
+++ b/integration/sql/impl/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["rlib"]
 [dependencies]
 anyhow = {workspace = true}
 
-sqlparser = "=0.60.0"
+sqlparser = "=0.62.0"

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -108,6 +108,7 @@ impl Visit for TableFactor {
                 lateral: _,
                 subquery,
                 alias,
+                sample: _,
             } => {
                 context.push_frame();
                 subquery.visit(context)?;
@@ -622,13 +623,15 @@ impl Visit for Statement {
                     TableObject::TableFunction(func) => {
                         func.visit(context)?;
                     }
+                    TableObject::TableQuery(_) => {}
                 }
             }
-            Statement::Merge { table, source, .. } => {
-                if let Some(table_name) = get_table_name_from_table_factor(table, &*context) {
+            Statement::Merge(merge) => {
+                if let Some(table_name) = get_table_name_from_table_factor(&merge.table, &*context)
+                {
                     context.add_output(table_name);
                 }
-                source.visit(context)?;
+                merge.source.visit(context)?;
             }
             Statement::CreateTable(ct) => {
                 if let Some(query) = &ct.query {

--- a/integration/sql/impl/tests/table_lineage/tests_cte.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_cte.rs
@@ -117,7 +117,7 @@ fn multiple_ctes() {
 #[test]
 fn cte_insert_overwrite() {
     assert_eq!(
-        test_sql(
+        test_sql_dialect(
             "
             WITH g_s AS (
               SELECT
@@ -185,7 +185,8 @@ fn cte_insert_overwrite() {
               grps.u_i,
               grps.uk,
               grps.grp
-        "
+        ",
+            "hive"
         )
         .unwrap()
         .table_lineage,

--- a/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
@@ -31,13 +31,14 @@ fn test_failing_statement_with_insert() {
             errors: vec![
                 ExtractionError {
                     index: 0,
-                    message: "Expected: an SQL statement, found: FAILING at Line: 1, Column: 1".to_string(),
+                    message: "Expected: an SQL statement, found: FAILING at Line: 1, Column: 1"
+                        .to_string(),
                     origin_statement: "FAILING STATEMENT;".to_string(),
                 },
                 ExtractionError {
                     index: 2,
                     message:
-                        "Expected: SELECT, VALUES, or a subquery in the query body, found: FAILING at Line: 1, Column: 13"
+                        "Expected: SELECT, VALUES, or a subquery in the query body, found: EOF"
                             .to_string(),
                     origin_statement: "INSERT ALSO FAILING".to_string(),
                 }

--- a/integration/sql/impl/tests/table_lineage/tests_insert.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_insert.rs
@@ -98,7 +98,7 @@ fn insert_snowflake_table() {
 #[test]
 fn insert_overwrite_table() {
     assert_eq!(
-        test_sql(
+        test_sql_dialect(
             "\
         INSERT OVERWRITE TABLE schema.dps
         PARTITION (ds = '2022-03-30')
@@ -119,7 +119,8 @@ fn insert_overwrite_table() {
             pid,
             uid,
             pii_userid
-    "
+    ",
+            "hive"
         )
         .unwrap()
         .table_lineage,
@@ -133,14 +134,15 @@ fn insert_overwrite_table() {
 #[test]
 fn insert_overwrite_subqueries() {
     assert_eq!(
-        test_sql(
+        test_sql_dialect(
             "
         INSERT OVERWRITE TABLE mytable
         PARTITION (ds = '2022-03-31')
         SELECT
             *
         FROM
-        (SELECT * FROM table2) a"
+        (SELECT * FROM table2) a",
+            "hive"
         )
         .unwrap()
         .table_lineage,
@@ -154,7 +156,7 @@ fn insert_overwrite_subqueries() {
 #[test]
 fn insert_overwrite_multiple_subqueries() {
     assert_eq!(
-        test_sql(
+        test_sql_dialect(
             "
         INSERT OVERWRITE TABLE mytable
         PARTITION (ds = '2022-03-31')
@@ -166,7 +168,8 @@ fn insert_overwrite_multiple_subqueries() {
          SELECT * FROM table3
          UNION ALL
          SELECT * FROM table4) a
-         "
+         ",
+            "hive"
         )
         .unwrap()
         .table_lineage,
@@ -477,7 +480,7 @@ fn test_triple_statements_insert_insert_insert() {
 #[test]
 fn insert_overwrite_multiple_unions() {
     assert_eq!(
-        test_sql(
+        test_sql_dialect(
             "
             INSERT OVERWRITE TABLE d_d_n.a_p_s_v
             PARTITION (ds = '2022-05-01')
@@ -529,7 +532,8 @@ fn insert_overwrite_multiple_unions() {
             GROUP BY
                 sub.p_i,
                 sub.u_i
-        "
+        ",
+            "hive"
         )
         .unwrap()
         .table_lineage,
@@ -543,7 +547,7 @@ fn insert_overwrite_multiple_unions() {
 #[test]
 fn insert_overwrite_partition_dates() {
     assert_eq!(
-        test_sql(
+        test_sql_dialect(
             "\
         INSERT OVERWRITE TABLE ddw.aps2
         PARTITION (ds = '2022-05-01')
@@ -661,7 +665,8 @@ fn insert_overwrite_partition_dates() {
             sub.pid,
             sub.uid,
             sub.userkey
-        "
+        ",
+            "hive"
         )
         .unwrap()
         .table_lineage,


### PR DESCRIPTION
## build(deps): bump sqlparser, jni, and pyo3 in `integration/sql`

Closes / supersedes #4689 (dependabot PR — carries the version bumps but fails CI).

### What changed

Three Rust dependency upgrades in the `integration/sql` workspace, each requiring source-level fixes to compile cleanly and pass all 133 tests.

| Package | Old | New | Changes needed |
|---|---|---|---|
| `sqlparser` | 0.60.0 | 0.62.0 | 3 compile fixes + 7 test fixes |
| `jni` | 0.20.0 | 0.22.4 | Full rewrite of `iface-java/src/lib.rs` |
| `pyo3` | 0.27.2 | 0.29.0 | Version bump only (deprecation warnings, no errors) |

---

### `sqlparser` 0.60.0 → 0.62.0

Three breaking AST changes were introduced across 0.61.0 and 0.62.0, none of which were labeled as breaking in either changelog file — they appear only under the generic `Other:` section. All caused compile errors in [`integration/sql/impl/src/visitor.rs`](integration/sql/impl/src/visitor.rs).

#### Fix 1 — `TableFactor::Derived` gained a new `sample` field

**Root cause:** [apache/datafusion-sqlparser-rs#2164](https://github.com/apache/datafusion-sqlparser-rs/pull/2164) *(v0.61.0, "Snowflake: Support SAMPLE clause on subqueries")* added `sample: Option<TableSampleKind>` to the `Derived` variant. Any exhaustive pattern match broke with `E0027`.

**Fix:** Added `sample: _` to the pattern in `visitor.rs`.

#### Fix 2 — `Statement::Merge` became a tuple variant

**Root cause:** [apache/datafusion-sqlparser-rs#2101](https://github.com/apache/datafusion-sqlparser-rs/pull/2101) *(v0.61.0, "Oracle: Support for MERGE predicates")* extracted the `Merge` fields into a standalone `Merge` struct and changed the enum variant from `Statement::Merge { table, source, … }` to `Statement::Merge(Merge)`. The PR author's reasoning: *"I have introduced a `Merge` struct akin to `Insert`, `Update`, … this makes it easier to pass the merge-relevant data around in a type-safe way."*

**Fix:** Changed the match arm to `Statement::Merge(merge)` and accessed fields via `merge.table`, `merge.source`.

#### Fix 3 — `TableObject` gained a new `TableQuery` variant

**Root cause:** [apache/datafusion-sqlparser-rs#2276](https://github.com/apache/datafusion-sqlparser-rs/pull/2276) *(v0.62.0, "[Oracle] Support for `INSERT INTO (<sub-query>) …`")* added `TableObject::TableQuery(Box<Query>)` for ClickHouse/Oracle's `INSERT INTO (SELECT …)` syntax. The exhaustive `match` on `TableObject` in `visitor.rs` broke with `E0004`.

**Fix:** Added a `TableObject::TableQuery(_) => {}` arm (no lineage to extract from an inline query object).

#### Fix 4 — INSERT OVERWRITE tests broke under postgres dialect

**Root cause:** [apache/datafusion-sqlparser-rs#2214](https://github.com/apache/datafusion-sqlparser-rs/pull/2214) *(v0.62.0, "[Oracle] Table alias for INSERTed table")* enabled `PostgreSqlDialect::supports_insert_table_alias() = true`. The parser now calls `maybe_parse(parse_identifier)` after the INSERT table name, which greedily consumed `PARTITION` as a table alias when using the postgres dialect — causing `INSERT OVERWRITE TABLE t PARTITION (ds = '2022-03-30')` to parse as an incomplete statement and return empty lineage.

This was always latent: these 6 tests were using Hive-specific syntax (`INSERT OVERWRITE TABLE … PARTITION (key = val)`) against the default postgres dialect. They passed before only because postgres dialect didn't try to parse a table alias after the INSERT target. The fix is to use the correct dialect for this syntax.

**Fix:** Changed 5 tests in `tests_insert.rs` and 1 in `tests_cte.rs` from `test_sql(sql)` to `test_sql_dialect(sql, "hive")`. Also updated the expected error message in `test_failing_statement_with_insert` — the same alias-parsing change causes `ALSO` in `INSERT ALSO FAILING` to be consumed as a table alias, so the parser reaches EOF rather than `FAILING` before erroring.

---

### `jni` 0.20.0 → 0.22.4

`jni-rs` 0.22 is a large API overhaul that accumulated changes from both 0.21 and 0.22. The entire `iface-java/src/lib.rs` was rewritten to match the new API. Key upstream changes:

#### `JNIEnv` split into `Env` + `EnvUnowned` ([jni-rs#634](https://github.com/jni-rs/jni-rs/pull/634), v0.22.0)

> *"`JNIEnv` is no longer a `#[transparent]` FFI-safe pointer wrapper and has been split into `EnvUnowned` (for FFI/native method args) and `Env` (non-FFI)."*

`JNIEnv` is now a deprecated alias for `EnvUnowned`. The actual JNI API lives on `Env`, obtained via `unowned_env.with_env(|env: &mut Env<'_>| { … })`. Both FFI entry points now wrap their bodies in `with_env`, and all trait methods were updated to accept `&mut Env<'local>`.

#### `JValue` / `JValueOwned` split ([jni-rs#392](https://github.com/jni-rs/jni-rs/pull/392), v0.21.0)

> *"`JValue` is now a type alias for `JValueGen<&JObject>`, that is, it borrows an object reference. `JValueOwned` is a type alias for `JValueGen<JObject>`, that is, it owns an object reference."*

Constructor argument vectors changed from `Box<[JValue<'a>]>` to `Vec<JValueOwned<'local>>`, and a `v.borrow()` call assembles the `&[JValue]` slice passed to `new_object`.

#### `JList` methods require explicit `env` ([jni-rs#392](https://github.com/jni-rs/jni-rs/pull/392), v0.21.0)

> *"Most `JList` and `JMap` methods now require a `&mut JNIEnv` parameter."*

Updated to the 0.22 form: `list.add(env, &obj)`, `list.size(env)`, `list.get(env, i)`.

#### `new_object` requires `MethodSignature` not `&str` ([jni-rs#714](https://github.com/jni-rs/jni-rs/pull/714), v0.22.0)

> *"All APIs that require a JNI signature now require a pre-parsed `MethodSignature` or `FieldSignature` type instead of a raw string. This enables compile-time signature parsing via the `jni_sig!` macro, and avoids runtime signature parsing costs."*

All constructor calls now parse via `RuntimeMethodSignature::from_str(sig)` and convert with `MethodSignature::from(&rt_sig)`.

#### Class names require `JNIString` / `AsRef<JNIStr>` ([jni-rs#617](https://github.com/jni-rs/jni-rs/pull/617), [#696](https://github.com/jni-rs/jni-rs/pull/696), v0.22.0)

> *"All APIs that were accepting modified-utf8 string args via `Into<JNIString>`, now take `AsRef<JNIStr>` to avoid string copies every call."*

All class name literals are now wrapped with `JNIString::from("…")`.

---

### `pyo3` 0.27.2 → 0.29.0

Version bump only — no source changes required. The upgrade produces deprecation warnings but no hard errors because the existing code doesn't use any API removed between 0.27 and 0.29. pyo3 follows a strict one-version deprecation cycle: 0.28 removed everything deprecated in 0.25–0.26, and 0.29 removed everything deprecated in 0.27 ([PyO3/pyo3#6068](https://github.com/PyO3/pyo3/pull/6068)). Notable deprecations introduced in 0.28/0.29 that will become errors in a future release include the implicit `FromPyObject` for `#[pyclass]` with `Clone` ([PyO3/pyo3#5550](https://github.com/PyO3/pyo3/pull/5550)) and `PyTypeInfo::NAME` / `::MODULE` ([PyO3/pyo3#5579](https://github.com/PyO3/pyo3/pull/5579)), but neither affects this codebase.

---

## Entire PR is AI generated
I did review the changes to all files, but `integration/sql/iface-java/src/lib.rs` needs one more proper review.