### PR TITLE
add support for lakehouse type catalog

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -49,7 +49,7 @@ public class IcebergHandler implements CatalogHandler {
             new NessieCatalogTypeHandler(),
             new GlueCatalogTypeHandler(),
             new SnowflakeCatalogTypeHandler(),
-            //            new LakehouseRestCatalogTypeHandler(),
+            new LakehouseRestCatalogTypeHandler(),
             new RestCatalogTypeHandler(),
             new BigQueryMetastoreCatalogTypeHandler(),
             new HadoopCatalogTypeHandler(),

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/LakehouseRestCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/LakehouseRestCatalogTypeHandler.java
@@ -1,0 +1,64 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import java.util.Collections;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+@Slf4j
+class LakehouseRestCatalogTypeHandler extends RestCatalogTypeHandler {
+
+  @Override
+  boolean matchesCatalogType(Map<String, String> catalogConf) {
+    return isRestCatalog(catalogConf)
+        && catalogConf.getOrDefault(CatalogProperties.URI, "").startsWith(BIGLAKE_CATALOG_URI);
+  }
+
+  @Override
+  DatasetIdentifier getPrimaryIdentifier(
+      SparkSession session,
+      Map<String, String> catalogConf,
+      Identifier identifier,
+      TableCatalog tableCatalog) {
+    String warehouseLocation = catalogConf.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
+    return PathUtils.fromPath(
+        getTableLocation(identifier, tableCatalog)
+            .orElse(generateTableLocation(identifier, tableCatalog, warehouseLocation)));
+  }
+
+  private Path generateTableLocation(
+      Identifier identifier, TableCatalog tableCatalog, String warehouseLocation) {
+    if (warehouseLocation.startsWith("bl://")) {
+      if (tableCatalog instanceof SparkCatalog) {
+        SparkCatalog sparkCatalog = (SparkCatalog) tableCatalog;
+        try {
+          Map<String, String> namespaceMetadata =
+              sparkCatalog.loadNamespaceMetadata(identifier.namespace());
+          return new Path(namespaceMetadata.getOrDefault("location", ""), identifier.name());
+        } catch (NoSuchNamespaceException e) {
+          log.warn("Unable to find namespace metadata for {}", identifier);
+        }
+      }
+    }
+    return defaultTableLocation(new Path(warehouseLocation), identifier);
+  }
+
+  @Override
+  Map<String, String> catalogProperties(Map<String, String> catalogConf) {
+    return Collections.singletonMap(
+        "gcp_project_id", catalogConf.get("header.x-goog-user-project"));
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
@@ -12,7 +12,6 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
@@ -36,9 +35,8 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   boolean matchesCatalogType(Map<String, String> catalogConf) {
-    return isRestCatalog(catalogConf);
-    //        && !catalogConf.getOrDefault(CatalogProperties.URI,
-    // "").startsWith(BIGLAKE_CATALOG_URI);
+    return isRestCatalog(catalogConf)
+        && !catalogConf.getOrDefault(CatalogProperties.URI, "").startsWith(BIGLAKE_CATALOG_URI);
   }
 
   @Override
@@ -69,16 +67,6 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
     String uri = new URI(confUri).toString();
     return Optional.of(
         new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE));
-  }
-
-  @Override
-  Map<String, String> catalogProperties(Map<String, String> catalogConf) {
-    if (catalogConf.getOrDefault(CatalogProperties.URI, "").startsWith(BIGLAKE_CATALOG_URI)) {
-      Map<String, String> properties = new HashMap<>();
-      properties.put("gcp_project_id", catalogConf.get("header.x-goog-user-project"));
-      return properties;
-    }
-    return super.catalogProperties(catalogConf);
   }
 
   protected static boolean isRestCatalog(Map<String, String> catalogConf) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -150,7 +150,7 @@ class IcebergHandlerTest {
 
   @Test
   @SneakyThrows
-  void testGetDatasetIdentifierForRest() {
+  void testGetDatasetIdentifierForRestCatalog() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())
         .thenReturn(
@@ -158,9 +158,9 @@ class IcebergHandlerTest {
                 "spark.sql.catalog.test.type",
                 "rest",
                 "spark.sql.catalog.test.uri",
-                "http://lakehouse-host:8080",
+                "http://rest-host:8080",
                 "spark.sql.catalog.test.warehouse",
-                "s3a://lakehouse/warehouse"));
+                "s3a://warehouse-bucket/warehouse"));
 
     SparkCatalog sparkCatalog = mock(SparkCatalog.class);
     SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
@@ -168,7 +168,8 @@ class IcebergHandlerTest {
 
     when(sparkCatalog.name()).thenReturn("test");
     when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
-    when(sparkTable.table().location()).thenReturn("s3a://lakehouse/warehouse/database/table");
+    when(sparkTable.table().location())
+        .thenReturn("s3a://warehouse-bucket/warehouse/database/table");
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
@@ -178,12 +179,12 @@ class IcebergHandlerTest {
             new HashMap<>());
 
     assertThat(datasetIdentifier)
-        .hasFieldOrPropertyWithValue("namespace", "s3://lakehouse")
+        .hasFieldOrPropertyWithValue("namespace", "s3://warehouse-bucket")
         .hasFieldOrPropertyWithValue("name", "warehouse/database/table");
 
     assertThat(datasetIdentifier.getSymlinks())
         .singleElement()
-        .hasFieldOrPropertyWithValue("namespace", "http://lakehouse-host:8080")
+        .hasFieldOrPropertyWithValue("namespace", "http://rest-host:8080")
         .hasFieldOrPropertyWithValue("name", "database.table")
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
@@ -200,7 +201,7 @@ class IcebergHandlerTest {
                 "spark.sql.catalog.rest.catalog-impl",
                 "org.apache.iceberg.rest.RESTCatalog",
                 "spark.sql.catalog.rest.uri",
-                "http://lakehouse-host:8080"));
+                "http://rest-host:8080"));
 
     SparkCatalog sparkCatalog = mock(SparkCatalog.class);
     Identifier identifier = Identifier.of(new String[] {"database"}, "table");
@@ -216,6 +217,126 @@ class IcebergHandlerTest {
                 sparkCatalog,
                 Identifier.of(new String[] {"database"}, "table"),
                 new HashMap<>()));
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierForLakehouseRestWithNBucketNoTableLocation() {
+    String catalogName = "biglake";
+    String catalogUri = "https://biglake.googleapis.com/iceberg/v1beta/restcatalog";
+    String warehouseLocation = "bl://projects/project-id/locations/us/catalogs/lakehouse";
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3<>(
+                "spark.sql.catalog." + catalogName + ".type",
+                "rest",
+                "spark.sql.catalog." + catalogName + ".uri",
+                catalogUri,
+                "spark.sql.catalog." + catalogName + ".warehouse",
+                warehouseLocation));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    when(sparkCatalog.name()).thenReturn(catalogName);
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
+    when(sparkCatalog.loadNamespaceMetadata(identifier.namespace()))
+        .thenReturn(Collections.singletonMap("location", "gs://bucket/path/to/database"));
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "gs://bucket")
+        .hasFieldOrPropertyWithValue("name", "path/to/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", catalogUri)
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierForLakehouseRestWithNBucketAndTableLocation() {
+    String catalogName = "biglake";
+    String catalogUri = "https://biglake.googleapis.com/iceberg/v1beta/restcatalog";
+    String warehouseLocation = "bl://projects/project-id/locations/us/catalogs/lakehouse";
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3<>(
+                "spark.sql.catalog." + catalogName + ".type",
+                "rest",
+                "spark.sql.catalog." + catalogName + ".uri",
+                catalogUri,
+                "spark.sql.catalog." + catalogName + ".warehouse",
+                warehouseLocation));
+
+    SparkSessionCatalog sparkCatalog = mock(SparkSessionCatalog.class);
+    Catalog icebergCatalog = mock(Catalog.class);
+    Table table = mock(Table.class);
+    when(sparkCatalog.name()).thenReturn(catalogName);
+    when(sparkCatalog.icebergCatalog()).thenReturn(icebergCatalog);
+    when(icebergCatalog.loadTable(TableIdentifier.parse(identifier.toString()))).thenReturn(table);
+    when(table.location()).thenReturn("gs://bucket/path/from/table/location");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "gs://bucket")
+        .hasFieldOrPropertyWithValue("name", "path/from/table/location");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", catalogUri)
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierForLakehouseRestWithSingleBucket() {
+    String catalogName = "biglake";
+    String catalogUri = "https://biglake.googleapis.com/iceberg/v1beta/restcatalog";
+    String warehouseLocation = "gs://bucket/path/to/warehouse";
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3<>(
+                "spark.sql.catalog." + catalogName + ".type",
+                "rest",
+                "spark.sql.catalog." + catalogName + ".uri",
+                catalogUri,
+                "spark.sql.catalog." + catalogName + ".warehouse",
+                warehouseLocation));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    when(sparkCatalog.name()).thenReturn(catalogName);
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "gs://bucket")
+        .hasFieldOrPropertyWithValue("name", "path/to/warehouse/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", catalogUri)
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Move Google Lakehouse Catalog handling logic from `RestCatalogTypeHandler` to custom one


### Meaningful description
The logic for extracting catalog info from Lakehouse catalog was almost identical to the generic REST catalog case so it was handled in `RestCatalogTypeHandler`. With addition of special handling for n-bucket catalog, it needs custom logic so it will have its custom handler

Tests are AI generated. 

### Checklist
- [x] AI was used in creating this PR
