### PR TITLE
build(deps): bump jackson-databind to 2.18.8 (CVE-2026-54512, CVE-202…

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -54,7 +54,7 @@ repositories {
 
 ext {
     assertjVersion = '3.27.7'
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     junit5Version = '5.13.4'
     lombokVersion = '1.18.46'
     mockitoVersion = '5.23.0'

--- a/client/java/generator/build.gradle
+++ b/client/java/generator/build.gradle
@@ -22,8 +22,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.4'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.18.8'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.8'
     implementation group: 'com.squareup', name: 'javapoet', version: '1.13.0'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.16'

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -232,6 +232,10 @@ shadowJar {
     relocate 'org.apache.commons.lang3', 'io.openlineage.flink.shaded.org.apache.commons.lang3'
     relocate "org.HdrHistogram", "io.openlineage.flink.shaded.org.hdrhistogram"
     relocate "org.LatencyUtils", "io.openlineage.flink.shaded.org.latencyutils"
+    // jackson-core 2.18+ ships FastDoubleParser as Java 21/22 multi-release classes that the
+    // shadow plugin's ASM cannot relocate; the Java 8 base classes remain and are fully functional.
+    exclude 'META-INF/versions/21/**'
+    exclude 'META-INF/versions/22/**'
     dependencies {
         exclude(dependency('org.slf4j::'))
     }

--- a/integration/flink/flink1/build.gradle
+++ b/integration/flink/flink1/build.gradle
@@ -24,7 +24,7 @@ ext {
     assertjVersion = '3.27.7'
     junit5Version = '5.14.4'
     lombokVersion = '1.18.46'
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     mockitoVersion = '5.2.0'
     testcontainersVersion = '1.21.4'
     micrometerVersion = '1.17.0'

--- a/integration/flink/flink2/build.gradle
+++ b/integration/flink/flink2/build.gradle
@@ -25,7 +25,7 @@ ext {
     testedflinkVersion = project.getProperty('flink.version')
     isReleaseVersion = !version.endsWith('-SNAPSHOT')
     assertjVersion = '3.27.7'
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     junit5Version = '5.14.4'
     lombokVersion = '1.18.46'
     scalaLibraryVersion = '2.12.20'

--- a/integration/hive/hive-openlineage-hook/build.gradle
+++ b/integration/hive/hive-openlineage-hook/build.gradle
@@ -30,7 +30,7 @@ ext {
     assertjVersion = '3.26.3'
     hiverunnerVersion = '6.1.0'
     jupiterVersion = '5.11.3'
-    jacksonVersion = '2.18.1'
+    jacksonVersion = '2.18.8'
     mockitoVersion = '4.11.0'
     hiveVersion = '3.1.3'
     hadoopVersion = '2.10.2'

--- a/integration/spark-extension-interfaces/build.gradle
+++ b/integration/spark-extension-interfaces/build.gradle
@@ -239,6 +239,11 @@ shadowJar {
     relocate('io.openlineage.client', 'io.openlineage.spark.shade.client')
     relocate('com.fasterxml', 'io.openlineage.spark.shade.com.fasterxml')
 
+    // jackson-core 2.18+ ships FastDoubleParser as Java 21/22 multi-release classes that the
+    // shadow plugin's ASM cannot relocate; the Java 8 base classes remain and are fully functional.
+    exclude 'META-INF/versions/21/**'
+    exclude 'META-INF/versions/22/**'
+
     archiveClassifier = ''
     // avoid conflict with any client version of that lib
     manifest {

--- a/integration/spark-extension-interfaces/build.gradle
+++ b/integration/spark-extension-interfaces/build.gradle
@@ -23,7 +23,7 @@ ext {
     assertjVersion = '3.25.3'
     mockitoVersion = '4.11.0'
     sparkVersion = '3.2.4'
-    jacksonVersion = '2.15.3'
+    jacksonVersion = '2.18.8'
 }
 
 final def mainSourceSet = sourceSets.main

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -275,6 +275,10 @@ tasks.named("shadowJar", ShadowJar.class) {
         exclude 'com.fasterxml.jackson.annotation.JsonIgnoreProperties'
         exclude 'com.fasterxml.jackson.annotation.JsonIgnoreType'
     }
+    // jackson-core 2.18+ ships FastDoubleParser as Java 21/22 multi-release classes that the
+    // shadow plugin's ASM cannot relocate; the Java 8 base classes remain and are fully functional.
+    exclude 'META-INF/versions/21/**'
+    exclude 'META-INF/versions/22/**'
     manifest {
         attributes([
                 'Created-By'            : "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -279,6 +279,11 @@ tasks.named("shadowJar", ShadowJar.class) {
     // shadow plugin's ASM cannot relocate; the Java 8 base classes remain and are fully functional.
     exclude 'META-INF/versions/21/**'
     exclude 'META-INF/versions/22/**'
+    // The agent does not use the server-side model, and the published shadowJar omits it too.
+    // Keeping it here shadows the unshaded openlineage-java copy on the integrationTest classpath
+    // with one whose Jackson annotations have been relocated, making them invisible to a plain
+    // ObjectMapper.
+    exclude 'io/openlineage/server/**'
     manifest {
         attributes([
                 'Created-By'            : "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -194,6 +194,10 @@ shadowJar {
     relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
     relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
+    // jackson-core 2.18+ ships FastDoubleParser as Java 21/22 multi-release classes that the
+    // shadow plugin's ASM cannot relocate; the Java 8 base classes remain and are fully functional.
+    exclude 'META-INF/versions/21/**'
+    exclude 'META-INF/versions/22/**'
     relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
     relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
 

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -31,7 +31,7 @@ ext {
     databricksVersion = "0.1.5"
     deltaVersion = "1.1.0"
     icebergVersion = "1.4.3"
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     junit5Version = "5.14.4"
     lombokVersion = "1.18.30"
     mockitoVersion = "4.11.0"

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -29,7 +29,7 @@ ext {
     assertjVersion = "3.27.7"
     deltaVersion = "1.1.0"
     icebergVersion = "0.14.1"
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     junit5Version = "5.14.4"
     mockitoVersion = "4.11.0"
     micrometerVersion = "1.17.0"

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -28,7 +28,7 @@ idea {
 ext {
     assertjVersion = "3.27.7"
     icebergVersion = "0.14.1"
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     junit5Version = "5.14.4"
     mockitoVersion = "4.11.0"
     micrometerVersion = "1.17.0"

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -29,7 +29,7 @@ ext {
     assertjVersion = "3.27.7"
     deltaVersion = "2.4.0"
     icebergVersion = "1.3.1"
-    jacksonVersion = "2.15.3"
+    jacksonVersion = "2.18.8"
     junit5Version = "5.14.4"
     mockitoVersion = "4.11.0"
     micrometerVersion = "1.17.0"


### PR DESCRIPTION
### One-line summary for changelog:
Build: Bump jackson-databind to 2.18.8 to remediate CVE-2026-54512 and CVE-2026-54513.


### Meaningful description
OpenLineage bundles jackson-databind 2.15.3 (2.18.1 in the Hive hook, 2.13.4.2 in the build-time generator), all within the affected ranges of two HIGH-severity (CVSS 8.1) PolymorphicTypeValidator allow-list bypass CVEs disclosed 2026-06-04:

- CVE-2026-54512 (GHSA-j3rv-43j4-c7qm): denied class smuggled as a generic type parameter of an allowed container.
- CVE-2026-54513 (GHSA-rmj7-2vxq-3g9f): array component type not validated by allowIfSubTypeIsArray().

Both are fixed in 2.18.8 / 2.21.4 / 3.1.4 (2.19.0–2.21.3 remain vulnerable). This PR bumps every `jacksonVersion` declaration and the generator's hard-coded jackson-core/databind versions to 2.18.8, a documented fixed release on the current 2.18 line. 2.18.8 keeps the existing single-version pattern working across all modules and avoids the jackson-annotations version split introduced in 2.20+ (which would be required to move to 2.21.4/2.22.x).

OpenLineage's own deserialization does not enable default typing or a PolymorphicTypeValidator and reads only trusted config, so it is not believed to be directly exploitable; this bump removes the flagged bundled dependency so SCA scanners (including this repo's datadog-sca workflow) and downstream consumers stay clean.

Verified locally: `./gradlew build check` in `client/java` passes - generator + code generation, main/shaded compile against 2.18.8, Spotless, PMD, and all 486 unit tests green.

Closes #4764

### Checklist
- [X] AI was used in creating this PR
