### PR TITLE
spark: support Spark 4.2, where CatalogManager became an interface

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -28,8 +28,6 @@ import scala.collection.immutable.HashMap;
 
 public class CatalogTableTestUtils {
 
-  private static final int PARAMETER_COUNT = 19;
-
   @SneakyThrows
   public static CatalogTable getCatalogTable(TableIdentifier tableIdentifier) {
     Method applyMethod =
@@ -40,14 +38,7 @@ public class CatalogTableTestUtils {
     List<Object> params = new ArrayList<>();
     params.add(tableIdentifier);
     params.add(CatalogTableType.MANAGED());
-    params.add(
-        CatalogStorageFormat.apply(
-            Option.apply(new URI("/some/location")),
-            Option.empty(),
-            Option.empty(),
-            Option.empty(),
-            false,
-            null));
+    params.add(getCatalogStorageFormat());
     params.add(
         new StructType(
             new StructField[] {
@@ -64,16 +55,38 @@ public class CatalogTableTestUtils {
     params.add(Option.empty());
     params.add(Option.empty());
     params.add(Option.empty());
-    if (System.getProperty("spark.version").startsWith("4")) {
+    if (Option.class.equals(applyMethod.getParameterTypes()[params.size()])) {
       params.add(Option.empty());
     }
     params.add(Seq$.MODULE$.<String>empty());
     params.add(false);
     params.add(false);
     params.add(new HashMap<>());
-    if (applyMethod.getParameterCount() > PARAMETER_COUNT) {
+    while (applyMethod.getParameterCount() > params.size()) {
       params.add(Option.empty());
     }
     return (CatalogTable) applyMethod.invoke(null, params.toArray());
+  }
+
+  private static CatalogStorageFormat getCatalogStorageFormat() throws Exception {
+    Method applyMethod =
+        Arrays.stream(CatalogStorageFormat.class.getDeclaredMethods())
+            .filter(m -> "apply".equals(m.getName()))
+            .filter(m -> CatalogStorageFormat.class.equals(m.getReturnType()))
+            .findFirst()
+            .get();
+    List<Object> params =
+        new ArrayList<>(
+            Arrays.asList(
+                Option.apply(new URI("/some/location")),
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                false,
+                new HashMap<>()));
+    if (applyMethod.getParameterCount() > params.size()) {
+      params.add(Option.empty());
+    }
+    return (CatalogStorageFormat) applyMethod.invoke(null, params.toArray());
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
@@ -46,6 +46,8 @@ import scala.collection.immutable.HashMap;
 // This test is disabled for Spark 4.x versions, as the LogicalPlan constructor has changed
 @DisabledIfSystemProperty(named = "spark.version", matches = "([4].*)")
 class LogicalPlanSerializerTest {
+  private static final int JDBC_RELATION_PARAMETER_COUNT = 4;
+  private static final int JDBC_RELATION_WITH_METRICS_PARAMETER_COUNT = 5;
   private static final String TEST_DATA = "test_data";
   private static final String NAME = "name";
   private static final String TEST = "test";
@@ -68,14 +70,12 @@ class LogicalPlanSerializerTest {
         ScalaConversionUtils.fromJavaMap(
             Collections.singletonMap("driver", Driver.class.getName()));
     JDBCRelation relation =
-        new JDBCRelation(
+        newJdbcRelation(
             new StructType(
                 new StructField[] {
                   new StructField(NAME, StringType$.MODULE$, false, Metadata.empty())
                 }),
-            new Partition[] {},
-            new JDBCOptions(jdbcUrl, sparkTableName, map),
-            mock(SparkSession.class));
+            new JDBCOptions(jdbcUrl, sparkTableName, map));
 
     LogicalRelation instance;
     Aggregate instanceAggregate;
@@ -239,5 +239,23 @@ class LogicalPlanSerializerTest {
         .satisfies(new MatchesMapRecursively(expectedCommandNode, Collections.singleton(EXPR_ID)));
     assertThat(hadoopFSActualNode)
         .satisfies(new MatchesMapRecursively(expectedHadoopFSNode, Collections.singleton(EXPR_ID)));
+  }
+
+  private JDBCRelation newJdbcRelation(StructType schema, JDBCOptions options)
+      throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    Constructor<?> constructor = JDBCRelation.class.getDeclaredConstructors()[0];
+    Object[] parameters;
+    if (constructor.getParameterCount() == JDBC_RELATION_PARAMETER_COUNT) {
+      parameters = new Object[] {schema, new Partition[] {}, options, mock(SparkSession.class)};
+    } else if (constructor.getParameterCount() == JDBC_RELATION_WITH_METRICS_PARAMETER_COUNT) {
+      parameters =
+          new Object[] {
+            schema, new Partition[] {}, options, new HashMap<>(), mock(SparkSession.class)
+          };
+    } else {
+      throw new IllegalStateException(
+          "Unsupported JDBCRelation constructor: " + constructor.toGenericString());
+    }
+    return (JDBCRelation) constructor.newInstance(parameters);
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -113,7 +113,7 @@ public class CatalogDatasetFacetUtils {
       //noinspection unchecked
       return Optional.ofNullable(
               ((Option<String>) MethodUtils.invokeMethod(identifier, "catalog")).get())
-          .map(catalogName -> session.sessionState().catalogManager().catalog(catalogName));
+          .flatMap(catalogName -> SparkSessionUtils.catalog(session, catalogName));
     } catch (NoSuchMethodException
         | IllegalAccessException
         | InvocationTargetException

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
@@ -7,7 +7,9 @@ package io.openlineage.spark.agent.util;
 
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 
 @Slf4j
 public class SparkSessionUtils {
@@ -19,6 +21,25 @@ public class SparkSessionUtils {
       // need to catch exception so that org.apache.spark.SparkException for Spark 4.0 is caught
       // which is not thrown for other Spark versions
       log.debug("Cannot obtain active spark session", e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Resolves a catalog by name from the session's catalog manager.
+   *
+   * <p>Spark 4.2 turned {@code CatalogManager} from a class into an interface, so code compiled
+   * against earlier Spark versions emits {@code invokevirtual} and fails at runtime with {@link
+   * IncompatibleClassChangeError}. Calling {@code catalog} reflectively keeps this binary
+   * compatible with both shapes of the API.
+   */
+  public static Optional<CatalogPlugin> catalog(SparkSession session, String catalogName) {
+    try {
+      Object catalogManager = session.sessionState().catalogManager();
+      return Optional.ofNullable(
+          (CatalogPlugin) MethodUtils.invokeMethod(catalogManager, "catalog", catalogName));
+    } catch (Exception e) {
+      log.debug("Cannot obtain catalog {} from the session catalog manager", catalogName, e);
       return Optional.empty();
     }
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -27,8 +27,6 @@ import scala.collection.immutable.HashMap;
 
 public class CatalogTableTestUtils {
 
-  private static final int PARAMETERS_COUNT = 19;
-
   @SneakyThrows
   public static CatalogTable getCatalogTable(TableIdentifier tableIdentifier) {
     Method applyMethod =
@@ -39,14 +37,7 @@ public class CatalogTableTestUtils {
     List<Object> params = new ArrayList<>();
     params.add(tableIdentifier);
     params.add(CatalogTableType.MANAGED());
-    params.add(
-        CatalogStorageFormat.apply(
-            Option.apply(new URI("/some/location")),
-            Option.empty(),
-            Option.empty(),
-            Option.empty(),
-            false,
-            null));
+    params.add(getCatalogStorageFormat());
     params.add(
         new StructType(
             new StructField[] {
@@ -63,13 +54,38 @@ public class CatalogTableTestUtils {
     params.add(Option.empty());
     params.add(Option.empty());
     params.add(Option.empty());
+    if (Option.class.equals(applyMethod.getParameterTypes()[params.size()])) {
+      params.add(Option.empty());
+    }
     params.add(ScalaConversionUtils.asScalaSeqEmpty());
     params.add(false);
     params.add(false);
     params.add(new HashMap<>());
-    if (applyMethod.getParameterCount() > PARAMETERS_COUNT) {
+    while (applyMethod.getParameterCount() > params.size()) {
       params.add(Option.empty());
     }
     return (CatalogTable) applyMethod.invoke(null, params.toArray());
+  }
+
+  private static CatalogStorageFormat getCatalogStorageFormat() throws Exception {
+    Method applyMethod =
+        Arrays.stream(CatalogStorageFormat.class.getDeclaredMethods())
+            .filter(m -> "apply".equals(m.getName()))
+            .filter(m -> CatalogStorageFormat.class.equals(m.getReturnType()))
+            .findFirst()
+            .get();
+    List<Object> params =
+        new ArrayList<>(
+            Arrays.asList(
+                Option.apply(new URI("/some/location")),
+                Option.empty(),
+                Option.empty(),
+                Option.empty(),
+                false,
+                new HashMap<>()));
+    if (applyMethod.getParameterCount() > params.size()) {
+      params.add(Option.empty());
+    }
+    return (CatalogStorageFormat) applyMethod.invoke(null, params.toArray());
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -9,6 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
@@ -19,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
-import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import scala.Option;
@@ -72,9 +72,8 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
       return;
     }
 
-    CatalogManager catalogManager = context.getSparkSession().get().sessionState().catalogManager();
-    Optional.of(catalogManager.catalog(catalogName))
-        .filter(catalogPlugin -> catalogPlugin instanceof TableCatalog)
+    SparkSessionUtils.catalog(context.getSparkSession().get(), catalogName)
+        .filter(plugin -> plugin instanceof TableCatalog)
         .map(TableCatalog.class::cast)
         .ifPresent(
             tableCatalog ->


### PR DESCRIPTION
## Problem

Every containerized Spark integration test on Spark 4.2 hangs until the CI job hits the 1h timeout — see [job 571359](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/19412/workflows/e08b204a-f572-4edc-bb82-3bf1ab101a30/jobs/571359) (surfaced while adding Spark 4.2 to the test matrix in #4747).

Root cause, from the container logs:

```
Exception in thread "spark-listener-group-shared" java.lang.IncompatibleClassChangeError:
  Found interface org.apache.spark.sql.connector.catalog.CatalogManager, but class was expected
	at io.openlineage.spark.agent.util.CatalogDatasetFacetUtils.lambda$getCatalogPlugin$4(CatalogDatasetFacetUtils.java:116)
	at io.openlineage.spark.agent.util.CatalogDatasetFacetUtils.isHiveCatalog(CatalogDatasetFacetUtils.java:90)
	at io.openlineage.spark.agent.util.PathUtils.fromCatalogTable(PathUtils.java:60)
	...
ERROR org.apache.spark.util.Utils - uncaught error in thread spark-listener-group-shared, stopping SparkContext
```

Spark 4.2 turned `CatalogManager` from a class into an interface. Our modules are compiled against older Spark versions, so `catalogManager().catalog(name)` was emitted as `invokevirtual` and fails to resolve at runtime. Because it throws on the listener thread, Spark stops the `SparkContext`, so the test app never reports and the job wedges.

## Change

- Add `SparkSessionUtils.catalog(session, catalogName)`, which resolves the catalog reflectively and is binary compatible with both the class and the interface shape of `CatalogManager`.
- Route both call sites (`CatalogDatasetFacetUtils.getCatalogPlugin` and `spark3`'s `LogicalRelationDatasetBuilder`) through it.
- Make the Spark test fixtures version tolerant: `CatalogTable` / `CatalogStorageFormat` factory arities and the `JDBCRelation` constructor changed again in 4.2, so they are discovered reflectively rather than keyed off hardcoded parameter counts.

## Verification

- `javap` on the rebuilt classes confirms no remaining `invokevirtual` against `CatalogManager` (only `SessionState.catalogManager()`, whose receiver is still a class).
- `:shared:test` passes against both ends of the supported range — Spark 3.2.4/Scala 2.12 and Spark 4.2.0/Scala 2.13.
- Full Spark 4.2 matrix coverage comes from #4747, which stacks on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
