### PR TITLE
dbt: fix structured logs test formatting

### DIFF
--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -2323,6 +2323,8 @@ class TestFullRefreshFromCommandLine:
 
         facet = processor.dbt_run_run_facet()["dbt_run"]
         assert facet.full_refresh is True
+
+
 def _command_completed_event(path):
     """Return the CommandCompleted dbt log event from a fixture list."""
     events = yaml.safe_load(open(path))


### PR DESCRIPTION
## What changed

Adds the blank lines required by `ruff-format` in the structured logs test.

This change affects formatting only. It does not change test behaviour.

## Why

The [CircleCI pre-commit job](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/19432/workflows/af12cb4b-75da-4be1-a935-8e9f64128685/jobs/572095) failed because `ruff-format` changed the test file during CI.

## Checks

- `ruff-format` passed for the changed file
- all commit-time pre-commit hooks passed
