### PR TITLE
Serialize website-snapshot workflow runs to avoid push races

### DIFF
--- a/.github/workflows/website-snapshot.yml
+++ b/.github/workflows/website-snapshot.yml
@@ -6,6 +6,10 @@ on:
       - main
       - docs-env
 
+concurrency:
+  group: website-snapshot
+  cancel-in-progress: false
+
 permissions:
   id-token: write
 
@@ -104,8 +108,8 @@ jobs:
           git add .
           if ! git diff-index --quiet HEAD; then
             git commit -m "Refreshing website content from main repo.
-            
-            Source commit: 
+
+            Source commit:
             https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
             git push
           fi


### PR DESCRIPTION
## Summary
- The `website-snapshot` workflow's push to `openlineage-site` can fail with a non-fast-forward error when two runs overlap (e.g. back-to-back pushes to `main` during a release trigger the job twice, and the second run's checkout of the target repo is stale by the time it pushes).
- Add a `concurrency` group so runs are serialized instead of racing.