### PR TITLE
sql: fix MySQL multi-table DELETE lineage

### DIFF
--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -159,6 +159,18 @@ impl<'a> Context<'a> {
         }
     }
 
+    pub fn move_input_to_output(&mut self, input: Vec<Ident>) {
+        let name = DbTableMeta::new(
+            input,
+            self.dialect,
+            self.default_schema.clone(),
+            self.default_database.clone(),
+        );
+        let output = self.resolve_table(&name).clone();
+        self.inputs.remove(&output);
+        self.outputs.insert(output);
+    }
+
     pub fn add_non_table_output(
         &mut self,
         output: Vec<Ident>,

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -726,22 +726,36 @@ impl Visit for Statement {
                 }
             }
             Statement::Delete(delete) => {
-                match &delete.from {
+                let tables = match &delete.from {
                     FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => {
-                        for table in tables {
+                        tables
+                    }
+                };
+
+                if delete.tables.is_empty() {
+                    for table in tables {
+                        if let Some(output) =
+                            get_table_name_from_table_factor(&table.relation, &*context)
+                        {
+                            context.add_output(output);
+                        }
+                        for join in &table.joins {
                             if let Some(output) =
-                                get_table_name_from_table_factor(&table.relation, &*context)
+                                get_table_name_from_table_factor(&join.relation, &*context)
                             {
                                 context.add_output(output);
                             }
-                            for join in &table.joins {
-                                if let Some(join_output) =
-                                    get_table_name_from_table_factor(&join.relation, &*context)
-                                {
-                                    context.add_output(join_output);
-                                }
-                            }
                         }
+                    }
+                } else {
+                    for table in tables {
+                        table.relation.visit(context)?;
+                        for join in &table.joins {
+                            join.relation.visit(context)?;
+                        }
+                    }
+                    for table in &delete.tables {
+                        context.move_input_to_output(convert_to_idents(table));
                     }
                 }
 

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -748,6 +748,7 @@ impl Visit for Statement {
                         }
                     }
                 } else {
+                    let existing_inputs = context.inputs.clone();
                     for table in tables {
                         table.relation.visit(context)?;
                         for join in &table.joins {
@@ -757,6 +758,7 @@ impl Visit for Statement {
                     for table in &delete.tables {
                         context.move_input_to_output(convert_to_idents(table));
                     }
+                    context.inputs.extend(existing_inputs);
                 }
 
                 if let Some(using) = &delete.using {

--- a/integration/sql/impl/tests/table_lineage/tests_delete.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_delete.rs
@@ -53,6 +53,38 @@ fn delete_from_using() {
 }
 
 #[test]
+fn delete_mysql_multiple_tables() {
+    let test_cases = vec![
+        (
+            "DELETE t1 FROM t1 JOIN t2 ON t1.id = t2.id",
+            vec!["t2"],
+            vec!["t1"],
+        ),
+        (
+            "DELETE target FROM foo AS target JOIN bar AS lookup ON target.id = lookup.id",
+            vec!["bar"],
+            vec!["foo"],
+        ),
+        (
+            "DELETE t1, t2 FROM t1 JOIN t2 ON t1.id = t2.id JOIN lookup ON t1.id = lookup.id",
+            vec!["lookup"],
+            vec!["t1", "t2"],
+        ),
+    ];
+
+    for (sql, in_tables, out_tables) in test_cases {
+        assert_eq!(
+            test_sql_dialect(sql, "mysql").unwrap().table_lineage,
+            TableLineage {
+                in_tables: tables(in_tables),
+                out_tables: tables(out_tables),
+            },
+            "Failed for SQL: {sql}"
+        );
+    }
+}
+
+#[test]
 fn delete_identifier_function() {
     let test_cases = vec![
         ("target", vec![table("target")]),

--- a/integration/sql/impl/tests/table_lineage/tests_delete.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_delete.rs
@@ -85,6 +85,25 @@ fn delete_mysql_multiple_tables() {
 }
 
 #[test]
+fn delete_mysql_preserves_previous_inputs() {
+    assert_eq!(
+        test_multiple_sql_dialect(
+            vec![
+                "SELECT * FROM t1",
+                "DELETE t1 FROM t1 JOIN t2 ON t1.id = t2.id",
+            ],
+            "mysql",
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["t1", "t2"]),
+            out_tables: tables(vec!["t1"]),
+        }
+    );
+}
+
+#[test]
 fn delete_identifier_function() {
     let test_cases = vec![
         ("target", vec![table("target")]),


### PR DESCRIPTION
### One-line summary for changelog:
Correct MySQL multi-table DELETE lineage so explicit targets are outputs and joined lookup tables are inputs.

### Meaningful description
MySQL supports an explicit target list before the `FROM` clause:

```sql
DELETE target
FROM foo AS target
JOIN bar AS lookup ON target.id = lookup.id;
```

The SQL visitor previously ignored that target list and classified every relation in the joined `FROM` tree as an output. This produced no input lineage and incorrectly marked lookup tables as mutated datasets.

This change visits the joined tree as inputs when an explicit DELETE target list is present, resolves target aliases back to their base tables, and moves only those targets to outputs. Because the parser aggregates lineage across multiple statements, inputs collected before the DELETE are preserved. Existing single-table DELETE and DELETE USING behavior remains unchanged.

Regression coverage includes unaliased, aliased, multiple-target, and multi-statement MySQL DELETE cases.

Closes #4774

### Validation

- `cargo test` — 147 passed, 3 pre-existing ignored
- `cargo test --no-default-features` — 147 passed, 3 pre-existing ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- all configured pre-commit hooks applicable to the changed files

### Checklist
- [x] AI was used in creating this PR