### PR TITLE
client/java: fix deserialization crash for additionalProperties column field (#4086)

### DIFF
--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -350,7 +350,8 @@ public class JavaPoetGenerator {
           .returns(additionalPropertiesType)
           .addModifiers(PUBLIC)
           .addCode("return $N;", fieldName)
-          .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build());
+          .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build())
+          .addAnnotation(AnnotationSpec.builder(JsonIgnore.class).build());
       type
           .getParents()
           .stream()
@@ -364,6 +365,13 @@ public class JavaPoetGenerator {
         .build());
       modelClassBuilder.addField(
           FieldSpec.builder(additionalPropertiesType, fieldName, PRIVATE, FINAL)
+              // JsonIgnore keeps this field out of Jackson's regular bean-property resolution.
+              // Without it, an incoming JSON property literally named "additionalProperties"
+              // (e.g. a column named "additionalProperties" in ColumnLineageDatasetFacetFields)
+              // collides with this field's own name and gets deserialized as if it were the
+              // whole map, instead of being routed through @JsonAnySetter as one entry.
+              // See https://github.com/OpenLineage/OpenLineage/issues/4086
+              .addAnnotation(JsonIgnore.class)
               .addAnnotation(JsonAnySetter.class)
               .build());
     }
@@ -747,10 +755,15 @@ public class JavaPoetGenerator {
         .addModifiers(PUBLIC)
         .addCode("return $N;", fieldName)
         .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build())
+        .addAnnotation(AnnotationSpec.builder(JsonIgnore.class).build())
         .addAnnotation(Override.class)
         .build());
     classBuilder.addField(
         FieldSpec.builder(additionalPropertiesType, fieldName, PRIVATE, FINAL)
+        // See the matching field in modelClass() for why JsonIgnore is required here:
+        // it prevents a JSON property literally named "additionalProperties" from colliding
+        // with this field's own name during deserialization (issue #4086).
+        .addAnnotation(JsonIgnore.class)
         .addAnnotation(JsonAnySetter.class)
         .build());
 

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openlineage.client.OpenLineage.DataQualityMetricsInputDatasetFacet;
 import io.openlineage.client.OpenLineage.DataQualityMetricsInputDatasetFacetColumnMetricsAdditional;
 import io.openlineage.client.OpenLineage.DatasetEvent;
+import io.openlineage.client.OpenLineage.DatasetFacets;
 import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.client.OpenLineage.InputField;
 import io.openlineage.client.OpenLineage.Job;
 import io.openlineage.client.OpenLineage.JobEvent;
 import io.openlineage.client.OpenLineage.JobFacets;
@@ -168,6 +170,60 @@ class OpenLineageTest {
     assertEquals(now, read.getEventTime());
     assertEquals(Boolean.TRUE, read.getDataset().getFacets().getDocumentation().get_deleted());
     assertEquals(Boolean.TRUE, read.getDataset().getFacets().getDocumentation().isDeleted());
+  }
+
+  @Test
+  void jsonRunEventWithColumnNamedAdditionalPropertiesDeserialization()
+      throws JsonProcessingException {
+    // Regression test for https://github.com/OpenLineage/OpenLineage/issues/4086
+    // A column lineage "fields" entry keyed by the literal column name "additionalProperties"
+    // used to collide with Jackson's own @JsonAnyGetter/@JsonAnySetter catch-all property of the
+    // same name on ColumnLineageDatasetFacetFields, causing deserialization to fail.
+    URI producer = URI.create("producer");
+    OpenLineage ol = new OpenLineage(producer);
+    UUID runId = UUID.randomUUID();
+    Run run = ol.newRun(runId, null);
+    Job job = ol.newJob("namespace", "jobName", null);
+
+    InputField inputField =
+        ol.newInputField(
+            "input-namespace", "input-dataset", "input-column", Collections.emptyList());
+    OpenLineage.ColumnLineageDatasetFacetFieldsAdditional columnFacet =
+        ol.newColumnLineageDatasetFacetFieldsAdditional(
+            Collections.singletonList(inputField), null, null);
+    OpenLineage.ColumnLineageDatasetFacetFields fields =
+        ol.newColumnLineageDatasetFacetFieldsBuilder()
+            .put("additionalProperties", columnFacet)
+            .build();
+    OpenLineage.ColumnLineageDatasetFacet columnLineage =
+        ol.newColumnLineageDatasetFacetBuilder().fields(fields).build();
+    DatasetFacets outputFacets = ol.newDatasetFacetsBuilder().columnLineage(columnLineage).build();
+    List<OutputDataset> outputs =
+        Arrays.asList(ol.newOutputDataset("ons", "output", outputFacets, null));
+
+    RunEvent runStateUpdate =
+        ol.newRunEvent(
+            now,
+            OpenLineage.RunEvent.EventType.COMPLETE,
+            run,
+            job,
+            Collections.emptyList(),
+            outputs);
+
+    String json = mapper.writeValueAsString(runStateUpdate);
+
+    // This used to throw MismatchedInputException before the fix.
+    RunEvent read = mapper.readValue(json, RunEvent.class);
+
+    OpenLineage.ColumnLineageDatasetFacetFields readFields =
+        read.getOutputs().get(0).getFacets().getColumnLineage().getFields();
+    assertEquals(1, readFields.getAdditionalProperties().size());
+    OpenLineage.ColumnLineageDatasetFacetFieldsAdditional readColumn =
+        readFields.getAdditionalProperties().get("additionalProperties");
+    assertEquals(1, readColumn.getInputFields().size());
+    assertEquals("input-namespace", readColumn.getInputFields().get(0).getNamespace());
+    assertEquals("input-dataset", readColumn.getInputFields().get(0).getName());
+    assertEquals("input-column", readColumn.getInputFields().get(0).getField());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).
-->

closes: #4086

### One-line summary for changelog:
Fix Java client deserialization failure when a column-lineage (or any other `additionalProperties`-backed) field is literally named `additionalProperties`.

### Meaningful description

**Root cause:** The Java client's code generator (`client/java/generator/.../JavaPoetGenerator.java`) emits a catch-all `Map<String, X> additionalProperties` field/getter for every generated model type that has JSON-schema `additionalProperties`, annotated with `@JsonAnySetter`/`@JsonAnyGetter` but *not* `@JsonIgnore`. On Jackson versions newer than the one this repo currently pins for its own build/tests (2.15.3 — I reproduced against 2.19.2, matching the version in the original report), an incoming JSON property that is itself literally named `additionalProperties` (e.g. a column named `"additionalProperties"` under `ColumnLineageDatasetFacet.fields`) collides with the generated map's own property name. Instead of being routed through the any-setter as a single map entry, Jackson resolves it as a regular getter-backed property and tries to merge the JSON value directly into the `Map<String, ColumnLineageDatasetFacetFieldsAdditional>` field itself, throwing `MismatchedInputException` because the single facet object doesn't look like a serialized map.

**What changed:** Added `@JsonIgnore` alongside the existing `@JsonAnySetter`/`@JsonAnyGetter` annotations on the generated `additionalProperties` field/getter, in both places `JavaPoetGenerator` emits this pattern (plain model classes and the `DefaultXxxFacet` classes used for facet interfaces). This excludes the catch-all accessor from Jackson's regular bean-property resolution while leaving the any-setter/any-getter mechanism fully functional for genuinely unrecognized properties — this is the standard fix for this well-known Jackson gotcha (also used by tools like jsonschema2pojo). The fix lives entirely in the generator, so it automatically covers every generated class with `additionalProperties`, not just `ColumnLineageDatasetFacetFields`.

**Why not scoped narrower:** The collision is generic to the shared any-setter/any-getter emission code in the generator, not specific to column lineage, so fixing it once at the source avoids the same bug resurfacing under any other facet or map-typed field with a schema `additionalProperties` in the future.

### Test evidence

- Added `OpenLineageTest#jsonRunEventWithColumnNamedAdditionalPropertiesDeserialization`, a regression test that builds a `RunEvent` whose output dataset has a `ColumnLineageDatasetFacet` with a column literally named `"additionalProperties"`, serializes it, and asserts it round-trips through `ObjectMapper#readValue` correctly.
- Confirmed the test fails before the fix and reproduces the exact `MismatchedInputException` / reference chain from the issue when run against Jackson 2.19.2 (the version reported in #4086; the project's own pinned `jacksonVersion` of 2.15.3 does not happen to trigger the bug, which is likely why it wasn't caught by existing tests — worth being aware of for future Jackson version bumps).
- After the fix, regenerated the client code (`./gradlew generateCode`) and confirmed the same test passes under both Jackson 2.19.2 and the project's pinned 2.15.3.
- Ran the full `client/java` test suite: `./gradlew :test` → **459 tests, all passing** (one unrelated pre-existing flaky test, `UUIDUtilsTest#testGenerateStaticUUIDResultIsDifferentForDifferentData`, which asserts two independently-random 16-bit UUID segments differ and has an inherent ~1/65536 collision chance; confirmed pre-existing/unrelated by rerunning it in isolation, where it passed).
- Ran formatting/lint: `./gradlew spotlessCheck` (applied `spotlessApply` once to fix a wrapping nit in the new test, then re-verified clean) and `./gradlew :pmdMain` — both pass.

### Checklist
- [x] AI was used in creating this PR

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.
