### PR TITLE
sql: include WHERE subquery inputs in lineage

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -536,6 +536,13 @@ impl Visit for Select {
 
         context.set_column_context(None);
 
+        if let Some(selection) = &self.selection {
+            context.push_frame();
+            selection.visit(context)?;
+            let frame = context.pop_frame().unwrap();
+            context.collect_aliases(&frame);
+        }
+
         if let Some(into) = &self.into {
             context.add_output(convert_to_idents(&into.name))
         }

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -14,6 +14,20 @@ fn select_simple() {
         }
     )
 }
+
+#[test]
+fn select_where_exists_subquery() {
+    assert_eq!(
+        test_sql("SELECT 1 WHERE EXISTS (SELECT 1 FROM customers);")
+            .unwrap()
+            .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["customers"]),
+            out_tables: vec![]
+        }
+    )
+}
+
 #[test]
 fn select_from_schema_table() {
     assert_eq!(


### PR DESCRIPTION
closes: #4751

### One-line summary for changelog:

SQL parser: include input tables referenced by WHERE predicate subqueries in table lineage.

### Meaningful description

#### Problem

`Select::visit` traverses `FROM` relations, joins, and projections, but did not traverse the SELECT `selection` expression. As a result, queries such as:

```sql
SELECT 1 WHERE EXISTS (SELECT 1 FROM customers)
```

silently omitted `customers` from `in_tables`.

#### Solution

Visit the selection expression in its own context frame, then collect its table dependencies and aliases without merging predicate-only column ancestry into projected column lineage.

Add a focused table-lineage regression test for a `WHERE EXISTS` subquery. The existing nested-subquery column-lineage test continues to pass and guards against predicate columns leaking into output column lineage.

#### Impact

SQL parser consumers now receive complete input-table lineage for tables read only through WHERE predicate subqueries.

#### Validation

- `cargo test` from `integration/sql`: 143 passed, 3 ignored
- `cargo fmt --all -- --check`
- Exact Python-binding reproduction repeated twice for `EXISTS` and `IN` subqueries, with projection-subquery controls
- All configured hooks applicable to the changed Rust files
- Repository-wide hooks passed except Docker-backed ShellCheck and Go lint, which could not run because Docker is unavailable; the transient `integration/common` mypy setup failure passed on rerun

### Checklist

- [x] AI was used in creating this PR
