### PR TITLE
client-java: generate singleton-enum discriminated unions

### DIFF
--- a/client/java/generator/build.gradle
+++ b/client/java/generator/build.gradle
@@ -27,5 +27,11 @@ dependencies {
     implementation group: 'com.squareup', name: 'javapoet', version: '1.13.0'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.16'
+
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.13.4'
+    testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher'
 }
 
+test {
+    useJUnitPlatform()
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.openlineage.client.TypeResolver.DefaultResolvedTypeVisitor;
 import io.openlineage.client.TypeResolver.ObjectResolvedType;
+import io.openlineage.client.TypeResolver.RefResolvedType;
 import io.openlineage.client.TypeResolver.ResolvedField;
 
 public class Generator {
@@ -164,26 +166,69 @@ public class Generator {
 
   private static void enrichFacetContainersWithFacets(
       TypeResolver typeResolver, Map<String, ObjectResolvedType> facetContainers) {
+    Set<String> explicitlyAttachedFacets = new HashSet<>();
     for (ObjectResolvedType objectResolvedType : typeResolver.getTypes()) {
       if (objectResolvedType.getContainer().equals(CONTAINER_CLASS_NAME)) {
         continue;
       }
       List<ResolvedField> properties = objectResolvedType.getProperties();
       for (ResolvedField property : properties) {
-        property.getType().accept(new DefaultResolvedTypeVisitor<Void>() {
-          @Override
-          public Void visit(ObjectResolvedType objectType) {
-            Set<ObjectResolvedType> parents = objectType.getParents();
-            for (ObjectResolvedType parent : parents) {
-              if (facetContainers.containsKey(parent.getName())) {
-                facetContainers.get(parent.getName()).getProperties().add(property);
-              }
+        Optional<ObjectResolvedType> propertyType =
+            typeResolver.resolveObjectType(property.getType());
+        if (propertyType.isPresent()) {
+          for (ObjectResolvedType parent : propertyType.get().getParents()) {
+            if (facetContainers.containsKey(parent.getName())) {
+              facetContainers.get(parent.getName()).getProperties().add(property);
+              explicitlyAttachedFacets.add(typeKey(propertyType.get()));
             }
-            return null;
           }
-        });
+        }
       }
     }
+
+    for (ObjectResolvedType objectResolvedType : typeResolver.getTypes()) {
+      if (objectResolvedType.getContainer().equals(CONTAINER_CLASS_NAME)
+          || explicitlyAttachedFacets.contains(typeKey(objectResolvedType))) {
+        continue;
+      }
+      for (ObjectResolvedType parent : objectResolvedType.getParents()) {
+        ObjectResolvedType facetContainer = facetContainers.get(parent.getName());
+        if (facetContainer == null) {
+          continue;
+        }
+
+        String facetName = inferFacetName(objectResolvedType.getName(), parent.getName());
+        if (facetName == null
+            || facetContainer.getProperties().stream()
+                .anyMatch(property -> property.getName().equals(facetName))) {
+          continue;
+        }
+        facetContainer
+            .getProperties()
+            .add(
+                new ResolvedField(
+                    new SchemaParser.Field(
+                        facetName,
+                        new SchemaParser.RefType("#/$defs/" + objectResolvedType.getName()),
+                        null),
+                    new RefResolvedType(
+                        objectResolvedType.getContainer(), objectResolvedType.getName())));
+      }
+    }
+  }
+
+  private static String typeKey(ObjectResolvedType type) {
+    return type.getContainer() + "." + type.getName();
+  }
+
+  private static String inferFacetName(String facetTypeName, String baseFacetTypeName) {
+    if (!facetTypeName.endsWith(baseFacetTypeName)
+        || facetTypeName.length() == baseFacetTypeName.length()) {
+      return null;
+    }
+    String prefix =
+        facetTypeName.substring(0, facetTypeName.length() - baseFacetTypeName.length());
+    return Character.toLowerCase(prefix.charAt(0)) + prefix.substring(1);
   }
 
   private static Map<String, ObjectResolvedType> indexFacetContainersByType(

--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -37,6 +37,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
@@ -53,6 +55,7 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 
 import io.openlineage.client.TypeResolver.ArrayResolvedType;
+import io.openlineage.client.TypeResolver.DiscriminatedUnionResolvedType;
 import io.openlineage.client.TypeResolver.ObjectResolvedType;
 import io.openlineage.client.TypeResolver.PrimitiveResolvedType;
 import io.openlineage.client.TypeResolver.ResolvedField;
@@ -309,7 +312,8 @@ public class JavaPoetGenerator {
           .build());
     }
     for (ObjectResolvedType parent : type.getParents()) {
-      modelClassBuilder.addSuperinterface(ClassName.get(containerPackage, parent.getContainer(), parent.getName()));
+      modelClassBuilder.addSuperinterface(
+          ClassName.get(containerPackage, containerClassName, parent.getName()));
     }
     //adds possibility to extend CustomFacet
     if (!type.getName().equals("CustomFacet")) {
@@ -562,6 +566,10 @@ public class JavaPoetGenerator {
         .addModifiers(STATIC, PUBLIC)
         .addJavadoc("Interface for $N\n", type.getName());
 
+    if (type instanceof DiscriminatedUnionResolvedType) {
+      addDiscriminatorAnnotations(interfaceBuilder, (DiscriminatedUnionResolvedType) type);
+    }
+
     generateDefaultImplementation(containerTypeBuilder, type, interfaceBuilder);
 
     for (ResolvedField f : type.getProperties()) {
@@ -603,6 +611,38 @@ public class JavaPoetGenerator {
     TypeSpec intrfc = interfaceBuilder.build();
 
     containerTypeBuilder.addType(intrfc);
+  }
+
+  private void addDiscriminatorAnnotations(
+      TypeSpec.Builder interfaceBuilder, DiscriminatedUnionResolvedType type) {
+    interfaceBuilder.addAnnotation(
+        AnnotationSpec.builder(JsonTypeInfo.class)
+            .addMember("use", "$T.$L", JsonTypeInfo.Id.class, JsonTypeInfo.Id.NAME)
+            .addMember(
+                "include",
+                "$T.$L",
+                JsonTypeInfo.As.class,
+                JsonTypeInfo.As.EXISTING_PROPERTY)
+            .addMember("property", "$S", type.getDiscriminatorField())
+            .addMember("visible", "$L", true)
+            .build());
+
+    AnnotationSpec.Builder subTypes = AnnotationSpec.builder(JsonSubTypes.class);
+    type
+        .getVariants()
+        .forEach(
+            (discriminatorValue, variant) ->
+                subTypes.addMember(
+                    "value",
+                    "$L",
+                    AnnotationSpec.builder(JsonSubTypes.Type.class)
+                        .addMember(
+                            "value",
+                            "$T.class",
+                            ClassName.get(containerClass, variant.getName()))
+                        .addMember("name", "$S", discriminatorValue)
+                        .build()));
+    interfaceBuilder.addAnnotation(subTypes.build());
   }
 
   private void generateDefaultImplementation(
@@ -833,7 +873,8 @@ public class JavaPoetGenerator {
 
       @Override
       public TypeName visit(TypeResolver.EnumResolvedType enumType) {
-        return ClassName.get(containerClass, enumType.getParentName() + "." + enumType.getName());
+        return ClassName.get(
+            containerPackage, containerClassName, enumType.getParentName(), enumType.getName());
       }
 
       @Override

--- a/client/java/generator/src/main/java/io/openlineage/client/TypeResolver.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/TypeResolver.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -124,14 +125,43 @@ public class TypeResolver {
               .map(refType -> visit(refType))
               .collect(Collectors.toList());
 
+          if (resolvedTypes.size() == oneOfType.getTypes().size()) {
+            Optional<Discriminator> discriminator = findDiscriminator(resolvedTypes);
+            if (discriminator.isPresent()) {
+              DiscriminatedUnionResolvedType unionType =
+                  new DiscriminatedUnionResolvedType(
+                      container,
+                      currentName,
+                      discriminator.get().getFieldName(),
+                      discriminator.get().getVariants());
+              String key = container + "." + unionType.getName();
+              if (types.put(key, unionType) != null) {
+                throw new RuntimeException("Duplicated type: " + unionType.getName());
+              }
+              baseTypes.add(unionType.getName());
+              discriminator
+                  .get()
+                  .getVariants()
+                  .values()
+                  .forEach(variant -> variant.addParent(unionType));
+              return unionType;
+            }
+          }
+
           // return first of
           return resolvedTypes.get(0);
         }
 
         @Override
-        public ResolvedType visit(AnyOfType oneOfType) {
+        public ResolvedType visit(AnyOfType anyOfType) {
           // in case of anyOf we generate code based on the first type available
-          return visit(oneOfType.getChildren().get(0));
+          List<Type> children = anyOfType.getChildren();
+          ResolvedType resolvedType = visit(children.get(0));
+          children.stream()
+              .skip(1)
+              .filter(type -> type instanceof RefType)
+              .forEach(this::visit);
+          return resolvedType;
         }
 
         @Override
@@ -226,6 +256,55 @@ public class TypeResolver {
           }
         }
 
+        private Optional<Discriminator> findDiscriminator(List<ResolvedType> resolvedTypes) {
+          List<ObjectResolvedType> variants =
+              resolvedTypes.stream()
+                  .map(TypeResolver.this::resolveObjectType)
+                  .filter(Optional::isPresent)
+                  .map(Optional::get)
+                  .collect(Collectors.toList());
+          if (variants.size() != resolvedTypes.size() || variants.size() < 2) {
+            return Optional.empty();
+          }
+
+          for (ResolvedField candidate : variants.get(0).getProperties()) {
+            if (!isSingletonEnum(candidate)) {
+              continue;
+            }
+
+            Map<String, ObjectResolvedType> variantsByValue = new LinkedHashMap<>();
+            boolean matchesAllVariants = true;
+            for (ObjectResolvedType variant : variants) {
+              Optional<ResolvedField> matchingField =
+                  variant.getProperties().stream()
+                      .filter(field -> field.getName().equals(candidate.getName()))
+                      .filter(this::isSingletonEnum)
+                      .findFirst();
+              if (!matchingField.isPresent()) {
+                matchesAllVariants = false;
+                break;
+              }
+
+              EnumResolvedType enumType = (EnumResolvedType) matchingField.get().getType();
+              String discriminatorValue = enumType.getValues().get(0);
+              if (variantsByValue.put(discriminatorValue, variant) != null) {
+                matchesAllVariants = false;
+                break;
+              }
+            }
+
+            if (matchesAllVariants) {
+              return Optional.of(new Discriminator(candidate.getName(), variantsByValue));
+            }
+          }
+          return Optional.empty();
+        }
+
+        private boolean isSingletonEnum(ResolvedField field) {
+          return field.getType() instanceof EnumResolvedType
+              && ((EnumResolvedType) field.getType()).getValues().size() == 1;
+        }
+
       };
 
       this.rootResolvedTypePerURL.put(baseUrl, rootType.accept(visitor));
@@ -257,6 +336,34 @@ public class TypeResolver {
 
   public ResolvedType getRootResolvedType(URL url) {
     return rootResolvedTypePerURL.get(url);
+  }
+
+  Optional<ObjectResolvedType> resolveObjectType(ResolvedType resolvedType) {
+    if (resolvedType instanceof ObjectResolvedType) {
+      return Optional.of((ObjectResolvedType) resolvedType);
+    }
+    if (resolvedType instanceof RefResolvedType) {
+      return Optional.ofNullable(types.get(((RefResolvedType) resolvedType).getFullName()));
+    }
+    return Optional.empty();
+  }
+
+  private static class Discriminator {
+    private final String fieldName;
+    private final Map<String, ObjectResolvedType> variants;
+
+    private Discriminator(String fieldName, Map<String, ObjectResolvedType> variants) {
+      this.fieldName = fieldName;
+      this.variants = variants;
+    }
+
+    private String getFieldName() {
+      return fieldName;
+    }
+
+    private Map<String, ObjectResolvedType> getVariants() {
+      return variants;
+    }
   }
 
   interface ResolvedType {
@@ -414,7 +521,7 @@ public class TypeResolver {
       this.container = container;
       this.objectTypes = objectTypes;
       this.name = name;
-      this.parents = parents;
+      this.parents = new LinkedHashSet<>(parents);
       this.properties = properties;
       this.additionalProperties = additionalProperties;
       this.additionalPropertiesType = additionalPropertiesType;
@@ -434,6 +541,10 @@ public class TypeResolver {
 
     public Set<ObjectResolvedType> getParents() {
       return parents;
+    }
+
+    public void addParent(ObjectResolvedType parent) {
+      parents.add(parent);
     }
 
     public List<ResolvedField> getProperties() {
@@ -481,6 +592,36 @@ public class TypeResolver {
     public int hashCode() {
       return Objects.hash(container, objectTypes, name, properties, additionalProperties,
           additionalPropertiesType, parents);
+    }
+  }
+
+  static class DiscriminatedUnionResolvedType extends ObjectResolvedType {
+    private final String discriminatorField;
+    private final Map<String, ObjectResolvedType> variants;
+
+    DiscriminatedUnionResolvedType(
+        String container,
+        String name,
+        String discriminatorField,
+        Map<String, ObjectResolvedType> variants) {
+      super(
+          container,
+          Collections.emptyList(),
+          name,
+          Collections.emptySet(),
+          Collections.emptyList(),
+          false,
+          null);
+      this.discriminatorField = discriminatorField;
+      this.variants = variants;
+    }
+
+    public String getDiscriminatorField() {
+      return discriminatorField;
+    }
+
+    public Map<String, ObjectResolvedType> getVariants() {
+      return variants;
     }
   }
 

--- a/client/java/generator/src/test/java/io/openlineage/client/GeneratorTest.java
+++ b/client/java/generator/src/test/java/io/openlineage/client/GeneratorTest.java
@@ -1,0 +1,149 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GeneratorTest {
+
+  @TempDir Path outputDirectory;
+
+  @Test
+  void generatesSingletonEnumDiscriminatedUnions() throws Exception {
+    String source = generate();
+
+    assertTrue(source.contains("public interface LineageEntry"));
+    assertTrue(
+        source.contains(
+            "@JsonTypeInfo(\n"
+                + "      use = JsonTypeInfo.Id.NAME,\n"
+                + "      include = JsonTypeInfo.As.EXISTING_PROPERTY,\n"
+                + "      property = \"type\",\n"
+                + "      visible = true\n"
+                + "  )"));
+    assertTrue(
+        source.contains(
+            "@JsonSubTypes.Type(value = LineageDatasetEntry.class, name = \"DATASET\")"));
+    assertTrue(
+        source.contains(
+            "@JsonSubTypes.Type(value = LineageJobEntry.class, name = \"JOB\")"));
+    assertTrue(
+        source.contains(
+            "public static final class LineageDatasetEntry implements LineageEntry"));
+    assertTrue(
+        source.contains("public static final class LineageJobEntry implements LineageEntry"));
+    assertTrue(source.contains("public interface LineageInput"));
+  }
+
+  @Test
+  void attachesFacetsSharingANameToTheirBaseFacetContainers() throws Exception {
+    String source = generate();
+
+    assertTrue(
+        source.contains("private final LineageDatasetFacet lineage;"));
+    assertTrue(
+        source.contains("private final LineageJobFacet lineage;"));
+  }
+
+  @Test
+  void generatedUnionDeserializesToItsConcreteVariant() throws Exception {
+    generate();
+    Path generatedSource = outputDirectory.resolve("OpenLineage.java");
+    Path compiledClasses = Files.createDirectory(outputDirectory.resolve("classes"));
+    ByteArrayOutputStream compilerOutput = new ByteArrayOutputStream();
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+    assertNotNull(compiler);
+    assertEquals(
+        0,
+        compiler.run(
+            null,
+            null,
+            compilerOutput,
+            "-classpath",
+            System.getProperty("java.class.path"),
+            "-d",
+            compiledClasses.toString(),
+            generatedSource.toString()),
+        compilerOutput.toString("UTF-8"));
+
+    try (URLClassLoader classLoader =
+        new URLClassLoader(
+            new URL[] {compiledClasses.toUri().toURL()}, getClass().getClassLoader())) {
+      Class<?> unionType =
+          classLoader.loadClass("io.openlineage.client.OpenLineage$LineageEntry");
+      Object value =
+          new ObjectMapper()
+              .readValue("{\"type\":\"DATASET\",\"namespace\":\"warehouse\"}", unionType);
+
+      assertEquals("LineageDatasetEntry", value.getClass().getSimpleName());
+    }
+  }
+
+  @Test
+  void preservesFirstBranchBehaviorForOtherUnions() throws Exception {
+    Set<URL> schemas = schemas();
+    TypeResolver resolver = new TypeResolver(schemas);
+    TypeResolver.ObjectResolvedType root =
+        (TypeResolver.ObjectResolvedType)
+            resolver.getRootResolvedType(
+                getClass().getResource("/discriminated-union/SharedFacet.json"));
+
+    String source = generate(schemas);
+    assertFalse(source.contains("interface LegacyChoice"));
+    assertFalse(source.contains("interface PlainChoice"));
+    assertEquals("LegacyFirst", resolvedObjectField(root, "legacy").getName());
+    assertEquals("PlainFirst", resolvedObjectField(root, "plain").getName());
+  }
+
+  private String generate() throws Exception {
+    return generate(schemas());
+  }
+
+  private String generate(Set<URL> schemas) throws Exception {
+    Generator.generate(
+        schemas, "io.openlineage.client", false, outputDirectory.toFile());
+
+    File generatedSource = outputDirectory.resolve("OpenLineage.java").toFile();
+    return new String(Files.readAllBytes(generatedSource.toPath()), "UTF-8");
+  }
+
+  private Set<URL> schemas() {
+    URL coreSchema = getClass().getResource("/discriminated-union/OpenLineage.json");
+    URL facetSchema = getClass().getResource("/discriminated-union/SharedFacet.json");
+    Set<URL> schemas = new LinkedHashSet<>();
+    schemas.add(coreSchema);
+    schemas.add(facetSchema);
+    return schemas;
+  }
+
+  private TypeResolver.ObjectResolvedType resolvedObjectField(
+      TypeResolver.ObjectResolvedType type, String fieldName) {
+    return (TypeResolver.ObjectResolvedType)
+        type.getProperties().stream()
+            .filter(field -> field.getName().equals(fieldName))
+            .findFirst()
+            .orElseThrow(AssertionError::new)
+            .getType();
+  }
+}

--- a/client/java/generator/src/test/resources/discriminated-union/OpenLineage.json
+++ b/client/java/generator/src/test/resources/discriminated-union/OpenLineage.json
@@ -1,0 +1,77 @@
+{
+  "$comment": "Copyright 2018-2026 contributors to the OpenLineage project; SPDX-License-Identifier: Apache-2.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "BaseFacet": {
+      "type": "object",
+      "properties": {
+        "_producer": {
+          "type": "string",
+          "format": "uri"
+        },
+        "_schemaURL": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": true
+    },
+    "JobFacet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseFacet"
+        }
+      ]
+    },
+    "DatasetFacet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/BaseFacet"
+        }
+      ]
+    },
+    "Job": {
+      "type": "object",
+      "properties": {
+        "facets": {
+          "type": "object",
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/JobFacet"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Dataset": {
+      "type": "object",
+      "properties": {
+        "facets": {
+          "type": "object",
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/DatasetFacet"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "job": {
+      "$ref": "#/$defs/Job"
+    },
+    "dataset": {
+      "$ref": "#/$defs/Dataset"
+    }
+  }
+}

--- a/client/java/generator/src/test/resources/discriminated-union/SharedFacet.json
+++ b/client/java/generator/src/test/resources/discriminated-union/SharedFacet.json
@@ -1,0 +1,191 @@
+{
+  "$comment": "Copyright 2018-2026 contributors to the OpenLineage project; SPDX-License-Identifier: Apache-2.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "LineageDatasetFacet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "inputs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/LineageInput"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "LineageJobFacet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "OpenLineage.json#/$defs/JobFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "entries": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/LineageEntry"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "LineageEntry": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LineageDatasetEntry"
+        },
+        {
+          "$ref": "#/$defs/LineageJobEntry"
+        }
+      ]
+    },
+    "LineageDatasetEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "DATASET"
+          ]
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    },
+    "LineageJobEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "JOB"
+          ]
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    },
+    "LineageInput": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LineageDatasetInput"
+        },
+        {
+          "$ref": "#/$defs/LineageJobInput"
+        }
+      ]
+    },
+    "LineageDatasetInput": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "DATASET"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "LineageJobInput": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "JOB"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "LegacyChoice": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LegacyFirst"
+        },
+        {
+          "$ref": "#/$defs/LegacySecond"
+        }
+      ]
+    },
+    "LegacyFirst": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "FIRST"
+        }
+      }
+    },
+    "LegacySecond": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "const": "SECOND"
+        }
+      }
+    },
+    "PlainChoice": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/PlainFirst"
+        },
+        {
+          "$ref": "#/$defs/PlainSecond"
+        }
+      ]
+    },
+    "PlainFirst": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "PlainSecond": {
+      "type": "object",
+      "properties": {
+        "otherValue": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "lineage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LineageDatasetFacet"
+        },
+        {
+          "$ref": "#/$defs/LineageJobFacet"
+        }
+      ]
+    },
+    "legacy": {
+      "$ref": "#/$defs/LegacyChoice"
+    },
+    "plain": {
+      "$ref": "#/$defs/PlainChoice"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- generate Jackson-polymorphic interfaces for `oneOf` references with distinct singleton string-enum discriminators
- make concrete variants implement the generated interface while preserving existing behavior for `const` and non-discriminated unions
- discover facets by their base facet type so job and dataset facets can share the same container key
- correctly qualify repeated nested enum names such as `Type`
- add synthetic generation, compilation, and deserialization tests

## Motivation

This is a prerequisite for generating Java models from the upcoming explicit lineage facet schema without hand-written model exceptions.

That schema needs a common entry type whose concrete shape is selected by a singleton enum:

```json
{
  "LineageEntry": {
    "oneOf": [
      { "$ref": "#/$defs/LineageDatasetEntry" },
      { "$ref": "#/$defs/LineageJobEntry" }
    ]
  },
  "LineageDatasetEntry": {
    "type": "object",
    "properties": {
      "type": { "type": "string", "enum": ["DATASET"] }
    }
  },
  "LineageJobEntry": {
    "type": "object",
    "properties": {
      "type": { "type": "string", "enum": ["JOB"] }
    }
  }
}
```

`LineageJobFacet.entries` then refers to `LineageEntry`:

```json
{
  "entries": {
    "type": "array",
    "items": { "$ref": "#/$defs/LineageEntry" }
  }
}
```

Before this change, the Java resolver discarded the union and returned its first referenced branch. The resulting API would therefore expose `List<LineageDatasetEntry>` instead of `List<LineageEntry>`. A `JOB` entry could neither be supplied through the generated factories/builders nor deserialized from JSON.

This PR instead generates the equivalent of:

```java
@JsonTypeInfo(property = "type", ...)
@JsonSubTypes({
  @JsonSubTypes.Type(value = LineageDatasetEntry.class, name = "DATASET"),
  @JsonSubTypes.Type(value = LineageJobEntry.class, name = "JOB")
})
interface LineageEntry {}

final class LineageDatasetEntry implements LineageEntry {}
final class LineageJobEntry implements LineageEntry {}
```

The explicit lineage schema also registers the same facet key for two different facet base types:

```json
{
  "lineage": {
    "anyOf": [
      { "$ref": "#/$defs/LineageDatasetFacet" },
      { "$ref": "#/$defs/LineageJobFacet" }
    ]
  }
}
```

Previously only the first branch was attached to a generated facet container. Facet discovery now uses each concrete facet's base type and inferred key, allowing both `DatasetFacets.lineage` and `JobFacets.lineage` to be generated from one schema document.
