### PR TITLE
Spark: refactor of iceberg handler

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
@@ -6,22 +6,34 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.jspecify.annotations.NonNull;
 
+@Slf4j
 abstract class BaseCatalogTypeHandler {
 
   abstract String getType();
 
   abstract boolean matchesCatalogType(Map<String, String> catalogConf);
 
-  abstract Optional<DatasetIdentifier> getIdentifier(
+  abstract Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table);
 
   String getFacetType(Map<String, String> catalogConf) {
@@ -34,12 +46,23 @@ abstract class BaseCatalogTypeHandler {
    * Tables override this so the user-facing identity matches the catalog (e.g. {@code
    * arn:aws:s3tables:...}) rather than an opaque physical bucket URI.
    */
-  Optional<DatasetIdentifier> getPrimaryIdentifier(
+  DatasetIdentifier getPrimaryIdentifier(
       SparkSession session,
       Map<String, String> catalogConf,
       Identifier identifier,
-      String catalogName) {
-    return Optional.empty();
+      TableCatalog tableCatalog) {
+    String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
+
+    Path path =
+        getTableLocation(identifier, tableCatalog)
+            .orElseGet(() -> defaultTableLocation(new Path(warehouseLocation), identifier));
+
+    return PathUtils.fromPath(path);
+  }
+
+  protected @NonNull Optional<Path> getTableLocation(
+      Identifier identifier, TableCatalog tableCatalog) {
+    return getIcebergTable(tableCatalog, identifier).map(tbl -> new Path(tbl.location()));
   }
 
   Path defaultTableLocation(Path warehouseLocation, Identifier identifier) {
@@ -52,11 +75,109 @@ abstract class BaseCatalogTypeHandler {
     return new Path(warehouseLocation, String.join(Path.SEPARATOR, pathComponents));
   }
 
-  boolean shouldOverridePrimary() {
-    return false;
-  }
-
   Map<String, String> catalogProperties(Map<String, String> catalogConf) {
     return Collections.emptyMap();
+  }
+
+  @SneakyThrows
+  protected Optional<Table> getIcebergTable(TableCatalog tableCatalog, Identifier identifier) {
+    try {
+      if (tableCatalog instanceof SparkCatalog) {
+        SparkCatalog sparkCatalog = (SparkCatalog) tableCatalog;
+        org.apache.spark.sql.connector.catalog.Table loadedTable =
+            sparkCatalog.loadTable(identifier);
+
+        // Handle different table implementations safely
+        if (loadedTable instanceof SparkTable) {
+          SparkTable sparkTable = (SparkTable) loadedTable;
+          return Optional.ofNullable(sparkTable.table());
+        } else {
+          // Handle SparkChangelogTable and other unknown table types
+          log.warn(
+              "Loaded table is not a SparkTable instance. Table type: {}, identifier: {}. "
+                  + "Attempting to extract Iceberg Table using reflection.",
+              loadedTable.getClass().getName(),
+              identifier);
+
+          // Try to extract the underlying Iceberg Table using reflection
+          // SparkChangelogTable and other wrappers typically have a table() method
+          Optional<Table> reflectedTable = extractIcebergTableViaReflection(loadedTable);
+          if (reflectedTable.isPresent()) {
+            log.debug(
+                "Successfully extracted Iceberg Table via reflection for identifier: {}",
+                identifier);
+            return reflectedTable;
+          }
+
+          log.warn(
+              "Unable to extract Iceberg Table from table type: {} for identifier: {}. "
+                  + "Returning empty to avoid ClassCastException.",
+              loadedTable.getClass().getName(),
+              identifier);
+          return Optional.empty();
+        }
+      } else if (tableCatalog instanceof SparkSessionCatalog) {
+        TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
+        SparkSessionCatalog sparkCatalog = (SparkSessionCatalog) tableCatalog;
+        return Optional.ofNullable(sparkCatalog.icebergCatalog().loadTable(tableIdentifier));
+      } else {
+        log.warn(
+            "Unknown catalog type: {} for identifier: {}. Expected SparkCatalog or SparkSessionCatalog.",
+            tableCatalog.getClass().getName(),
+            identifier);
+        return Optional.empty();
+      }
+    } catch (ClassCastException e) {
+      log.error(
+          "ClassCastException while loading table from catalog. Catalog type: {}, identifier: {}",
+          tableCatalog.getClass().getName(),
+          identifier,
+          e);
+      return Optional.empty();
+    } catch (Exception e) {
+      if (e instanceof org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+          || e instanceof org.apache.iceberg.exceptions.NoSuchTableException) {
+        // probably trying to obtain table details on START event while table does not exist
+        log.debug("Table does not exist: {}", identifier);
+        return Optional.empty();
+      }
+      log.error("Unexpected error while loading table: {}", identifier, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Attempts to extract an Iceberg Table from unknown table implementations using reflection. This
+   * handles cases like SparkChangelogTable and future table types that wrap an Iceberg Table.
+   *
+   * @param table The loaded Spark table
+   * @return Optional containing the Iceberg Table if successfully extracted, empty otherwise
+   */
+  private Optional<Table> extractIcebergTableViaReflection(
+      org.apache.spark.sql.connector.catalog.Table table) {
+    try {
+      // Try to invoke table() method which is common across Iceberg table implementations
+      java.lang.reflect.Method tableMethod = table.getClass().getMethod("table");
+      Object result = tableMethod.invoke(table);
+
+      if (result instanceof Table) {
+        return Optional.of((Table) result);
+      } else if (result != null) {
+        log.warn(
+            "table() method returned non-Table type: {} for table class: {}",
+            result.getClass().getName(),
+            table.getClass().getName());
+      }
+    } catch (NoSuchMethodException e) {
+      log.debug(
+          "No table() method found on table type: {}. This may not be an Iceberg table wrapper.",
+          table.getClass().getName());
+    } catch (Exception e) {
+      log.warn(
+          "Failed to extract Iceberg Table via reflection from table type: {}",
+          table.getClass().getName(),
+          e);
+    }
+    return Optional.empty();
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
@@ -32,11 +32,14 @@ class BigQueryMetastoreCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
+    DatasetIdentifier di =
+        FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table);
     return Optional.of(
-        FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table));
+        new DatasetIdentifier.Symlink(
+            di.getName(), di.getNamespace(), DatasetIdentifier.SymlinkType.TABLE));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
@@ -45,7 +45,7 @@ class GlueCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     SparkContext sparkContext = session.sparkContext();
     Optional<String> arn =
@@ -53,6 +53,11 @@ class GlueCatalogTypeHandler extends BaseCatalogTypeHandler {
     if (!arn.isPresent()) {
       log.warn("Glue catalog ARN is unavailable; omitting Glue table symlink for table {}.", table);
     }
-    return arn.map(s -> new DatasetIdentifier(GLUE_TABLE_PREFIX + table.replace(".", "/"), s));
+    return arn.map(
+        s ->
+            new DatasetIdentifier.Symlink(
+                GLUE_TABLE_PREFIX + table.replace(".", "/"),
+                s,
+                DatasetIdentifier.SymlinkType.TABLE));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HadoopCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HadoopCatalogTypeHandler.java
@@ -34,10 +34,13 @@ class HadoopCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   @SneakyThrows
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
+    DatasetIdentifier di =
+        FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table);
     return Optional.of(
-        FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table));
+        new DatasetIdentifier.Symlink(
+            di.getName(), di.getNamespace(), DatasetIdentifier.SymlinkType.TABLE));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
@@ -12,17 +12,25 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.SparkConfUtils;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 @Slf4j
 class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
+  // NOTE: This is default handler, so it contains the logic for edge cases that can happen for
+  // undefined catalogs
 
   private static final String HIVE_CATALOG_TYPE = "hive";
+  private static final String ICEBERG_PATH_IDENTIFIER_CLASS_NAME =
+      "org.apache.iceberg.spark.PathIdentifier";
 
   @Override
   String getType() {
@@ -35,8 +43,55 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
+  DatasetIdentifier getPrimaryIdentifier(
+      SparkSession session,
+      Map<String, String> catalogConf,
+      Identifier identifier,
+      TableCatalog tableCatalog) {
+
+    // Several things to be aware of:
+    // 1. You can read iceberg data without using an Iceberg catalog
+    // 2. You can't write iceberg data without using an Iceberg catalog (Spark crashes)
+    // 3. Iceberg will configure a default catalog called "default_iceberg". This catalog (usually)
+    // lacks the warehouse property.
+    // 4. When you read the metadata.json path of an Iceberg dataset, the concrete type of the
+    // Identifier interface is "org.apache.iceberg.spark.PathIdentifier"
+
+    // A heuristic to check for:
+    // Is the catalog name "default_iceberg"?
+    // Is the warehouse property set?
+    // Is the identifier of type "org.apache.iceberg.spark.PathIdentifier"?
+    // If the answer to all 3 is "YES" then we cannot assume that we are reading from a catalog that
+    // belongs to this Spark application
+    String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
+    boolean isDefaultIcebergCatalog = "default_iceberg".equals(tableCatalog.name());
+    boolean lacksWarehouseProperty =
+        warehouseLocation == null || warehouseLocation.trim().isEmpty();
+    boolean isPathIdentifier =
+        ICEBERG_PATH_IDENTIFIER_CLASS_NAME.equals(identifier.getClass().getName());
+    if (isDefaultIcebergCatalog && lacksWarehouseProperty && isPathIdentifier) {
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "Encountered an Iceberg-formatted dataset ({}) that does not belong to the configured Iceberg catalog (catalog={})",
+            identifierToString(identifier),
+            tableCatalog.name());
+      }
+
+      return getIcebergTable(tableCatalog, identifier)
+          .map(tbl -> PathUtils.fromPath(new Path(tbl.location())))
+          .orElseThrow(
+              () ->
+                  new MissingDatasetIdentifierCatalogException(
+                      String.format(
+                          "Unable to determine the location of the Iceberg dataset %s in catalog %s",
+                          identifierToString(identifier), tableCatalog.name())));
+    }
+    return super.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog);
+  }
+
+  @Override
   @SneakyThrows
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     URI metastoreUri;
     String confUri = catalogConf.get(CatalogProperties.URI);
@@ -48,6 +103,16 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
       metastoreUri = new URI(confUri);
     }
     return Optional.of(
-        new DatasetIdentifier(table, PathUtils.prepareHiveUri(metastoreUri).toString()));
+        new DatasetIdentifier.Symlink(
+            table,
+            PathUtils.prepareHiveUri(metastoreUri).toString(),
+            DatasetIdentifier.SymlinkType.TABLE));
+  }
+
+  private String identifierToString(Identifier identifier) {
+    Class<? extends Identifier> cls = identifier.getClass();
+    String[] namespace = identifier.namespace();
+    String ns = namespace.length > 1 ? Arrays.toString(namespace) : namespace[0];
+    return String.format("%s(namespace=%s; name=%s)", cls.getSimpleName(), ns, identifier.name());
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
@@ -12,6 +12,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.SparkConfUtils;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +44,7 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
+  @SneakyThrows
   DatasetIdentifier getPrimaryIdentifier(
       SparkSession session,
       Map<String, String> catalogConf,
@@ -86,13 +88,17 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
                           "Unable to determine the location of the Iceberg dataset %s in catalog %s",
                           identifierToString(identifier), tableCatalog.name())));
     }
-    return super.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog);
+
+    return super.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog)
+        .withSymlink(
+            new DatasetIdentifier.Symlink(
+                identifier.toString(),
+                PathUtils.prepareHiveUri(getUri(session, catalogConf)).toString(),
+                DatasetIdentifier.SymlinkType.TABLE));
   }
 
-  @Override
-  @SneakyThrows
-  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
-      SparkSession session, Map<String, String> catalogConf, String table) {
+  private static URI getUri(SparkSession session, Map<String, String> catalogConf)
+      throws URISyntaxException {
     URI metastoreUri;
     String confUri = catalogConf.get(CatalogProperties.URI);
     if (confUri == null) {
@@ -102,11 +108,14 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
     } else {
       metastoreUri = new URI(confUri);
     }
-    return Optional.of(
-        new DatasetIdentifier.Symlink(
-            table,
-            PathUtils.prepareHiveUri(metastoreUri).toString(),
-            DatasetIdentifier.SymlinkType.TABLE));
+    return metastoreUri;
+  }
+
+  @Override
+  @SneakyThrows
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
+      SparkSession session, Map<String, String> catalogConf, String table) {
+    return Optional.empty();
   }
 
   private String identifierToString(Identifier identifier) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -7,12 +7,9 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
-import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -23,21 +20,17 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSessionCatalog;
-import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.jspecify.annotations.NonNull;
 
 @Slf4j
 public class IcebergHandler implements CatalogHandler {
-  private static final String ICEBERG_PATH_IDENTIFIER_CLASS_NAME =
-      "org.apache.iceberg.spark.PathIdentifier";
 
   private final OpenLineageContext context;
   private final List<BaseCatalogTypeHandler> catalogTypeHandlers;
@@ -56,6 +49,7 @@ public class IcebergHandler implements CatalogHandler {
             new NessieCatalogTypeHandler(),
             new GlueCatalogTypeHandler(),
             new SnowflakeCatalogTypeHandler(),
+            //            new LakehouseRestCatalogTypeHandler(),
             new RestCatalogTypeHandler(),
             new BigQueryMetastoreCatalogTypeHandler(),
             new HadoopCatalogTypeHandler(),
@@ -131,100 +125,24 @@ public class IcebergHandler implements CatalogHandler {
       TableCatalog tableCatalog,
       Identifier identifier,
       Map<String, String> properties) {
-    String catalogName = tableCatalog.name();
-    Map<String, String> sparkRuntimeConfig = ScalaConversionUtils.fromMap(session.conf().getAll());
-    Map<String, String> catalogConf = getCatalogProperties(sparkRuntimeConfig, catalogName);
-    BaseCatalogTypeHandler catalogTypeHandler = getCatalogTypeHandler(catalogConf);
-    String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
 
-    // Several things to be aware of:
-    // 1. You can read iceberg data without using an Iceberg catalog
-    // 2. You can't write iceberg data without using an Iceberg catalog (Spark crashes)
-    // 3. Iceberg will configure a default catalog called "default_iceberg". This catalog (usually)
-    // lacks the warehouse property.
-    // 4. When you read the metadata.json path of an Iceberg dataset, the concrete type of the
-    // Identifier interface is "org.apache.iceberg.spark.PathIdentifier"
+    Map<String, String> catalogConf = getCatalogConf(session, tableCatalog);
+    BaseCatalogTypeHandler catalogTypeHandler =
+        getCatalogTypeHandler(getCatalogConf(session, tableCatalog));
+    DatasetIdentifier primaryIdentifier =
+        catalogTypeHandler.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog);
 
-    // A heuristic to check for:
-    // Is the catalog name "default_iceberg"?
-    // Is the warehouse property set?
-    // Is the identifier of type "org.apache.iceberg.spark.PathIdentifier"?
-    // If the answer to all 3 is "YES" then we cannot assume that we are reading from a catalog that
-    // belongs to this Spark application
-    boolean isDefaultIcebergCatalog = "default_iceberg".equals(catalogName);
-    boolean lacksWarehouseProperty =
-        warehouseLocation == null || warehouseLocation.trim().isEmpty();
-    boolean isPathIdentifier =
-        ICEBERG_PATH_IDENTIFIER_CLASS_NAME.equals(identifier.getClass().getName());
-    Optional<Table> table = getIcebergTable(tableCatalog, identifier);
-    Optional<Path> maybeTableLocation = table.map(tbl -> new Path(tbl.location()));
-
-    // S3 Tables identity comes from catalog config and the logical Spark identifier, not
-    // table.location(). Build it before path-based fallback so NoSuchTableException paths
-    // (for example, create-like operations) can still produce a stable dataset name.
-    Optional<DatasetIdentifier> primaryOverride =
-        catalogTypeHandler.getPrimaryIdentifier(session, catalogConf, identifier, catalogName);
-    if (primaryOverride.isPresent()) {
-      DatasetIdentifier di = primaryOverride.get();
-      maybeTableLocation.ifPresent(
-          loc -> {
-            String authority = loc.toUri().getAuthority();
-            if (authority != null) {
-              di.withSymlink("/", "s3://" + authority, SymlinkType.LOCATION);
-            }
-          });
-      return di;
-    }
-
-    Optional<DatasetIdentifier> maybeSymlink = Optional.empty();
-    if (isDefaultIcebergCatalog && lacksWarehouseProperty && isPathIdentifier) {
-      if (log.isDebugEnabled()) {
-        log.debug(
-            "Encountered an Iceberg-formatted dataset ({}) that does not belong to the configured Iceberg catalog (catalog={})",
-            identifierToString(identifier),
-            catalogName);
-      }
-      maybeTableLocation = table.map(tbl -> new Path(tbl.location()));
-    } else {
-      if (log.isDebugEnabled()) {
-        log.debug(
-            "Encountered an Iceberg-formatted dataset ({}) that belongs to the configured Iceberg catalog (catalog={})",
-            identifierToString(identifier),
-            catalogName);
-      }
-      String tableName = identifier.toString();
-      maybeSymlink = catalogTypeHandler.getIdentifier(session, catalogConf, tableName);
-    }
-
-    if (!maybeTableLocation.isPresent() && warehouseLocation == null) {
-      log.debug(
-          "The catalog type is 'rest' and the table location and warehouse location is empty. This is likely a table that is being created");
-      throw new MissingDatasetIdentifierCatalogException(
-          "No table location found. Probably needs to create table first");
-    }
-
-    Path tableLocation =
-        maybeTableLocation.orElseGet(
-            () -> catalogTypeHandler.defaultTableLocation(new Path(warehouseLocation), identifier));
-
-    if (maybeSymlink.isPresent() && catalogTypeHandler.shouldOverridePrimary()) {
-      DatasetIdentifier primaryDi = maybeSymlink.get();
-      DatasetIdentifier physicalDi = PathUtils.fromPath(tableLocation);
-      primaryDi.withSymlink(physicalDi.getName(), physicalDi.getNamespace(), SymlinkType.TABLE);
-      return primaryDi;
-    }
-
-    DatasetIdentifier di = PathUtils.fromPath(tableLocation);
-    maybeSymlink.ifPresent(
-        symlink -> di.withSymlink(symlink.getName(), symlink.getNamespace(), SymlinkType.TABLE));
-    return di;
+    return catalogTypeHandler
+        .getSymlinkIdentifiers(session, catalogConf, identifier.toString())
+        .map(primaryIdentifier::withSymlink)
+        .orElse(primaryIdentifier);
   }
 
-  private String identifierToString(Identifier identifier) {
-    Class<? extends Identifier> cls = identifier.getClass();
-    String[] namespace = identifier.namespace();
-    String ns = namespace.length > 1 ? Arrays.toString(namespace) : namespace[0];
-    return String.format("%s(namespace=%s; name=%s)", cls.getSimpleName(), ns, identifier.name());
+  private @NonNull Map<String, String> getCatalogConf(
+      SparkSession session, TableCatalog tableCatalog) {
+    String catalogName = tableCatalog.name();
+    Map<String, String> sparkRuntimeConfig = ScalaConversionUtils.fromMap(session.conf().getAll());
+    return getCatalogProperties(sparkRuntimeConfig, catalogName);
   }
 
   private void logMap(String message, Map<String, String> map) {
@@ -271,111 +189,10 @@ public class IcebergHandler implements CatalogHandler {
   @Override
   public Optional<String> getDatasetVersion(
       TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
-    return getIcebergTable(tableCatalog, identifier)
-        .map(table -> table.currentSnapshot())
+    return getCatalogTypeHandler(getCatalogProperties(properties, tableCatalog.name()))
+        .getIcebergTable(tableCatalog, identifier)
+        .map(Table::currentSnapshot)
         .map(snapshot -> Long.toString(snapshot.snapshotId()));
-  }
-
-  @SneakyThrows
-  private Optional<Table> getIcebergTable(TableCatalog tableCatalog, Identifier identifier) {
-    try {
-      if (tableCatalog instanceof SparkCatalog) {
-        SparkCatalog sparkCatalog = (SparkCatalog) tableCatalog;
-        org.apache.spark.sql.connector.catalog.Table loadedTable =
-            sparkCatalog.loadTable(identifier);
-
-        // Handle different table implementations safely
-        if (loadedTable instanceof SparkTable) {
-          SparkTable sparkTable = (SparkTable) loadedTable;
-          return Optional.ofNullable(sparkTable.table());
-        } else {
-          // Handle SparkChangelogTable and other unknown table types
-          log.warn(
-              "Loaded table is not a SparkTable instance. Table type: {}, identifier: {}. "
-                  + "Attempting to extract Iceberg Table using reflection.",
-              loadedTable.getClass().getName(),
-              identifier);
-
-          // Try to extract the underlying Iceberg Table using reflection
-          // SparkChangelogTable and other wrappers typically have a table() method
-          Optional<Table> reflectedTable = extractIcebergTableViaReflection(loadedTable);
-          if (reflectedTable.isPresent()) {
-            log.debug(
-                "Successfully extracted Iceberg Table via reflection for identifier: {}",
-                identifier);
-            return reflectedTable;
-          }
-
-          log.warn(
-              "Unable to extract Iceberg Table from table type: {} for identifier: {}. "
-                  + "Returning empty to avoid ClassCastException.",
-              loadedTable.getClass().getName(),
-              identifier);
-          return Optional.empty();
-        }
-      } else if (tableCatalog instanceof SparkSessionCatalog) {
-        TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
-        SparkSessionCatalog sparkCatalog = (SparkSessionCatalog) tableCatalog;
-        return Optional.ofNullable(sparkCatalog.icebergCatalog().loadTable(tableIdentifier));
-      } else {
-        log.warn(
-            "Unknown catalog type: {} for identifier: {}. Expected SparkCatalog or SparkSessionCatalog.",
-            tableCatalog.getClass().getName(),
-            identifier);
-        return Optional.empty();
-      }
-    } catch (ClassCastException e) {
-      log.error(
-          "ClassCastException while loading table from catalog. Catalog type: {}, identifier: {}",
-          tableCatalog.getClass().getName(),
-          identifier,
-          e);
-      return Optional.empty();
-    } catch (Exception e) {
-      if (e instanceof org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-          || e instanceof org.apache.iceberg.exceptions.NoSuchTableException) {
-        // probably trying to obtain table details on START event while table does not exist
-        log.debug("Table does not exist: {}", identifier);
-        return Optional.empty();
-      }
-      log.error("Unexpected error while loading table: {}", identifier, e);
-      throw e;
-    }
-  }
-
-  /**
-   * Attempts to extract an Iceberg Table from unknown table implementations using reflection. This
-   * handles cases like SparkChangelogTable and future table types that wrap an Iceberg Table.
-   *
-   * @param table The loaded Spark table
-   * @return Optional containing the Iceberg Table if successfully extracted, empty otherwise
-   */
-  private Optional<Table> extractIcebergTableViaReflection(
-      org.apache.spark.sql.connector.catalog.Table table) {
-    try {
-      // Try to invoke table() method which is common across Iceberg table implementations
-      java.lang.reflect.Method tableMethod = table.getClass().getMethod("table");
-      Object result = tableMethod.invoke(table);
-
-      if (result instanceof Table) {
-        return Optional.of((Table) result);
-      } else if (result != null) {
-        log.warn(
-            "table() method returned non-Table type: {} for table class: {}",
-            result.getClass().getName(),
-            table.getClass().getName());
-      }
-    } catch (NoSuchMethodException e) {
-      log.debug(
-          "No table() method found on table type: {}. This may not be an Iceberg table wrapper.",
-          table.getClass().getName());
-    } catch (Exception e) {
-      log.warn(
-          "Failed to extract Iceberg Table via reflection from table type: {}",
-          table.getClass().getName(),
-          e);
-    }
-    return Optional.empty();
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/NessieCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/NessieCatalogTypeHandler.java
@@ -33,11 +33,12 @@ class NessieCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   @SneakyThrows
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     log.debug("Getting identifier for nessie");
     String confUri = catalogConf.get(CatalogProperties.URI);
     String uri = new URI(confUri).toString();
-    return Optional.of(new DatasetIdentifier(table, uri));
+    return Optional.of(
+        new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
@@ -9,20 +9,25 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.IcebergHandler.TYPE;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 @Slf4j
 class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
 
-  private static final String REST_CATALOG_TYPE = "rest";
-  private static final String BIGLAKE_CATALOG_URI = "https://biglake.googleapis.com/";
+  protected static final String REST_CATALOG_TYPE = "rest";
+  protected static final String BIGLAKE_CATALOG_URI = "https://biglake.googleapis.com/";
 
   @Override
   String getType() {
@@ -31,18 +36,39 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   boolean matchesCatalogType(Map<String, String> catalogConf) {
-    return "rest".equalsIgnoreCase(catalogConf.get(TYPE))
-        || catalogConf.containsKey(CATALOG_IMPL)
-            && catalogConf.get(CATALOG_IMPL).endsWith("RESTCatalog");
+    return isRestCatalog(catalogConf);
+    //        && !catalogConf.getOrDefault(CatalogProperties.URI,
+    // "").startsWith(BIGLAKE_CATALOG_URI);
+  }
+
+  @Override
+  DatasetIdentifier getPrimaryIdentifier(
+      SparkSession session,
+      Map<String, String> catalogConf,
+      Identifier identifier,
+      TableCatalog tableCatalog) {
+
+    Optional<Path> maybeTableLocation = getTableLocation(identifier, tableCatalog);
+    String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
+    if (!maybeTableLocation.isPresent() && warehouseLocation == null) {
+      log.debug(
+          "The catalog type is 'rest' and the table location and warehouse location is empty. This is likely a table that is being created");
+      throw new MissingDatasetIdentifierCatalogException(
+          "No table location found. Probably needs to create table first");
+    }
+    return PathUtils.fromPath(
+        maybeTableLocation.orElseGet(
+            () -> defaultTableLocation(new Path(warehouseLocation), identifier)));
   }
 
   @Override
   @SneakyThrows
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     String confUri = catalogConf.get(CatalogProperties.URI);
     String uri = new URI(confUri).toString();
-    return Optional.of(new DatasetIdentifier(table, uri));
+    return Optional.of(
+        new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE));
   }
 
   @Override
@@ -53,5 +79,11 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
       return properties;
     }
     return super.catalogProperties(catalogConf);
+  }
+
+  protected static boolean isRestCatalog(Map<String, String> catalogConf) {
+    return "rest".equalsIgnoreCase(catalogConf.get(TYPE))
+        || catalogConf.containsKey(CATALOG_IMPL)
+            && catalogConf.get(CATALOG_IMPL).endsWith("RESTCatalog");
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/S3TablesCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/S3TablesCatalogTypeHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 /**
  * Handles S3 Tables catalogs configured as native {@code S3TablesCatalog}, REST catalogs pointing
@@ -38,16 +39,16 @@ class S3TablesCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  Optional<DatasetIdentifier> getPrimaryIdentifier(
+  DatasetIdentifier getPrimaryIdentifier(
       SparkSession session,
       Map<String, String> catalogConf,
       Identifier identifier,
-      String catalogName) {
+      TableCatalog tableCatalog) {
     // S3 Tables data lives in AWS-managed physical buckets such as s3://...--table-s3.
     // That path is an implementation detail; lineage should use the user-facing S3 Tables
     // ARN plus the logical Spark catalog/namespace/table name.
     String[] namespace = identifier.namespace();
-    StringBuilder nameBuilder = new StringBuilder(catalogName);
+    StringBuilder nameBuilder = new StringBuilder(tableCatalog.name());
     for (String ns : namespace) {
       nameBuilder.append('.').append(ns);
     }
@@ -57,18 +58,22 @@ class S3TablesCatalogTypeHandler extends BaseCatalogTypeHandler {
     String ns =
         S3TablesUtils.buildS3TablesArnFromCatalogConf(
             ctx.getConf(), ctx.hadoopConfiguration(), catalogConf);
-    return Optional.of(new DatasetIdentifier(nameBuilder.toString(), ns));
+    DatasetIdentifier di = new DatasetIdentifier(nameBuilder.toString(), ns);
+    getTableLocation(identifier, tableCatalog)
+        .ifPresent(
+            loc -> {
+              String authority = loc.toUri().getAuthority();
+              if (authority != null) {
+                di.withSymlink("/", "s3://" + authority, DatasetIdentifier.SymlinkType.LOCATION);
+              }
+            });
+
+    return di;
   }
 
   @Override
-  Optional<DatasetIdentifier> getIdentifier(
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
-    // Kept for back-compat with the existing symlink dispatch in IcebergHandler;
-    // not normally reached because getPrimaryIdentifier short-circuits the path.
-    SparkContext ctx = session.sparkContext();
-    String namespace =
-        S3TablesUtils.buildS3TablesArnFromCatalogConf(
-            ctx.getConf(), ctx.hadoopConfiguration(), catalogConf);
-    return Optional.of(new DatasetIdentifier(table, namespace));
+    return Optional.empty();
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/SnowflakeCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/SnowflakeCatalogTypeHandler.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 @Slf4j
 class SnowflakeCatalogTypeHandler extends BaseCatalogTypeHandler {
@@ -38,23 +40,34 @@ class SnowflakeCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  Optional<DatasetIdentifier> getIdentifier(
-      SparkSession session, Map<String, String> catalogConf, String table) {
+  DatasetIdentifier getPrimaryIdentifier(
+      SparkSession session,
+      Map<String, String> catalogConf,
+      Identifier identifier,
+      TableCatalog tableCatalog) {
+    // symlink and primary inverted in snowflake
+    DatasetIdentifier symlink =
+        super.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog);
     String accountIdentifier =
         SnowflakeUtils.parseAccountIdentifier(catalogConf.get(CatalogProperties.URI));
     log.debug(
         "Getting identifier for Snowflake Iceberg REST catalog, account={}", accountIdentifier);
     String warehouse = catalogConf.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
-    String fullName = warehouse.isEmpty() ? table : warehouse + "." + table;
-    return Optional.of(
-        new DatasetIdentifier(
+    String fullName =
+        warehouse.isEmpty() ? identifier.toString() : warehouse + "." + identifier.toString();
+
+    return new DatasetIdentifier(
             fullName.toUpperCase(Locale.ROOT),
-            SnowflakeUtils.SNOWFLAKE_NAMESPACE_PREFIX + accountIdentifier));
+            SnowflakeUtils.SNOWFLAKE_NAMESPACE_PREFIX + accountIdentifier)
+        .withSymlink(
+            new DatasetIdentifier.Symlink(
+                symlink.getName(), symlink.getNamespace(), DatasetIdentifier.SymlinkType.TABLE));
   }
 
   @Override
-  boolean shouldOverridePrimary() {
-    return true;
+  Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
+      SparkSession session, Map<String, String> catalogConf, String table) {
+    return Optional.empty();
   }
 
   @Override


### PR DESCRIPTION
### One-line summary for changelog:
Refactor of iceberg handler, moving catalog specific logic to `CatalogTypeHandler` classes


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
`IcebergHandler.getDatasetIdentifier` method contained logic for a lot of edge cases specific to certain catalog types. This made it increasingly difficult to add anything new, as any new logic had to take into account a lot of cases that were not relevant. In the method code we had handling for

- `default_iceberg` catalog which cannot happen for any type of catalog except the default one.
- s3 method bypassing the general dataset creation logic
- snowflake primary-symlink inversion and its own special flag for it
- lack of warehouse and location with specific log `The catalog type is 'rest'`

After changes:

There are two method in `BaseCatalogTypeHandler`, `getPrimaryIdentifier` and `getSymlinkIdentifiers`. All the logic of extracting the dataset information is in those `*CatalogTypeHandler` methods. 

The `IcebergHandler` logic only knows that it needs to create primary DatasetIdentifier and if any Symlinks exist, add them to it. If necessary, the `getPrimaryIdentifier` may return `DatasetIdentifier` that already has symlinks.



### Checklist
- [ ] AI was used in creating this PR
