### PR TITLE
ci: test Python 3.14 and Spark 4.2 on Java 21

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -93,12 +93,40 @@ commands:
           echo spark=$SPARK java=$JAVA scala=$SCALA
           JAVA8_HOME='/usr/lib/jvm/java-8-openjdk-amd64'
           JAVA17_HOME='/usr/lib/jvm/java-17-openjdk-amd64'
-          JAVA_BIN=$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/java" || echo "$JAVA8_HOME/jre/bin/java")
-          JAVAC_BIN=$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/javac" || echo "$JAVA8_HOME/bin/javac")
-            
+          JAVA21_HOME='/usr/lib/jvm/java-21-openjdk-amd64'
+
+          case "$JAVA" in
+            8)
+              JAVA_HOME="$JAVA8_HOME"
+              JAVA_TEST_HOME="$JAVA8_HOME"
+              JAVA_BIN="$JAVA8_HOME/jre/bin/java"
+              JAVAC_BIN="$JAVA8_HOME/bin/javac"
+              ;;
+            17)
+              JAVA_HOME="$JAVA17_HOME"
+              JAVA_TEST_HOME="$JAVA17_HOME"
+              JAVA_BIN="$JAVA17_HOME/bin/java"
+              JAVAC_BIN="$JAVA17_HOME/bin/javac"
+              ;;
+            21)
+              # Keep Gradle build tools on Java 17; launch test processes with Java 21 below.
+              JAVA_HOME="$JAVA17_HOME"
+              JAVA_TEST_HOME="$JAVA21_HOME"
+              JAVA_BIN="$JAVA21_HOME/bin/java"
+              JAVAC_BIN="$JAVA21_HOME/bin/javac"
+              ;;
+            *)
+              echo "Unsupported Java version: $JAVA" >&2
+              exit 1
+              ;;
+          esac
+
           echo 'export JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"' >> "$BASH_ENV"
+          echo 'export JAVA21_HOME="/usr/lib/jvm/java-21-openjdk-amd64"' >> "$BASH_ENV"
           echo "export SPARK=\"${SPARK}\"" >> "$BASH_ENV"
           echo "export JAVA=\"${JAVA}\"" >> "$BASH_ENV"
+          echo "export JAVA_HOME=\"${JAVA_HOME}\"" >> "$BASH_ENV"
+          echo "export JAVA_TEST_HOME=\"${JAVA_TEST_HOME}\"" >> "$BASH_ENV"
           echo "export JAVA_BIN=\"${JAVA_BIN}\"" >> "$BASH_ENV"
           echo "export JAVAC_BIN=\"${JAVAC_BIN}\"" >> "$BASH_ENV"
           echo "export SCALA=\"${SCALA}\"" >> "$BASH_ENV"
@@ -607,7 +635,7 @@ jobs:
           echo "Setting default Java to ${JAVA_BIN}"
           sudo update-alternatives --set java ${JAVA_BIN}
           sudo update-alternatives --set javac ${JAVAC_BIN}
-      - run: ./gradlew --no-daemon --console=plain --stacktrace build check -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
+      - run: ./gradlew --no-daemon --console=plain --stacktrace build check -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Papp.java.test.home=${JAVA_TEST_HOME}
       - run:
           when: on_fail
           command: cat build/test-results/test/TEST-*.xml
@@ -661,7 +689,7 @@ jobs:
             - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
-      - run: ./gradlew --no-daemon --console=plain integrationTest -x test -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
+      - run: ./gradlew --no-daemon --console=plain integrationTest -x test -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Papp.java.test.home=${JAVA_TEST_HOME}
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
       - store_test_results:
           path: app/build/test-results/integrationTest

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -635,7 +635,7 @@ jobs:
           echo "Setting default Java to ${JAVA_BIN}"
           sudo update-alternatives --set java ${JAVA_BIN}
           sudo update-alternatives --set javac ${JAVAC_BIN}
-      - run: ./gradlew --no-daemon --console=plain --stacktrace build check -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Papp.java.test.home=${JAVA_TEST_HOME}
+      - run: ./gradlew --no-daemon --console=plain --stacktrace build check -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Papp.java.test.home=${JAVA_TEST_HOME} -Pspark.docker.java.version=${JAVA}
       - run:
           when: on_fail
           command: cat build/test-results/test/TEST-*.xml
@@ -689,7 +689,7 @@ jobs:
             - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
-      - run: ./gradlew --no-daemon --console=plain integrationTest -x test -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Papp.java.test.home=${JAVA_TEST_HOME}
+      - run: ./gradlew --no-daemon --console=plain integrationTest -x test -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Papp.java.test.home=${JAVA_TEST_HOME} -Pspark.docker.java.version=${JAVA}
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
       - store_test_results:
           path: app/build/test-results/integrationTest

--- a/.circleci/workflows/openlineage-python.yml
+++ b/.circleci/workflows/openlineage-python.yml
@@ -67,6 +67,13 @@ workflows:
           name: "CPython 3.13"
           tox_env: py313
           py_env: "3.13"
+      - unit-test-client-python:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+          name: "CPython 3.14"
+          tox_env: py314
+          py_env: "3.14"
       - unit-tests-client-python:
           filters:
             tags:
@@ -76,6 +83,7 @@ workflows:
             - "CPython 3.11"
             - "CPython 3.12"
             - "CPython 3.13"
+            - "CPython 3.14"
       - build-client-python:
           filters:
             tags:

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -34,7 +34,9 @@ workflows:
                 'java:8-spark:3.5.6-scala:2.13-full-tests',
                 'java:17-spark:3.5.6-scala:2.12-full-tests',
                 'java:17-spark:3.5.6-scala:2.13',
-                'java:17-spark:4.0.0-scala:2.13'
+                'java:17-spark:4.0.0-scala:2.13',
+                'java:17-spark:4.2.0-scala:2.13',
+                'java:21-spark:4.2.0-scala:2.13'
               ]
           requires:
             - build-integration-sql-java
@@ -125,7 +127,9 @@ workflows:
                 'java:8-spark:3.5.6-scala:2.13-full-tests',
                 'java:17-spark:3.5.6-scala:2.12-full-tests',
                 'java:17-spark:3.5.6-scala:2.13',
-                'java:17-spark:4.0.0-scala:2.13'
+                'java:17-spark:4.0.0-scala:2.13',
+                'java:17-spark:4.2.0-scala:2.13',
+                'java:21-spark:4.2.0-scala:2.13'
               ]
           requires:
             - approval-integration-spark

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -33,8 +33,8 @@ workflows:
                 'java:8-spark:3.5.6-scala:2.12-full-tests',
                 'java:8-spark:3.5.6-scala:2.13-full-tests',
                 'java:17-spark:3.5.6-scala:2.12-full-tests',
-                'java:17-spark:3.5.6-scala:2.13',
-                'java:17-spark:4.0.0-scala:2.13',
+                'java:17-spark:3.5.6-scala:2.13-full-tests',
+                'java:17-spark:4.0.0-scala:2.13-full-tests',
                 'java:17-spark:4.2.0-scala:2.13',
                 'java:21-spark:4.2.0-scala:2.13'
               ]
@@ -126,8 +126,8 @@ workflows:
                 'java:8-spark:3.5.6-scala:2.12-full-tests',
                 'java:8-spark:3.5.6-scala:2.13-full-tests',
                 'java:17-spark:3.5.6-scala:2.12-full-tests',
-                'java:17-spark:3.5.6-scala:2.13',
-                'java:17-spark:4.0.0-scala:2.13',
+                'java:17-spark:3.5.6-scala:2.13-full-tests',
+                'java:17-spark:4.0.0-scala:2.13-full-tests',
                 'java:17-spark:4.2.0-scala:2.13',
                 'java:21-spark:4.2.0-scala:2.13'
               ]

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -22,7 +22,8 @@ workflows:
           matrix:
             parameters:
               env-variant: [
-                'java:8-spark:3.2.4-scala:2.12-full-tests',
+                # Runs on every PR: oldest supported Spark on oldest supported Java.
+                'java:8-spark:3.2.4-scala:2.12',
                 'java:8-spark:3.2.4-scala:2.13-full-tests',
                 'java:8-spark:3.3.4-scala:2.12-full-tests',
                 'java:8-spark:3.3.4-scala:2.13-full-tests',
@@ -35,7 +36,8 @@ workflows:
                 'java:17-spark:3.5.6-scala:2.12-full-tests',
                 'java:17-spark:3.5.6-scala:2.13-full-tests',
                 'java:17-spark:4.0.0-scala:2.13-full-tests',
-                'java:17-spark:4.2.0-scala:2.13',
+                'java:17-spark:4.2.0-scala:2.13-full-tests',
+                # Runs on every PR: newest supported Spark on newest supported Java.
                 'java:21-spark:4.2.0-scala:2.13'
               ]
           requires:
@@ -115,7 +117,8 @@ workflows:
           matrix:
             parameters:
               env-variant: [
-                'java:8-spark:3.2.4-scala:2.12-full-tests',
+                # Runs on every PR: oldest supported Spark on oldest supported Java.
+                'java:8-spark:3.2.4-scala:2.12',
                 'java:8-spark:3.2.4-scala:2.13-full-tests',
                 'java:8-spark:3.3.4-scala:2.12-full-tests',
                 'java:8-spark:3.3.4-scala:2.13-full-tests',
@@ -128,7 +131,8 @@ workflows:
                 'java:17-spark:3.5.6-scala:2.12-full-tests',
                 'java:17-spark:3.5.6-scala:2.13-full-tests',
                 'java:17-spark:4.0.0-scala:2.13-full-tests',
-                'java:17-spark:4.2.0-scala:2.13',
+                'java:17-spark:4.2.0-scala:2.13-full-tests',
+                # Runs on every PR: newest supported Spark on newest supported Java.
                 'java:21-spark:4.2.0-scala:2.13'
               ]
           requires:

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "attrs>=20.0",
@@ -68,7 +69,7 @@ optional-dependencies.docs = [
 optional-dependencies.generator = [
   "ruff",
   "click",
-  "datamodel-code-generator==0.33.0"
+  "datamodel-code-generator==0.43.1"
 ]
 optional-dependencies.dev = [
   "mypy",
@@ -157,7 +158,7 @@ addopts = [
 legacy_tox_ini = """
 [tox]
 requires = tox-uv
-env_list = py310,py311,py312,py313
+env_list = py310,py311,py312,py313,py314
 skip_missing_interpreters = true
 
 [testenv]

--- a/integration/common/pyproject.toml
+++ b/integration/common/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -23,6 +23,7 @@ plugins {
 ext {
     spark = project.findProperty('spark.version').toString()
     scala = project.findProperty('scala.binary.version').toString()
+    sparkDockerJavaVersion = (project.findProperty('spark.docker.java.version') ?: '17').toString()
     activeRuntimeElementsConfiguration = "scala" + scala.replace(".", "") + "RuntimeElements"
 
     assertjVersion = '3.27.7'
@@ -213,7 +214,8 @@ def testSystemProperties = { String spark, String scala ->
             "mockserver.logLevel"                 : "ERROR",
             "resources.dir"                       : testResourcesDir.get().asFile.absolutePath,
             "scala.fixtures.jar.name"             : scalaFixturesJarName.toString(),
-            "spark.docker.image"                  : spark.startsWith("4") ? "apache/spark:${spark}-scala${scala}-java17-python3-r-ubuntu" : "quay.io/openlineage/spark:spark-${spark}-scala-${scala}",
+            "spark.docker.image"                  : spark.startsWith("4") ? "apache/spark:${spark}-scala${scala}-java${sparkDockerJavaVersion}-python3-r-ubuntu" : "quay.io/openlineage/spark:spark-${spark}-scala-${scala}",
+            "spark.docker.java.version"           : sparkDockerJavaVersion,
             "spark.home.dir"                      : spark.startsWith("4") ? "/opt/spark" : "/opt/bitnami/spark",
             "spark.sql.warehouse.dir"             : sparkWarehouseDir.get().asFile.absolutePath,
             "spark.version"                       : spark,
@@ -270,6 +272,7 @@ tasks.named("shadowJar", ShadowJar.class) {
 
     // TODO: make integration test use build JAR rather than raw, pre-relocate code
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
+    relocate 'io.netty', 'io.openlineage.spark.shaded.io.netty'
     relocate('com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson') {
         exclude 'com.fasterxml.jackson.annotation.JsonIgnore'
         exclude 'com.fasterxml.jackson.annotation.JsonIgnoreProperties'

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/AwsDynamicFrameIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/AwsDynamicFrameIntegrationTest.java
@@ -12,9 +12,9 @@ import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LOG4J2_PR
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LOG4J_PROPERTIES_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_RESOURCES_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.SPARK_DOCKER_IMAGE;
-import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAINER_WAIT_MESSAGE;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
+import static io.openlineage.spark.agent.SparkContainerUtils.oneShotStartupCheckStrategy;
 import static io.openlineage.spark.agent.SparkTestUtils.SPARK_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockserver.model.HttpRequest.request;
@@ -22,6 +22,7 @@ import static org.mockserver.model.HttpRequest.request;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineageClientUtils;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,7 +38,6 @@ import org.mockserver.client.MockServerClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -103,7 +103,7 @@ class AwsDynamicFrameIntegrationTest {
             .withNetwork(network)
             .withNetworkAliases("spark")
             .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(10)))
             .dependsOn(mockServerContainer)
             .withCommand(command.toString());
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ConfigurableIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ConfigurableIntegrationTest.java
@@ -11,6 +11,7 @@ import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_LOG4
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LOG4J2_PROPERTIES_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LOG4J_PROPERTIES_PATH;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
+import static io.openlineage.spark.agent.SparkContainerUtils.oneShotStartupCheckStrategy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openlineage.spark.agent.util.RunEventVerifier;
@@ -24,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,7 +43,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 /**
  * Contains generic & configurable integration test which can be triggered through CLI script to
@@ -182,8 +181,7 @@ class ConfigurableIntegrationTest {
                     output.write(outputFrame.getUtf8String());
                   }
                 })
-            .waitingFor(Wait.forLogMessage(config.getDocker().getWaitForLogMessage(), 1))
-            .withStartupTimeout(Duration.of(10, ChronoUnit.MINUTES))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(10)))
             .withCommand(command.toArray(new String[] {}));
 
     log.debug("Host root openlineage dir is {}", System.getProperty("host.dir"));

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ConfigurableTestConfig.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ConfigurableTestConfig.java
@@ -220,6 +220,5 @@ public class ConfigurableTestConfig {
   public static class DockerTestConfig {
     String image;
     String sparkSubmit = "./bin/spark-submit";
-    String waitForLogMessage = ".*ShutdownHookManager - Shutdown hook called.*";
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerPropertiesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerPropertiesTest.java
@@ -1,0 +1,28 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static io.openlineage.spark.agent.SparkContainerProperties.SCALA_BINARY_VERSION;
+import static io.openlineage.spark.agent.SparkContainerProperties.SPARK_DOCKER_IMAGE;
+import static io.openlineage.spark.agent.SparkContainerProperties.SPARK_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+class SparkContainerPropertiesTest {
+  @Test
+  @EnabledIfSystemProperty(named = "spark.version", matches = "4\\..*")
+  void spark4DockerImageUsesRequestedJavaVersion() {
+    String dockerJavaVersion = System.getProperty("spark.docker.java.version");
+
+    assertThat(SPARK_DOCKER_IMAGE)
+        .isEqualTo(
+            String.format(
+                "apache/spark:%s-scala%s-java%s-python3-r-ubuntu",
+                SPARK_VERSION, SCALA_BINARY_VERSION, dockerJavaVersion));
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -37,13 +37,12 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 public class SparkContainerUtils {
-  public static final String SPARK_DOCKER_CONTAINER_WAIT_MESSAGE = ".*Shutdown hook called.*";
-
   public static final DockerImageName MOCKSERVER_IMAGE =
       DockerImageName.parse("mockserver/mockserver")
           .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());
@@ -130,10 +129,16 @@ public class SparkContainerUtils {
             .withNetwork(network)
             .withNetworkAliases("spark")
             .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .waitingFor(Wait.forLogMessage(waitMessage, 1))
-            .withStartupTimeout(Duration.of(10, ChronoUnit.MINUTES))
             .dependsOn(mockServerContainer)
             .withCommand(command);
+
+    if (waitMessage == null) {
+      container.withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(10)));
+    } else {
+      container
+          .waitingFor(Wait.forLogMessage(waitMessage, 1))
+          .withStartupTimeout(Duration.ofMinutes(10));
+    }
 
     final Path buildDir = Paths.get(System.getProperty("build.dir")).toAbsolutePath();
     mountPath(container, buildDir.resolve("gcloud"), Paths.get("/opt/gcloud"));
@@ -166,7 +171,7 @@ public class SparkContainerUtils {
     return makePysparkContainerWithDefaultConf(
         network,
         "http://openlineageclient:1080",
-        SPARK_DOCKER_CONTAINER_WAIT_MESSAGE,
+        null,
         mockServerContainer,
         namespace,
         urlParams,
@@ -250,6 +255,12 @@ public class SparkContainerUtils {
   public static void addSparkConfig(List<String> command, String value) {
     command.add("--conf");
     command.add(value);
+  }
+
+  public static OneShotStartupCheckStrategy oneShotStartupCheckStrategy(Duration timeout) {
+    OneShotStartupCheckStrategy strategy = new OneShotStartupCheckStrategy();
+    strategy.withTimeout(timeout);
+    return strategy;
   }
 
   static void runPysparkContainerWithDefaultConf(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergMetadataJsonTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergMetadataJsonTest.java
@@ -12,7 +12,7 @@ import static io.openlineage.spark.agent.SparkContainerProperties.HOST_ADDITIONA
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LIB_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_SCALA_FIXTURES_JAR_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.SPARK_DOCKER_IMAGE;
-import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAINER_WAIT_MESSAGE;
+import static io.openlineage.spark.agent.SparkContainerUtils.oneShotStartupCheckStrategy;
 import static io.openlineage.spark.agent.SparkTestUtils.SPARK_VERSION;
 import static org.testcontainers.containers.Network.newNetwork;
 
@@ -56,7 +56,6 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -363,8 +362,7 @@ class SparkIcebergMetadataJsonTest {
             .withNetwork(NETWORK)
             .withNetworkAliases("spark")
             .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-            .withStartupTimeout(Duration.ofSeconds(60L))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofSeconds(60L)))
             .withCommand(command)
             .withCreateContainerCmdModifier(
                 createContainerCmd ->

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -15,10 +15,10 @@ import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LIB_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.HOST_SCALA_FIXTURES_JAR_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.SCALA_BINARY_VERSION;
 import static io.openlineage.spark.agent.SparkContainerProperties.SPARK_DOCKER_IMAGE;
-import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAINER_WAIT_MESSAGE;
 import static io.openlineage.spark.agent.SparkContainerUtils.addSparkConfig;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
+import static io.openlineage.spark.agent.SparkContainerUtils.oneShotStartupCheckStrategy;
 import static io.openlineage.spark.agent.SparkTestUtils.mapToSchemaRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -133,8 +132,7 @@ class SparkScalaContainerTest {
             .withNetwork(network)
             .withNetworkAliases("spark")
             .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(2)))
             .dependsOn(openLineageClientMockContainer)
             .withCommand(command);
 
@@ -265,7 +263,7 @@ class SparkScalaContainerTest {
     GenericContainer spark =
         new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
             .dependsOn(kafkaContainer)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(2)))
             .withNetwork(network)
             .withLogConsumer(SparkContainerUtils::consumeOutput)
             .withStartupTimeout(Duration.ofMinutes(2));
@@ -402,7 +400,7 @@ class SparkScalaContainerTest {
     GenericContainer spark =
         new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
             .dependsOn(localStack)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(2)))
             .withNetwork(localstackNetwork)
             .withLogConsumer(SparkContainerUtils::consumeOutput)
             .withEnv("AWS_ACCESS_KEY_ID", "test")
@@ -498,7 +496,7 @@ class SparkScalaContainerTest {
     GenericContainer spark =
         new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
             .dependsOn(mongo1, mongo2, mongo3)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withStartupCheckStrategy(oneShotStartupCheckStrategy(Duration.ofMinutes(2)))
             .withNetwork(containersNetwork)
             .withStartupTimeout(Duration.ofMinutes(2));
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -28,8 +28,6 @@ import scala.collection.immutable.HashMap;
 
 public class CatalogTableTestUtils {
 
-  private static final int PARAMETER_COUNT = 19;
-
   @SneakyThrows
   public static CatalogTable getCatalogTable(TableIdentifier tableIdentifier) {
     Method applyMethod =
@@ -40,14 +38,7 @@ public class CatalogTableTestUtils {
     List<Object> params = new ArrayList<>();
     params.add(tableIdentifier);
     params.add(CatalogTableType.MANAGED());
-    params.add(
-        CatalogStorageFormat.apply(
-            Option.apply(new URI("/some/location")),
-            Option.empty(),
-            Option.empty(),
-            Option.empty(),
-            false,
-            null));
+    params.add(getCatalogStorageFormat());
     params.add(
         new StructType(
             new StructField[] {
@@ -64,16 +55,38 @@ public class CatalogTableTestUtils {
     params.add(Option.empty());
     params.add(Option.empty());
     params.add(Option.empty());
-    if (System.getProperty("spark.version").startsWith("4")) {
+    if (Option.class.equals(applyMethod.getParameterTypes()[params.size()])) {
       params.add(Option.empty());
     }
     params.add(Seq$.MODULE$.<String>empty());
     params.add(false);
     params.add(false);
     params.add(new HashMap<>());
-    if (applyMethod.getParameterCount() > PARAMETER_COUNT) {
+    while (applyMethod.getParameterCount() > params.size()) {
       params.add(Option.empty());
     }
     return (CatalogTable) applyMethod.invoke(null, params.toArray());
+  }
+
+  private static CatalogStorageFormat getCatalogStorageFormat() throws Exception {
+    Method applyMethod =
+        Arrays.stream(CatalogStorageFormat.class.getDeclaredMethods())
+            .filter(m -> "apply".equals(m.getName()))
+            .filter(m -> CatalogStorageFormat.class.equals(m.getReturnType()))
+            .findFirst()
+            .get();
+    List<Object> params =
+        new ArrayList<>(
+            Arrays.asList(
+                Option.apply(new URI("/some/location")),
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                false,
+                new HashMap<>()));
+    if (applyMethod.getParameterCount() > params.size()) {
+      params.add(Option.empty());
+    }
+    return (CatalogStorageFormat) applyMethod.invoke(null, params.toArray());
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
@@ -46,6 +46,8 @@ import scala.collection.immutable.HashMap;
 // This test is disabled for Spark 4.x versions, as the LogicalPlan constructor has changed
 @DisabledIfSystemProperty(named = "spark.version", matches = "([4].*)")
 class LogicalPlanSerializerTest {
+  private static final int JDBC_RELATION_PARAMETER_COUNT = 4;
+  private static final int JDBC_RELATION_WITH_METRICS_PARAMETER_COUNT = 5;
   private static final String TEST_DATA = "test_data";
   private static final String NAME = "name";
   private static final String TEST = "test";
@@ -68,14 +70,12 @@ class LogicalPlanSerializerTest {
         ScalaConversionUtils.fromJavaMap(
             Collections.singletonMap("driver", Driver.class.getName()));
     JDBCRelation relation =
-        new JDBCRelation(
+        newJdbcRelation(
             new StructType(
                 new StructField[] {
                   new StructField(NAME, StringType$.MODULE$, false, Metadata.empty())
                 }),
-            new Partition[] {},
-            new JDBCOptions(jdbcUrl, sparkTableName, map),
-            mock(SparkSession.class));
+            new JDBCOptions(jdbcUrl, sparkTableName, map));
 
     LogicalRelation instance;
     Aggregate instanceAggregate;
@@ -239,5 +239,23 @@ class LogicalPlanSerializerTest {
         .satisfies(new MatchesMapRecursively(expectedCommandNode, Collections.singleton(EXPR_ID)));
     assertThat(hadoopFSActualNode)
         .satisfies(new MatchesMapRecursively(expectedHadoopFSNode, Collections.singleton(EXPR_ID)));
+  }
+
+  private JDBCRelation newJdbcRelation(StructType schema, JDBCOptions options)
+      throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    Constructor<?> constructor = JDBCRelation.class.getDeclaredConstructors()[0];
+    Object[] parameters;
+    if (constructor.getParameterCount() == JDBC_RELATION_PARAMETER_COUNT) {
+      parameters = new Object[] {schema, new Partition[] {}, options, mock(SparkSession.class)};
+    } else if (constructor.getParameterCount() == JDBC_RELATION_WITH_METRICS_PARAMETER_COUNT) {
+      parameters =
+          new Object[] {
+            schema, new Partition[] {}, options, new HashMap<>(), mock(SparkSession.class)
+          };
+    } else {
+      throw new IllegalStateException(
+          "Unsupported JDBCRelation constructor: " + constructor.toGenericString());
+    }
+    return (JDBCRelation) constructor.newInstance(parameters);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -37,6 +37,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -128,7 +132,7 @@ class SparkReadWriteIntegTest {
 
   @Test
   void testReadFromFileWriteToJdbc(@TempDir Path writeDir, SparkSession spark)
-      throws InterruptedException, TimeoutException, IOException {
+      throws InterruptedException, TimeoutException, IOException, SQLException {
     Path testFile = writeTestDataToFile(writeDir);
 
     Dataset<Row> df = spark.read().json(FILE_URI_PREFIX + testFile.toAbsolutePath().toString());
@@ -136,12 +140,16 @@ class SparkReadWriteIntegTest {
     Path sqliteFile = writeDir.resolve("sqlite/database");
     sqliteFile.getParent().toFile().mkdir();
     String tableName = "data_table";
-    df.filter("age > 100")
-        .write()
-        .jdbc(
-            "jdbc:sqlite:" + sqliteFile.toAbsolutePath().toUri().toString(),
-            tableName,
-            new Properties());
+    String jdbcUrl = "jdbc:sqlite:" + sqliteFile.toAbsolutePath().toUri();
+
+    // Spark 4.2 expects JDBC dialects to identify missing-table SQL exceptions. SQLite uses the
+    // generic dialect, so create the target explicitly instead of relying on that detection.
+    try (Connection connection = DriverManager.getConnection(jdbcUrl);
+        Statement statement = connection.createStatement()) {
+      statement.execute("CREATE TABLE " + tableName + " (age INTEGER, name TEXT)");
+    }
+
+    df.filter("age > 100").write().mode(SaveMode.Append).jdbc(jdbcUrl, tableName, new Properties());
     // wait for event processing to complete
     StaticExecutionContextFactory.waitForExecutionEnd();
 

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_facets_disable.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_facets_disable.py
@@ -23,4 +23,4 @@ spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING hive")
 spark.sql("CREATE TABLE IF NOT EXISTS target (key INT, value STRING) USING hive")
 spark.sql("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c')")
 
-spark.sql("INSERT INTO target SELECT * from test WHERE value > 1")
+spark.sql("INSERT INTO target SELECT * from test WHERE key > 1")

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_hadoop_fs_relation.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_hadoop_fs_relation.py
@@ -20,4 +20,4 @@ spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING parquet
 spark.sql("CREATE TABLE IF NOT EXISTS target (key INT, value STRING) USING parquet")
 spark.sql("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c')")
 
-spark.sql("INSERT INTO target SELECT * from test WHERE value > 1")
+spark.sql("INSERT INTO target SELECT * from test WHERE key > 1")

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_hive.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_hive.py
@@ -20,4 +20,4 @@ spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING hive")
 spark.sql("CREATE TABLE IF NOT EXISTS target (key INT, value STRING) USING hive")
 spark.sql("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c')")
 
-spark.sql("INSERT INTO target SELECT * from test WHERE value > 1")
+spark.sql("INSERT INTO target SELECT * from test WHERE key > 1")

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -97,7 +97,11 @@ class CommonConfigPlugin : Plugin<Project> {
                 showStandardStreams = true
             }
 
-            if (target.hasProperty("java.test.home")) {
+            if (target.path == ":app" && target.hasProperty("app.java.test.home")) {
+                // The app project exercises the selected Spark runtime. Keep tests for modules
+                // compiled against older Spark versions on the Gradle JVM for compatibility.
+                executable = "${target.findProperty("app.java.test.home")}/bin/java"
+            } else if (target.hasProperty("java.test.home")) {
                 // Allow running tests with a specific JDK (e.g. Java 17) independently of the
                 // JDK used to run Gradle. Mirrors the java.compile.home mechanism for compilation.
                 executable = "${target.findProperty("java.test.home")}/bin/java"

--- a/integration/spark/cli/spark-conf-docker.yml
+++ b/integration/spark/cli/spark-conf-docker.yml
@@ -2,7 +2,6 @@ appName: "CLI test application"
 docker:
   image: "apache/spark:3.3.3-scala2.12-java11-python3-ubuntu"
   sparkSubmit: /opt/spark/bin/spark-submit
-  waitForLogMessage: ".*ShutdownHookManager: Shutdown hook called.*"
 scalaBinaryVersion: 2.12
 enableHiveSupport: true
 packages:

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -113,7 +113,7 @@ public class CatalogDatasetFacetUtils {
       //noinspection unchecked
       return Optional.ofNullable(
               ((Option<String>) MethodUtils.invokeMethod(identifier, "catalog")).get())
-          .map(catalogName -> session.sessionState().catalogManager().catalog(catalogName));
+          .flatMap(catalogName -> SparkSessionUtils.catalog(session, catalogName));
     } catch (NoSuchMethodException
         | IllegalAccessException
         | InvocationTargetException

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
@@ -7,7 +7,9 @@ package io.openlineage.spark.agent.util;
 
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 
 @Slf4j
 public class SparkSessionUtils {
@@ -19,6 +21,25 @@ public class SparkSessionUtils {
       // need to catch exception so that org.apache.spark.SparkException for Spark 4.0 is caught
       // which is not thrown for other Spark versions
       log.debug("Cannot obtain active spark session", e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Resolves a catalog by name from the session's catalog manager.
+   *
+   * <p>Spark 4.2 turned {@code CatalogManager} from a class into an interface, so code compiled
+   * against earlier Spark versions emits {@code invokevirtual} and fails at runtime with {@link
+   * IncompatibleClassChangeError}. Calling {@code catalog} reflectively keeps this binary
+   * compatible with both shapes of the API.
+   */
+  public static Optional<CatalogPlugin> catalog(SparkSession session, String catalogName) {
+    try {
+      Object catalogManager = session.sessionState().catalogManager();
+      return Optional.ofNullable(
+          (CatalogPlugin) MethodUtils.invokeMethod(catalogManager, "catalog", catalogName));
+    } catch (Exception e) {
+      log.debug("Cannot obtain catalog {} from the session catalog manager", catalogName, e);
       return Optional.empty();
     }
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -27,8 +27,6 @@ import scala.collection.immutable.HashMap;
 
 public class CatalogTableTestUtils {
 
-  private static final int PARAMETERS_COUNT = 19;
-
   @SneakyThrows
   public static CatalogTable getCatalogTable(TableIdentifier tableIdentifier) {
     Method applyMethod =
@@ -39,14 +37,7 @@ public class CatalogTableTestUtils {
     List<Object> params = new ArrayList<>();
     params.add(tableIdentifier);
     params.add(CatalogTableType.MANAGED());
-    params.add(
-        CatalogStorageFormat.apply(
-            Option.apply(new URI("/some/location")),
-            Option.empty(),
-            Option.empty(),
-            Option.empty(),
-            false,
-            null));
+    params.add(getCatalogStorageFormat());
     params.add(
         new StructType(
             new StructField[] {
@@ -63,13 +54,38 @@ public class CatalogTableTestUtils {
     params.add(Option.empty());
     params.add(Option.empty());
     params.add(Option.empty());
+    if (Option.class.equals(applyMethod.getParameterTypes()[params.size()])) {
+      params.add(Option.empty());
+    }
     params.add(ScalaConversionUtils.asScalaSeqEmpty());
     params.add(false);
     params.add(false);
     params.add(new HashMap<>());
-    if (applyMethod.getParameterCount() > PARAMETERS_COUNT) {
+    while (applyMethod.getParameterCount() > params.size()) {
       params.add(Option.empty());
     }
     return (CatalogTable) applyMethod.invoke(null, params.toArray());
+  }
+
+  private static CatalogStorageFormat getCatalogStorageFormat() throws Exception {
+    Method applyMethod =
+        Arrays.stream(CatalogStorageFormat.class.getDeclaredMethods())
+            .filter(m -> "apply".equals(m.getName()))
+            .filter(m -> CatalogStorageFormat.class.equals(m.getReturnType()))
+            .findFirst()
+            .get();
+    List<Object> params =
+        new ArrayList<>(
+            Arrays.asList(
+                Option.apply(new URI("/some/location")),
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                false,
+                new HashMap<>()));
+    if (applyMethod.getParameterCount() > params.size()) {
+      params.add(Option.empty());
+    }
+    return (CatalogStorageFormat) applyMethod.invoke(null, params.toArray());
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -9,6 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
@@ -19,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
-import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import scala.Option;
@@ -72,9 +72,8 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
       return;
     }
 
-    CatalogManager catalogManager = context.getSparkSession().get().sessionState().catalogManager();
-    Optional.of(catalogManager.catalog(catalogName))
-        .filter(catalogPlugin -> catalogPlugin instanceof TableCatalog)
+    SparkSessionUtils.catalog(context.getSparkSession().get(), catalogName)
+        .filter(plugin -> plugin instanceof TableCatalog)
         .map(TableCatalog.class::cast)
         .ifPresent(
             tableCatalog ->

--- a/integration/sql/iface-py/pyproject.toml
+++ b/integration/sql/iface-py/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
## Summary

- test the Python client on CPython 3.14 and advertise Python 3.14 support across the Python packages
- test Spark 4.2.0 with Scala 2.13 on Java 17 and Java 21 in the unit and integration matrices
- run the Spark 4.2 application tests on the selected JDK while keeping Gradle and legacy Spark modules on compatible JDKs
- handle Spark 4.2 catalog and constructor API changes in the existing compatibility tests and runtime code

## Why

Python 3.14 was not represented in the client test matrix, and the pinned data model generator could not run on that interpreter. Spark 4.2 also changes several catalog and relation APIs, while the Java 21 lane needs to avoid running legacy Spark modules and Gradle formatting tools on an incompatible JDK.

## Validation

- Python 3.14 tox suite: 605 non-Docker tests passed
- Spark 4.2.0 / Scala 2.13 `build check`: passed with Java 17
- Spark 4.2.0 / Scala 2.13 `build check`: passed with the application tests on Java 21
- pre-commit hooks scoped to the changed files: passed
- YAML and TOML parsing and `git diff --check`: passed

