### PR TITLE
sql: include ARRAY subquery inputs in lineage

### DIFF
--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -265,7 +265,9 @@ def test_parse_bugged_cte():
             FROM sum_trans
             WHERE count > 1000 OR balance > 100000;
     """
-    assert parse(sql).errors == [ExtractionError(0, "Expected: ), found: ( at Line: 3, Column: 34", sql)]
+    assert parse(sql, dialect="postgres").errors == [
+        ExtractionError(0, "Expected: ), found: ( at Line: 3, Column: 34", sql)
+    ]
 
 
 def test_parse_recursive_cte():

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -409,7 +409,7 @@ impl Visit for Function {
     fn visit(&self, context: &mut Context) -> Result<()> {
         match &self.args {
             FunctionArguments::None => {}
-            FunctionArguments::Subquery(_) => {}
+            FunctionArguments::Subquery(query) => query.visit(context)?,
             FunctionArguments::List(arguments) => {
                 for arg in &arguments.args {
                     arg.visit(context)?;

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -217,6 +217,19 @@ fn select_bq_array_function() {
 }
 
 #[test]
+fn select_bq_array_subquery() {
+    assert_eq!(
+        test_sql_dialect("SELECT ARRAY(SELECT id FROM source_table)", "bigquery")
+            .unwrap()
+            .table_lineage,
+        TableLineage {
+            in_tables: vec![table("source_table")],
+            out_tables: vec![],
+        }
+    )
+}
+
+#[test]
 fn select_identifier_function() {
     let test_cases = vec![
         ("target", vec![table("target")]),


### PR DESCRIPTION
### One-line summary for changelog:

SQL parser now includes tables referenced by BigQuery ARRAY subqueries in input lineage.

### Meaningful description

BigQuery ARRAY subqueries parsed successfully but silently omitted their input tables from table lineage. `FunctionArguments::Subquery` was the only function-argument variant that the visitor did not traverse.

This change visits the contained query and adds a focused regression test verifying that:

```sql
SELECT ARRAY(SELECT id FROM source_table)
```

reports `source_table` as an input.

Validation:

- `cargo test -p openlineage_sql select_bq_array_subquery`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-default-features`
- Repository commit hooks

Closes #4762

### Checklist

- [x] AI was used in creating this PR
