### PR TITLE
sql: include JOIN condition subquery inputs

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -7,10 +7,10 @@ use crate::lineage::*;
 use anyhow::{anyhow, Result};
 use sqlparser::ast::{
     AccessExpr, AlterTableOperation, CreateTableLikeKind, Expr, FromTable, Function, FunctionArg,
-    FunctionArgExpr, FunctionArguments, Ident, ObjectName, ObjectNamePart, Query,
-    RenameTableNameKind, Select, SelectItem, SetExpr, Statement, Subscript, Table, TableFactor,
-    TableFunctionArgs, TableObject, UpdateTableFromKind, Use, Value, ValueWithSpan, WindowSpec,
-    WindowType, With,
+    FunctionArgExpr, FunctionArguments, Ident, Join, JoinConstraint, JoinOperator, ObjectName,
+    ObjectNamePart, Query, RenameTableNameKind, Select, SelectItem, SetExpr, Statement, Subscript,
+    Table, TableFactor, TableFunctionArgs, TableObject, UpdateTableFromKind, Use, Value,
+    ValueWithSpan, WindowSpec, WindowType, With,
 };
 use sqlparser::dialect::{DatabricksDialect, MsSqlDialect, SnowflakeDialect};
 
@@ -473,6 +473,48 @@ impl Visit for WindowSpec {
     }
 }
 
+impl Visit for Join {
+    fn visit(&self, context: &mut Context) -> Result<()> {
+        self.relation.visit(context)?;
+
+        let constraint = match &self.join_operator {
+            JoinOperator::Join(constraint)
+            | JoinOperator::Inner(constraint)
+            | JoinOperator::Left(constraint)
+            | JoinOperator::LeftOuter(constraint)
+            | JoinOperator::Right(constraint)
+            | JoinOperator::RightOuter(constraint)
+            | JoinOperator::FullOuter(constraint)
+            | JoinOperator::CrossJoin(constraint)
+            | JoinOperator::Semi(constraint)
+            | JoinOperator::LeftSemi(constraint)
+            | JoinOperator::RightSemi(constraint)
+            | JoinOperator::Anti(constraint)
+            | JoinOperator::LeftAnti(constraint)
+            | JoinOperator::RightAnti(constraint)
+            | JoinOperator::StraightJoin(constraint) => constraint,
+            JoinOperator::AsOf {
+                match_condition,
+                constraint,
+            } => {
+                match_condition.visit(context)?;
+                constraint
+            }
+            JoinOperator::CrossApply
+            | JoinOperator::OuterApply
+            | JoinOperator::ArrayJoin
+            | JoinOperator::LeftArrayJoin
+            | JoinOperator::InnerArrayJoin => return Ok(()),
+        };
+
+        if let JoinConstraint::On(expr) = constraint {
+            expr.visit(context)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl Visit for Select {
     fn visit(&self, context: &mut Context) -> Result<()> {
         // If we're selecting from a single table, that table becomes the default
@@ -503,7 +545,7 @@ impl Visit for Select {
 
             for join in &table.joins {
                 context.push_frame();
-                join.relation.visit(context)?;
+                join.visit(context)?;
                 let frame = context.pop_frame().unwrap();
                 context.collect_aliases(&frame);
                 context.collect(frame);
@@ -688,7 +730,7 @@ impl Visit for Statement {
                             for table_with_joins in tables {
                                 table_with_joins.relation.visit(context)?;
                                 for join in &table_with_joins.joins {
-                                    join.relation.visit(context)?;
+                                    join.visit(context)?;
                                 }
                             }
                         }
@@ -752,7 +794,7 @@ impl Visit for Statement {
                     for table in tables {
                         table.relation.visit(context)?;
                         for join in &table.joins {
-                            join.relation.visit(context)?;
+                            join.visit(context)?;
                         }
                     }
                     for table in &delete.tables {
@@ -765,7 +807,7 @@ impl Visit for Statement {
                     for table in using {
                         table.relation.visit(context)?;
                         for join in &table.joins {
-                            join.relation.visit(context)?;
+                            join.visit(context)?;
                         }
                     }
                 }

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -60,6 +60,23 @@ fn select_join() {
 }
 
 #[test]
+fn select_join_condition_subquery() {
+    assert_eq!(
+        test_sql(
+            "SELECT a.id
+             FROM a
+             JOIN b ON b.id IN (SELECT c.id FROM c)"
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["a", "b", "c"]),
+            out_tables: vec![]
+        }
+    )
+}
+
+#[test]
 fn select_inner_join() {
     assert_eq!(
         test_sql(


### PR DESCRIPTION
closes: #4781

### One-line summary for changelog:
SQL parser lineage includes input tables referenced only by JOIN condition subqueries.

### Meaningful description
The parser previously visited each joined relation but skipped the join operator and its ON expression. As a result, a table read only by a subquery in JOIN ... ON was silently omitted from input lineage.

This adds one shared join visitor that traverses the relation and expression-bearing join operators, then uses it at every existing SELECT, UPDATE, and DELETE join traversal site. A focused regression test proves the missing ON-subquery input is retained without changing the reported joined relations.

Local validation covered the full Rust workspace with default and no-default features, formatting, Clippy with warnings denied, the exact macOS Python wheel CI build/import smoke test, the Java binding build and 13-test/smoke suite, changed-file repository hooks, and the issue reproduction.

### Checklist
- [x] AI was used in creating this PR