### PR TITLE
ci: add py3-common-dbt-1.3 tox env to unit-test-integration-common

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -330,6 +330,8 @@ jobs:
       - run: |
           uv run --python 3.10 --with tox python -m tox r -e "py3-common-dbt-1.0" --notest
           uv run --python 3.10 --with tox python -m tox r -e "py3-common-dbt-1.0" --skip-pkg-install
+          uv run --python 3.10 --with tox python -m tox r -e "py3-common-dbt-1.3" --notest
+          uv run --python 3.10 --with tox python -m tox r -e "py3-common-dbt-1.3" --skip-pkg-install
           uv run --python 3.10 mypy --install-types --non-interactive --ignore-missing-imports src
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:


### PR DESCRIPTION
## Summary

- Adds `py3-common-dbt-1.3` (dbt-core>=1.3) to the `unit-test-integration-common` CI job alongside the existing `py3-common-dbt-1.0` (dbt-core>=1.0,<1.3) environment
- This ensures manifest v12 code paths (dbt v1.8+, introduced in dbt-core 1.8) are exercised in CI; previously only pre-1.3 builds ran
- The `tox.ini` in `integration/common/pyproject.toml` already declares both environments (`env_list = py3-common-dbt-1.0,py3-common-dbt-1.3`), but CI only ran the 1.0 variant

## Context

`pyproject.toml` defines two tox environments:
- `dbt-1.0`: `dbt-core>=1.0,<1.3`
- `dbt-1.3`: `dbt-core>=1.3` (covers dbt v1.8 which introduced manifest v12)

The CI job was only running `py3-common-dbt-1.0`, leaving the v1.8+ code path untested in CI.

## Test plan

- [ ] Verify `unit-test-integration-common` now runs both `py3-common-dbt-1.0` and `py3-common-dbt-1.3` tox environments in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)