### PR TITLE
spark/iceberg: detect output/input datasets for Iceberg JDBC catalogs

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -58,6 +58,7 @@ public class IcebergHandler implements CatalogHandler {
             new SnowflakeCatalogTypeHandler(),
             new RestCatalogTypeHandler(),
             new BigQueryMetastoreCatalogTypeHandler(),
+            new JdbcCatalogTypeHandler(),
             new HadoopCatalogTypeHandler(),
             new HiveCatalogTypeHandler());
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/JdbcCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/JdbcCatalogTypeHandler.java
@@ -1,0 +1,77 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
+
+import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.IcebergHandler.CATALOG_IMPL;
+import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.IcebergHandler.TYPE;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.jdbc.JdbcDatasetUtils;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Handles Iceberg catalogs backed by a JDBC/relational-database catalog implementation (Iceberg's
+ * {@code org.apache.iceberg.jdbc.JdbcCatalog}, configured with {@code type=jdbc} or {@code
+ * catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog}).
+ *
+ * <p>Without this handler, {@link IcebergHandler} falls back to {@link HiveCatalogTypeHandler} for
+ * unrecognized catalog types, which tries to parse the catalog's {@code uri} property (a JDBC
+ * connection string, e.g. {@code jdbc:postgresql://host:5432/db}) as a Hive Thrift metastore URI.
+ * Since a JDBC URI is opaque (has no URI authority), that produces an invalid {@code hive:} URI and
+ * throws an uncaught {@link java.net.URISyntaxException} from deep inside dataset extraction -
+ * silently dropping the dataset (input or output) from the emitted lineage event instead of just
+ * failing to attach a symlink. See https://github.com/OpenLineage/OpenLineage/issues/4677.
+ */
+@Slf4j
+class JdbcCatalogTypeHandler extends BaseCatalogTypeHandler {
+
+  private static final String JDBC_CATALOG_TYPE = "jdbc";
+  private static final String JDBC_CATALOG_IMPL_SUFFIX = "JdbcCatalog";
+  private static final String JDBC_PROPERTY_PREFIX = "jdbc.";
+
+  @Override
+  String getType() {
+    return JDBC_CATALOG_TYPE;
+  }
+
+  @Override
+  boolean matchesCatalogType(Map<String, String> catalogConf) {
+    return JDBC_CATALOG_TYPE.equalsIgnoreCase(catalogConf.get(TYPE))
+        || (catalogConf.containsKey(CATALOG_IMPL)
+            && catalogConf.get(CATALOG_IMPL).endsWith(JDBC_CATALOG_IMPL_SUFFIX));
+  }
+
+  @Override
+  Optional<DatasetIdentifier> getIdentifier(
+      SparkSession session, Map<String, String> catalogConf, String table) {
+    String jdbcUrl = catalogConf.get(CatalogProperties.URI);
+    if (jdbcUrl == null || jdbcUrl.trim().isEmpty()) {
+      log.debug(
+          "Iceberg JDBC catalog is missing the '{}' property; cannot build a symlink for {}",
+          CatalogProperties.URI,
+          table);
+      return Optional.empty();
+    }
+
+    Properties jdbcProperties = new Properties();
+    catalogConf.forEach(
+        (key, value) -> {
+          if (key.startsWith(JDBC_PROPERTY_PREFIX) && value != null) {
+            jdbcProperties.setProperty(key.substring(JDBC_PROPERTY_PREFIX.length()), value);
+          }
+        });
+
+    // Reuses the same JDBC URL -> DatasetIdentifier resolution used for plain JDBC datasets
+    // elsewhere in the Spark integration, so an Iceberg JDBC-catalog table symlinks to the same
+    // namespace a directly-queried JDBC table on that database would use.
+    return Optional.of(JdbcDatasetUtils.getDatasetIdentifier(jdbcUrl, table, jdbcProperties));
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -150,6 +150,97 @@ class IcebergHandlerTest {
 
   @Test
   @SneakyThrows
+  void testGetDatasetIdentifierForJdbcCatalog() {
+    // Regression test for https://github.com/OpenLineage/OpenLineage/issues/4677: an Iceberg
+    // catalog configured with type=jdbc (Iceberg's JdbcCatalog) has no dedicated
+    // BaseCatalogTypeHandler, so it used to fall back to HiveCatalogTypeHandler, which tried to
+    // parse the JDBC connection string as a Hive Thrift metastore URI and threw an uncaught
+    // URISyntaxException - causing the whole dataset (input or output) to be silently dropped
+    // from the emitted lineage event rather than just missing its symlink.
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3<>(
+                "spark.sql.catalog.test.type",
+                "jdbc",
+                "spark.sql.catalog.test.uri",
+                "jdbc:postgresql://metastore-host:5432/icebergdb",
+                "spark.sql.catalog.test.warehouse",
+                "/tmp/warehouse"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession,
+            sparkCatalog,
+            Identifier.of(new String[] {"database"}, "table"),
+            new HashMap<>());
+
+    // The primary identifier is still the table's physical storage location - this part already
+    // worked before the fix, since it doesn't go through the catalog type handler.
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+
+    // The catalog symlink is what used to throw. It should now resolve using the same JDBC URL
+    // parsing used for plain JDBC datasets elsewhere in the Spark integration.
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "postgres://metastore-host:5432")
+        .hasFieldOrPropertyWithValue("name", "icebergdb.database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierForJdbcCatalogWithCatalogImpl() {
+    // The Iceberg JDBC catalog can also be configured via catalog-impl instead of type=jdbc.
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3<>(
+                "spark.sql.catalog.test.catalog-impl",
+                "org.apache.iceberg.jdbc.JdbcCatalog",
+                "spark.sql.catalog.test.uri",
+                "jdbc:postgresql://metastore-host:5432/icebergdb",
+                "spark.sql.catalog.test.warehouse",
+                "/tmp/warehouse"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession,
+            sparkCatalog,
+            Identifier.of(new String[] {"database"}, "table"),
+            new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "postgres://metastore-host:5432")
+        .hasFieldOrPropertyWithValue("name", "icebergdb.database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
   void testGetDatasetIdentifierForRest() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())


### PR DESCRIPTION
## Summary

Fixes #4677.

An Iceberg catalog configured with `type=jdbc` (Iceberg's `JdbcCatalog`, backed by a relational database instead of a Hive metastore or REST catalog) has no dedicated `BaseCatalogTypeHandler` in `IcebergHandler`. `getCatalogTypeHandler()` therefore falls back to `HiveCatalogTypeHandler` for any unrecognized catalog type:

```java
} else {
  // https://github.com/apache/iceberg/blob/apache-iceberg-1.9.1/core/src/main/java/org/apache/iceberg/CatalogUtil.java#L298
  return new HiveCatalogTypeHandler();
}
```

`HiveCatalogTypeHandler.getIdentifier()` tries to parse the catalog's `uri` property as a Hive Thrift metastore URI via `PathUtils.prepareHiveUri()`:

```java
public static URI prepareHiveUri(URI uri) {
  return new URI("hive", uri.getAuthority(), null, null, null);
}
```

A JDBC connection string such as `jdbc:postgresql://host:5432/db` is an **opaque** `java.net.URI` (the scheme-specific part `postgresql://host:5432/db` doesn't get parsed as hierarchical because it doesn't immediately follow `jdbc:` with `//`), so `uri.getAuthority()` returns `null`. `new URI("hive", null, null, null, null)` then throws:

```
java.net.URISyntaxException: Expected scheme-specific part at index 5: hive:
```

This exception is uncaught (`HiveCatalogTypeHandler.getIdentifier` is `@SneakyThrows`) and propagates out of `IcebergHandler.getDatasetIdentifier()` for that table. The exception is only caught much further up the call stack (`PlanUtils.safeApply`), by which point the *entire dataset* - not just its Hive-style symlink - has been dropped from the emitted lineage event. This matches the reporter's logs exactly: the primary key/value pairs are logged, `PlanUtils` logs "apply method failed with" + the `URISyntaxException` with this precise stack trace, and the resulting event has `"outputs":[]`.

## Fix

Add `JdbcCatalogTypeHandler`, matching `type=jdbc` or a `catalog-impl` ending in `JdbcCatalog` (mirroring how `RestCatalogTypeHandler` and `BigQueryMetastoreCatalogTypeHandler` match both `type=` and `catalog-impl=` configurations). It resolves the catalog symlink using `JdbcDatasetUtils` - the same JDBC URL parser already used for plain JDBC datasets elsewhere in the Spark integration (`JdbcSparkUtils`) - so a JDBC-catalog table symlinks to the same `postgres://host:port`-style namespace a directly-queried JDBC table on that database would use, instead of crashing.

The *primary* dataset identifier (derived from the Iceberg table's physical storage location via `table.location()`) was already catalog-type-agnostic and unaffected by this bug - only the catalog symlink resolution was broken, but broken badly enough to take down the whole dataset.

## Test evidence

Added two regression tests to `IcebergHandlerTest`:
- `testGetDatasetIdentifierForJdbcCatalog` - `type=jdbc` with a `jdbc:postgresql://...` uri
- `testGetDatasetIdentifierForJdbcCatalogWithCatalogImpl` - `catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog`

I verified both fail against the pre-fix code with the exact exception from the bug report:

```
IcebergHandlerTest > testGetDatasetIdentifierForJdbcCatalog() FAILED
    java.net.URISyntaxException at IcebergHandlerTest.java:180

IcebergHandlerTest > testGetDatasetIdentifierForJdbcCatalogWithCatalogImpl() FAILED
    java.net.URISyntaxException at IcebergHandlerTest.java:225
```

And pass after the fix:

```
IcebergHandlerTest > testGetDatasetIdentifierForJdbcCatalog() PASSED
IcebergHandlerTest > testGetDatasetIdentifierForJdbcCatalogWithCatalogImpl() PASSED
```

Ran the full `spark3` catalog test suite (`IcebergHandlerTest` - 39 tests, `JdbcHandlerTest`, `V2SessionCatalogHandlerTest`) against Spark 3.5.6 / Scala 2.12 - all pass, no regressions.

## Test plan

- [x] Added regression tests reproducing the reported bug (JDBC catalog type/catalog-impl)
- [x] Verified new tests fail with the reported `URISyntaxException` against pre-fix code
- [x] Verified new tests pass after the fix
- [x] Ran the full `spark3` catalog handler test suite - no regressions