### PR TITLE
sql: fix Snowflake COPY unload lineage

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -6,11 +6,11 @@ use crate::lineage::*;
 
 use anyhow::{anyhow, Result};
 use sqlparser::ast::{
-    AccessExpr, AlterTableOperation, CreateTableLikeKind, Expr, FromTable, Function, FunctionArg,
-    FunctionArgExpr, FunctionArguments, Ident, Join, JoinConstraint, JoinOperator, ObjectName,
-    ObjectNamePart, Query, RenameTableNameKind, Select, SelectItem, SetExpr, Statement, Subscript,
-    Table, TableFactor, TableFunctionArgs, TableObject, UpdateTableFromKind, Use, Value,
-    ValueWithSpan, WindowSpec, WindowType, With,
+    AccessExpr, AlterTableOperation, CopyIntoSnowflakeKind, CreateTableLikeKind, Expr, FromTable,
+    Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, Join, JoinConstraint,
+    JoinOperator, ObjectName, ObjectNamePart, Query, RenameTableNameKind, Select, SelectItem,
+    SetExpr, Statement, Subscript, Table, TableFactor, TableFunctionArgs, TableObject,
+    UpdateTableFromKind, Use, Value, ValueWithSpan, WindowSpec, WindowType, With,
 };
 use sqlparser::dialect::{DatabricksDialect, MsSqlDialect, SnowflakeDialect};
 
@@ -840,26 +840,33 @@ impl Visit for Statement {
                     context.add_output(convert_to_idents(name))
                 }
             }
-            Statement::CopyIntoSnowflake { into, from_obj, .. } => {
-                context.add_output(convert_to_idents(into));
-                if let Some(from_object) = from_obj {
-                    if from_object.to_string().contains("gcs://")
-                        || from_object.to_string().contains("s3://")
-                        || from_object.to_string().contains("azure://")
-                    {
+            Statement::CopyIntoSnowflake {
+                kind,
+                into,
+                from_obj,
+                from_query,
+                ..
+            } => match kind {
+                CopyIntoSnowflakeKind::Table => {
+                    context.add_output(convert_to_idents(into));
+                    if let Some(from_object) = from_obj {
                         context.add_non_table_input(
-                            vec![Ident::new(
-                                from_object.to_string().replace(['\"', '\''], ""),
-                            )], // just unquoted location URL with,
+                            convert_copy_location_to_idents(from_object),
                             true,
                             true,
                         );
-                    } else {
-                        // Stage
-                        context.add_non_table_input(convert_to_idents(from_object), true, true);
-                    };
+                    }
                 }
-            }
+                CopyIntoSnowflakeKind::Location => {
+                    context.add_non_table_output(convert_copy_location_to_idents(into), true, true);
+                    if let Some(from_object) = from_obj {
+                        context.add_input(convert_to_idents(from_object));
+                    }
+                    if let Some(query) = from_query {
+                        query.visit(context)?;
+                    }
+                }
+            },
             Statement::Use(use_enum) => {
                 // We expect either one id (USE [...] foo;) or two ids (USE [...] foo.bar;)
                 let (first_id, second_id) = match use_enum {
@@ -995,6 +1002,15 @@ fn get_table_name_from_identifier_function_args(args: &[FunctionArg]) -> Option<
             _ => None,
         },
         _ => None,
+    }
+}
+
+fn convert_copy_location_to_idents(object_name: &ObjectName) -> Vec<Ident> {
+    let location = object_name.to_string();
+    if location.contains("gcs://") || location.contains("s3://") || location.contains("azure://") {
+        vec![Ident::new(location.replace(['\"', '\''], ""))]
+    } else {
+        convert_to_idents(object_name)
     }
 }
 

--- a/integration/sql/impl/tests/table_lineage/tests_copy.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_copy.rs
@@ -118,6 +118,48 @@ fn parse_copy_into_with_snowflake_internal_stages() {
 }
 
 #[test]
+fn parse_copy_into_location_from_table() {
+    assert_eq!(
+        parse_sql(
+            "COPY INTO @namespace.stage FROM db.schema.source_table",
+            &SnowflakeDialect {},
+            None,
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["db.schema.source_table"]),
+            out_tables: vec![DbTableMeta::new_default_dialect_with_namespace_and_schema(
+                "@namespace.stage".to_string(),
+                true,
+                true,
+            )],
+        }
+    );
+}
+
+#[test]
+fn parse_copy_into_location_from_query() {
+    assert_eq!(
+        parse_sql(
+            "COPY INTO 's3://bucket/path' FROM (SELECT * FROM db.schema.source_table)",
+            &SnowflakeDialect {},
+            None,
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["db.schema.source_table"]),
+            out_tables: vec![DbTableMeta::new_default_dialect_with_namespace_and_schema(
+                "s3://bucket/path".to_string(),
+                true,
+                true,
+            )],
+        }
+    );
+}
+
+#[test]
 fn parse_pivot_table() {
     assert_eq!(
         parse_sql(


### PR DESCRIPTION
### One-line summary for changelog:

Fix Snowflake `COPY INTO <location>` lineage to report source tables as inputs and the unload location as output.

### Meaningful description

closes: #4790

Snowflake uses the same `COPY INTO` statement for table loads and location unloads, while the parser AST distinguishes them with `CopyIntoSnowflakeKind`. The visitor previously treated both forms as table loads, which reversed unload lineage and ignored sources inside unload queries.

This change branches on the AST kind so that:

- existing `COPY INTO <table> FROM <location>` lineage remains unchanged;
- `COPY INTO <location> FROM <table>` records the table as an input and the location as a non-table output; and
- `COPY INTO <location> FROM (<query>)` visits the source query and records its tables as inputs.

Regression tests cover both direct-table and query-based Snowflake unloads.

Validation completed locally:

- `cargo test --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `RUN_TESTS=true bash iface-py/script/build-macos.sh`
- `bash script/compile.sh` and `bash script/build.sh` for the Java interface
- all repository `prek` hooks, including pinned ShellCheck 0.10.0 and golangci-lint 2.10.1 runs

### Checklist
- [x] AI was used in creating this PR
