### PR TITLE
sql: include HAVING subquery inputs in lineage

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -585,6 +585,13 @@ impl Visit for Select {
             context.collect_aliases(&frame);
         }
 
+        if let Some(having) = &self.having {
+            context.push_frame();
+            having.visit(context)?;
+            let frame = context.pop_frame().unwrap();
+            context.collect_aliases(&frame);
+        }
+
         if let Some(into) = &self.into {
             context.add_output(convert_to_idents(&into.name))
         }

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -29,6 +29,23 @@ fn select_where_exists_subquery() {
 }
 
 #[test]
+fn select_having_exists_subquery() {
+    assert_eq!(
+        test_sql(
+            "SELECT count(*)
+             FROM orders
+             HAVING EXISTS (SELECT 1 FROM customers);"
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["customers", "orders"]),
+            out_tables: vec![]
+        }
+    )
+}
+
+#[test]
 fn select_from_schema_table() {
     assert_eq!(
         test_sql("SELECT * FROM schema0.table0;",)


### PR DESCRIPTION
### One-line summary for changelog:

Include input tables referenced by `HAVING` subqueries in SQL table lineage.

### Meaningful description

Closes: #4784

The `Select` visitor handled projection and `WHERE` expressions but skipped the optional `HAVING` expression. As a result, tables read only by a `HAVING` subquery were silently omitted from `in_tables`.

This change visits `self.having` using the same scoped-frame handling already used for `self.selection`. A focused regression test verifies that both the main `FROM` table and the table referenced by `HAVING EXISTS` are returned.

No public API or parser contract changes are required.

### Validation

- `cargo test -p openlineage_sql select_having_exists_subquery`
- `cargo test --no-default-features` — 140 passed, 3 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- Python binding reproduction:
  - inputs: `customers`, `orders`
  - outputs: `analytics`
  - errors: `0`
- Repository commit hooks

### Checklist

- [x] AI was used in creating this PR
