### PR TITLE
sql: include VALUES subquery inputs in lineage

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -608,7 +608,14 @@ impl Visit for SetExpr {
     fn visit(&self, context: &mut Context) -> Result<()> {
         match self {
             SetExpr::Select(select) => select.visit(context),
-            SetExpr::Values(_) => Ok(()),
+            SetExpr::Values(values) => {
+                for row in &values.rows {
+                    for expression in row.iter() {
+                        expression.visit(context)?;
+                    }
+                }
+                Ok(())
+            }
             SetExpr::Insert(stmt) => stmt.visit(context),
             SetExpr::Query(q) => q.visit(context),
             SetExpr::SetOperation {

--- a/integration/sql/impl/tests/table_lineage/tests_insert.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_insert.rs
@@ -18,6 +18,19 @@ fn insert_values() {
 }
 
 #[test]
+fn insert_values_subquery() {
+    assert_eq!(
+        test_sql("INSERT INTO report (total) VALUES ((SELECT count(*) FROM orders))",)
+            .unwrap()
+            .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["orders"]),
+            out_tables: tables(vec!["report"])
+        }
+    );
+}
+
+#[test]
 fn insert_cols_values() {
     assert_eq!(
         test_sql("INSERT INTO tbl(col1, col2) VALUES (1, 2), (2, 3)",)


### PR DESCRIPTION
Closes: #4787

### One-line summary for changelog:

SQL parser table lineage now includes input tables read by scalar subqueries in `VALUES` expressions.

### Meaningful description

`SetExpr::Values` previously returned without visiting any row expressions. As a result, valid statements such as:

```sql
INSERT INTO report (total) VALUES ((SELECT count(*) FROM orders))
```

reported `report` as an output but omitted `orders` from the inputs, despite parsing without errors.

This change visits every expression in every `VALUES` row, reusing the existing expression and subquery visitors. It fixes the shared Rust implementation for all bindings while preserving literal-only `VALUES` behavior. A focused table-lineage regression test covers the failure.

Validated locally with:

- `cargo test -p openlineage_sql`
- `cargo test --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `prek run --files integration/sql/impl/src/visitor.rs integration/sql/impl/tests/table_lineage/tests_insert.rs`
- Rebuilt Python extension smoke test: `inputs=['orders']`, `outputs=['report']`, `errors=[]`

### Checklist

- [x] AI was used in creating this PR
