### PR TITLE
java: add retry configuration to gcp lineage transport

### DIFF
--- a/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageRetryConfig.java
+++ b/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageRetryConfig.java
@@ -1,0 +1,64 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports.gcplineage;
+
+import datalineage.shaded.org.threeten.bp.Duration;
+import io.openlineage.client.MergeConfig;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class GcpLineageRetryConfig implements MergeConfig<GcpLineageRetryConfig> {
+  private @Nullable Integer maxAttempts;
+  private @Nullable Duration totalTimeout;
+  private @Nullable Duration initialRetryDelay;
+  private @Nullable Double retryDelayMultiplier;
+  private @Nullable Duration maxRetryDelay;
+  private @Nullable Duration initialRpcTimeout;
+  private @Nullable Double rpcTimeoutMultiplier;
+  private @Nullable Duration maxRpcTimeout;
+
+  public void setTotalTimeout(String totalTimeout) {
+    this.totalTimeout = Duration.parse(totalTimeout);
+  }
+
+  public void setInitialRetryDelay(String initialRetryDelay) {
+    this.initialRetryDelay = Duration.parse(initialRetryDelay);
+  }
+
+  public void setMaxRetryDelay(String maxRetryDelay) {
+    this.maxRetryDelay = Duration.parse(maxRetryDelay);
+  }
+
+  public void setInitialRpcTimeout(String initialRpcTimeout) {
+    this.initialRpcTimeout = Duration.parse(initialRpcTimeout);
+  }
+
+  public void setMaxRpcTimeout(String maxRpcTimeout) {
+    this.maxRpcTimeout = Duration.parse(maxRpcTimeout);
+  }
+
+  @Override
+  public GcpLineageRetryConfig mergeWithNonNull(GcpLineageRetryConfig gcpLineageRetryConfig) {
+    return new GcpLineageRetryConfig(
+        mergePropertyWith(maxAttempts, gcpLineageRetryConfig.maxAttempts),
+        mergePropertyWith(totalTimeout, gcpLineageRetryConfig.totalTimeout),
+        mergePropertyWith(initialRetryDelay, gcpLineageRetryConfig.initialRetryDelay),
+        mergePropertyWith(retryDelayMultiplier, gcpLineageRetryConfig.retryDelayMultiplier),
+        mergePropertyWith(maxRetryDelay, gcpLineageRetryConfig.maxRetryDelay),
+        mergePropertyWith(initialRpcTimeout, gcpLineageRetryConfig.initialRpcTimeout),
+        mergePropertyWith(rpcTimeoutMultiplier, gcpLineageRetryConfig.rpcTimeoutMultiplier),
+        mergePropertyWith(maxRpcTimeout, gcpLineageRetryConfig.maxRpcTimeout));
+  }
+}

--- a/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageTransport.java
+++ b/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageTransport.java
@@ -8,6 +8,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -171,6 +172,48 @@ public class GcpLineageTransport extends Transport {
       if (config.getEndpoint() != null) {
         builder.setEndpoint(config.getEndpoint());
       }
+
+      GcpLineageRetryConfig conf = config.getRetryConfig();
+      if (conf != null) {
+        RetrySettings current = builder.processOpenLineageRunEventSettings().getRetrySettings();
+        RetrySettings build =
+            current.toBuilder()
+                .setMaxAttempts(
+                    conf.getMaxAttempts() != null
+                        ? conf.getMaxAttempts()
+                        : current.getMaxAttempts())
+                .setTotalTimeout(
+                    conf.getTotalTimeout() != null
+                        ? conf.getTotalTimeout()
+                        : current.getTotalTimeout())
+                .setInitialRetryDelay(
+                    conf.getInitialRetryDelay() != null
+                        ? conf.getInitialRetryDelay()
+                        : current.getInitialRetryDelay())
+                .setRetryDelayMultiplier(
+                    conf.getRetryDelayMultiplier() != null
+                        ? conf.getRetryDelayMultiplier()
+                        : current.getRetryDelayMultiplier())
+                .setMaxRetryDelay(
+                    conf.getMaxRetryDelay() != null
+                        ? conf.getMaxRetryDelay()
+                        : current.getMaxRetryDelay())
+                .setInitialRpcTimeout(
+                    conf.getInitialRpcTimeout() != null
+                        ? conf.getInitialRpcTimeout()
+                        : current.getInitialRpcTimeout())
+                .setRpcTimeoutMultiplier(
+                    conf.getRpcTimeoutMultiplier() != null
+                        ? conf.getRpcTimeoutMultiplier()
+                        : current.getRpcTimeoutMultiplier())
+                .setMaxRpcTimeout(
+                    conf.getMaxRpcTimeout() != null
+                        ? conf.getMaxRpcTimeout()
+                        : current.getMaxRpcTimeout())
+                .build();
+        builder.processOpenLineageRunEventSettings().setRetrySettings(build);
+      }
+
       if (config.getProjectId() != null) {
         builder.setQuotaProjectId(config.getProjectId());
       }

--- a/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageTransport.java
+++ b/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageTransport.java
@@ -51,17 +51,17 @@ public class GcpLineageTransport extends Transport {
   }
 
   @Override
-  public void emit(OpenLineage.@NonNull RunEvent runEvent) {
+  public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     producerClientWrapper.emitEvent(runEvent);
   }
 
   @Override
-  public void emit(OpenLineage.@NonNull DatasetEvent datasetEvent) {
+  public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
     producerClientWrapper.emitEvent(datasetEvent);
   }
 
   @Override
-  public void emit(OpenLineage.@NonNull JobEvent jobEvent) {
+  public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
     producerClientWrapper.emitEvent(jobEvent);
   }
 
@@ -70,6 +70,7 @@ public class GcpLineageTransport extends Transport {
     producerClientWrapper.close();
   }
 
+  @SuppressWarnings("PMD.NullAssignment")
   static class ProducerClientWrapper implements Closeable {
     private final SyncLineageClient syncLineageClient;
     private final AsyncLineageClient asyncLineageClient;
@@ -167,7 +168,7 @@ public class GcpLineageTransport extends Transport {
       return createSettings(config, builder).build();
     }
 
-    private static <T extends LineageSettings.Builder> T createSettings(
+    static <T extends LineageSettings.Builder> T createSettings(
         GcpLineageTransportConfig config, T builder) throws IOException {
       if (config.getEndpoint() != null) {
         builder.setEndpoint(config.getEndpoint());

--- a/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportConfig.java
+++ b/client/java/transports-gcplineage/src/main/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportConfig.java
@@ -4,6 +4,7 @@
 */
 package io.openlineage.client.transports.gcplineage;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.MergeConfig;
 import io.openlineage.client.transports.TransportConfig;
 import javax.annotation.Nullable;
@@ -36,6 +37,11 @@ public class GcpLineageTransportConfig
 
   @Getter @Setter private @Nullable String gracefulShutdownDuration;
 
+  @JsonProperty("retry")
+  @Getter
+  @Setter
+  private @Nullable GcpLineageRetryConfig retryConfig;
+
   @Override
   public GcpLineageTransportConfig mergeWithNonNull(GcpLineageTransportConfig other) {
     return new GcpLineageTransportConfig(
@@ -44,6 +50,7 @@ public class GcpLineageTransportConfig
         mergePropertyWith(credentialsFile, other.credentialsFile),
         mergePropertyWith(location, other.location),
         mergePropertyWith(mode, other.mode),
-        mergePropertyWith(gracefulShutdownDuration, other.gracefulShutdownDuration));
+        mergePropertyWith(gracefulShutdownDuration, other.gracefulShutdownDuration),
+        mergePropertyWith(retryConfig, other.retryConfig));
   }
 }

--- a/client/java/transports-gcplineage/src/test/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportBuilderTest.java
+++ b/client/java/transports-gcplineage/src/test/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportBuilderTest.java
@@ -7,6 +7,7 @@ package io.openlineage.client.transports.gcplineage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import datalineage.shaded.org.threeten.bp.Duration;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.transports.gcplineage.GcpLineageTransportConfig.Mode;
@@ -14,6 +15,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -31,5 +33,32 @@ class GcpLineageTransportBuilderTest {
     GcpLineageTransportConfig gcpLineageTransportConfig =
         (GcpLineageTransportConfig) openLineageConfig.getTransportConfig();
     assertEquals(Mode.ASYNC, gcpLineageTransportConfig.getMode());
+  }
+
+  @Test
+  void buildFromYamlConfigWithRetry() throws URISyntaxException {
+    Path path =
+        Paths.get(this.getClass().getClassLoader().getResource("config/retry_config.yaml").toURI());
+
+    OpenLineageConfig openLineageConfig =
+        OpenLineageClientUtils.loadOpenLineageConfigYaml(
+            () -> Collections.singletonList(path), new TypeReference<OpenLineageConfig>() {});
+    GcpLineageTransportConfig gcpLineageTransportConfig =
+        (GcpLineageTransportConfig) openLineageConfig.getTransportConfig();
+    assertEquals(Mode.ASYNC, gcpLineageTransportConfig.getMode());
+    assertEquals(5, gcpLineageTransportConfig.getRetryConfig().getMaxAttempts());
+    assertEquals(2, gcpLineageTransportConfig.getRetryConfig().getRetryDelayMultiplier());
+    assertEquals(2, gcpLineageTransportConfig.getRetryConfig().getRpcTimeoutMultiplier());
+
+    assertEquals(
+        Duration.ofMillis(6000), gcpLineageTransportConfig.getRetryConfig().getTotalTimeout());
+    assertEquals(
+        Duration.ofMillis(1000), gcpLineageTransportConfig.getRetryConfig().getInitialRetryDelay());
+    assertEquals(
+        Duration.ofMillis(1000), gcpLineageTransportConfig.getRetryConfig().getMaxRetryDelay());
+    assertEquals(
+        Duration.ofMillis(1000), gcpLineageTransportConfig.getRetryConfig().getInitialRpcTimeout());
+    assertEquals(
+        Duration.ofMillis(1000), gcpLineageTransportConfig.getRetryConfig().getMaxRpcTimeout());
   }
 }

--- a/client/java/transports-gcplineage/src/test/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportTest.java
+++ b/client/java/transports-gcplineage/src/test/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportTest.java
@@ -13,11 +13,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.AsyncTaskException;
+import com.google.cloud.datacatalog.lineage.v1.LineageSettings;
 import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventRequest;
 import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventResponse;
 import com.google.cloud.datalineage.producerclient.helpers.OpenLineageHelper;
 import com.google.cloud.datalineage.producerclient.v1.AsyncLineageProducerClient;
+import com.google.cloud.datalineage.producerclient.v1.AsyncLineageProducerClientSettings;
 import com.google.cloud.datalineage.producerclient.v1.SyncLineageProducerClient;
 import datalineage.shaded.org.threeten.bp.Duration;
 import datalineage.shaded.org.threeten.bp.format.DateTimeParseException;
@@ -28,6 +31,8 @@ import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.transports.Transport;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -162,6 +167,54 @@ class GcpLineageTransportTest {
         () -> {
           new GcpLineageTransport.ProducerClientWrapper(config);
         });
+  }
+
+  @Test
+  void testPassingRetryConfigToSettings(@TempDir Path tempDir)
+      throws GeneralSecurityException,
+          IOException,
+          NoSuchFieldException,
+          IllegalAccessException,
+          NoSuchMethodException,
+          InvocationTargetException {
+    Path mockCredentialsFile = createMockCredentialsFile(tempDir);
+
+    GcpLineageTransportConfig config = new GcpLineageTransportConfig();
+    config.setCredentialsFile(mockCredentialsFile.toString());
+
+    GcpLineageRetryConfig retryConfig = new GcpLineageRetryConfig();
+    retryConfig.setMaxAttempts(11);
+    retryConfig.setRetryDelayMultiplier(12.0);
+    retryConfig.setRpcTimeoutMultiplier(13.0);
+    retryConfig.setTotalTimeout("PT6S");
+    retryConfig.setInitialRetryDelay("PT1S");
+    retryConfig.setMaxRetryDelay("PT3S");
+    retryConfig.setInitialRpcTimeout("PT1S");
+    retryConfig.setMaxRpcTimeout("PT3S");
+    config.setRetryConfig(retryConfig);
+
+    GcpLineageTransport gcpLineageTransport = new GcpLineageTransport(config);
+    GcpLineageTransport.ProducerClientWrapper wrapper =
+        getValue("producerClientWrapper", GcpLineageTransport.class, gcpLineageTransport);
+
+    Method method =
+        GcpLineageTransport.ProducerClientWrapper.class.getDeclaredMethod(
+            "createSettings", GcpLineageTransportConfig.class, LineageSettings.Builder.class);
+    method.setAccessible(true);
+    AsyncLineageProducerClientSettings.Builder invoke =
+        (AsyncLineageProducerClientSettings.Builder)
+            method.invoke(wrapper, config, AsyncLineageProducerClientSettings.newBuilder());
+
+    RetrySettings retrySettings = invoke.processOpenLineageRunEventSettings().getRetrySettings();
+
+    assertEquals(11, retrySettings.getMaxAttempts());
+    assertEquals(12.0, retrySettings.getRetryDelayMultiplier());
+    assertEquals(13.0, retrySettings.getRpcTimeoutMultiplier());
+    assertEquals(Duration.ofSeconds(6), retrySettings.getTotalTimeout());
+    assertEquals(Duration.ofSeconds(1), retrySettings.getInitialRetryDelay());
+    assertEquals(Duration.ofSeconds(3), retrySettings.getMaxRetryDelay());
+    assertEquals(Duration.ofSeconds(1), retrySettings.getInitialRpcTimeout());
+    assertEquals(Duration.ofSeconds(3), retrySettings.getMaxRpcTimeout());
   }
 
   public static OpenLineage.RunEvent runEvent() {

--- a/client/java/transports-gcplineage/src/test/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportTest.java
+++ b/client/java/transports-gcplineage/src/test/java/io/openlineage/client/transports/gcplineage/GcpLineageTransportTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.AsyncTaskException;
-import com.google.cloud.datacatalog.lineage.v1.LineageSettings;
 import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventRequest;
 import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventResponse;
 import com.google.cloud.datalineage.producerclient.helpers.OpenLineageHelper;
@@ -31,8 +30,6 @@ import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.transports.Transport;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -171,12 +168,7 @@ class GcpLineageTransportTest {
 
   @Test
   void testPassingRetryConfigToSettings(@TempDir Path tempDir)
-      throws GeneralSecurityException,
-          IOException,
-          NoSuchFieldException,
-          IllegalAccessException,
-          NoSuchMethodException,
-          InvocationTargetException {
+      throws GeneralSecurityException, IOException {
     Path mockCredentialsFile = createMockCredentialsFile(tempDir);
 
     GcpLineageTransportConfig config = new GcpLineageTransportConfig();
@@ -193,17 +185,9 @@ class GcpLineageTransportTest {
     retryConfig.setMaxRpcTimeout("PT3S");
     config.setRetryConfig(retryConfig);
 
-    GcpLineageTransport gcpLineageTransport = new GcpLineageTransport(config);
-    GcpLineageTransport.ProducerClientWrapper wrapper =
-        getValue("producerClientWrapper", GcpLineageTransport.class, gcpLineageTransport);
-
-    Method method =
-        GcpLineageTransport.ProducerClientWrapper.class.getDeclaredMethod(
-            "createSettings", GcpLineageTransportConfig.class, LineageSettings.Builder.class);
-    method.setAccessible(true);
     AsyncLineageProducerClientSettings.Builder invoke =
-        (AsyncLineageProducerClientSettings.Builder)
-            method.invoke(wrapper, config, AsyncLineageProducerClientSettings.newBuilder());
+        GcpLineageTransport.ProducerClientWrapper.createSettings(
+            config, AsyncLineageProducerClientSettings.newBuilder());
 
     RetrySettings retrySettings = invoke.processOpenLineageRunEventSettings().getRetrySettings();
 

--- a/client/java/transports-gcplineage/src/test/resources/config/retry_config.yaml
+++ b/client/java/transports-gcplineage/src/test/resources/config/retry_config.yaml
@@ -1,0 +1,15 @@
+transport:
+  type: gcplineage
+  projectId: your_gcp_project_id
+  location: us
+  mode: async
+  credentialsFile: path/to/credentials.json
+  retry:
+    maxAttempts: 5
+    retryDelayMultiplier: 2
+    rpcTimeoutMultiplier: 2
+    totalTimeout: PT6S
+    initialRetryDelay: PT1S
+    maxRetryDelay: PT1S
+    initialRpcTimeout: PT1S
+    maxRpcTimeout: PT1S


### PR DESCRIPTION
### One-line summary for changelog:
pass retry configuration to google lineage producer client via gcp lineage transport config


### Meaningful description
GCP Lineage client has configurable retry capabilities, the transport uses defaults without any way of modifying them. 

Adding retry configuration to `GcpLineageTransportConfig` allows us to pass them to `LineageSettings`. That lets the user configure them through the OL config.


### Checklist
- [x] AI was used in creating this PR
