### PR TITLE
sql: include UPDATE assignment subquery inputs

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -694,6 +694,9 @@ impl Visit for Statement {
                         }
                     }
                 }
+                for assignment in &update.assignments {
+                    assignment.value.visit(context)?;
+                }
                 if let Some(expr) = &update.selection {
                     expr.visit(context)?;
                 }

--- a/integration/sql/impl/tests/table_lineage/tests_update.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_update.rs
@@ -57,6 +57,22 @@ fn update_table_from_subquery() {
 }
 
 #[test]
+fn update_table_from_assignment_subquery() {
+    assert_eq!(
+        test_sql(
+            "UPDATE dataset.Inventory
+            SET quantity = (SELECT quantity FROM dataset.NewArrivals)"
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["dataset.NewArrivals"]),
+            out_tables: tables(vec!["dataset.Inventory"])
+        }
+    )
+}
+
+#[test]
 fn update_identifier_function() {
     let test_cases = vec![
         (


### PR DESCRIPTION
### One-line summary for changelog:

SQL parser now includes tables referenced by UPDATE assignment subqueries in input lineage.

### Meaningful description

`Statement::Update` visited the target table, optional `FROM` tables, and optional `WHERE` expression, but skipped every `SET` assignment value. As a result, an assignment-only source such as:

```sql
UPDATE dataset.Inventory
SET quantity = (SELECT quantity FROM dataset.NewArrivals)
```

parsed without errors while silently omitting `dataset.NewArrivals` from `in_tables`.

This change visits each assignment value through the existing expression visitor and adds a focused regression test where the source appears only in the assignment subquery.

Closes #4766

Validation:

- `cargo test -p openlineage_sql update_table_from_assignment_subquery`
- `cargo test`
- `cargo test --no-default-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUN_TESTS=true bash iface-py/script/build-macos.sh` (universal2 wheel build and import smoke test)
- `bash script/compile.sh` and `bash script/build.sh` from `iface-java` (13 Gradle tests and packaged-jar smoke test)
- `uv run pytest` from `integration/common` (345 passed, 2 skipped)
- `uv run mypy --install-types --non-interactive --ignore-missing-imports src` from `integration/common`
- `prek run --files integration/sql/impl/src/visitor.rs integration/sql/impl/tests/table_lineage/tests_update.rs`
- `prek run --all-files` passed every non-Docker hook; Docker-backed ShellCheck and Go lint were unavailable because Docker Desktop is not installed, and neither applies to the changed Rust files

### Checklist

- [x] AI was used in creating this PR
