### PR TITLE
add configurable retry to gcs transport

### DIFF
--- a/client/java/transports-gcs/src/main/java/io/openlineage/client/transports/gcs/GcsTransport.java
+++ b/client/java/transports-gcs/src/main/java/io/openlineage/client/transports/gcs/GcsTransport.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.transports.gcs;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -20,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
 import lombok.NonNull;
@@ -43,23 +45,33 @@ public class GcsTransport extends Transport {
   }
 
   @Override
-  public void emit(OpenLineage.@NonNull RunEvent runEvent) {
+  public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     emitEvent(runEvent);
   }
 
   @Override
-  public void emit(OpenLineage.@NonNull DatasetEvent datasetEvent) {
+  public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
     emitEvent(datasetEvent);
   }
 
   @Override
-  public void emit(OpenLineage.@NonNull JobEvent jobEvent) {
+  public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
     emitEvent(jobEvent);
   }
 
   private static Storage buildStorage(GcsTransportConfig config) throws IOException {
     StorageOptions.Builder builder = StorageOptions.newBuilder();
     builder.setProjectId(config.getProjectId());
+    RetrySettings retrySettings = StorageOptions.getDefaultInstance().getRetrySettings();
+    int maxRetries = config.getMaxRetries() != null ? config.getMaxRetries() : 1;
+    long retryIntervalMillis =
+        config.getRetryIntervalMillis() != null ? config.getRetryIntervalMillis() : 1000L;
+    builder.setRetrySettings(
+        retrySettings.toBuilder()
+            .setMaxAttempts(maxRetries)
+            .setInitialRetryDelayDuration(Duration.ofMillis(retryIntervalMillis))
+            .setMaxRetryDelayDuration(Duration.ofMillis(retryIntervalMillis))
+            .build());
     if (config.getCredentialsFile() != null) {
       File file = new File(config.getCredentialsFile());
       try (InputStream credentialsStream = Files.newInputStream(file.toPath())) {
@@ -71,6 +83,7 @@ public class GcsTransport extends Transport {
     return builder.build().getService();
   }
 
+  @SuppressWarnings("PMD.UnusedPrivateMethod")
   private <T extends OpenLineage.BaseEvent> void emitEvent(T event) {
     Long timestamp = event.getEventTime().toInstant().toEpochMilli();
     String fileName = fileNamePrefix.map(getFileName(timestamp)).orElse(timestamp + ".json");
@@ -101,5 +114,9 @@ public class GcsTransport extends Transport {
   @Override
   public void close() throws Exception {
     storage.close();
+  }
+
+  Storage getStorage() {
+    return storage;
   }
 }

--- a/client/java/transports-gcs/src/main/java/io/openlineage/client/transports/gcs/GcsTransportConfig.java
+++ b/client/java/transports-gcs/src/main/java/io/openlineage/client/transports/gcs/GcsTransportConfig.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.transports.gcs;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.MergeConfig;
 import io.openlineage.client.transports.TransportConfig;
 import javax.annotation.Nullable;
@@ -24,12 +25,24 @@ public class GcsTransportConfig implements TransportConfig, MergeConfig<GcsTrans
   @Getter @Setter private @Nullable String credentialsFile;
   @Getter @Setter private @Nullable String fileNamePrefix;
 
+  @JsonProperty("maxRetries")
+  @Getter
+  @Setter
+  private @Nullable Integer maxRetries;
+
+  @JsonProperty("retryIntervalMillis")
+  @Getter
+  @Setter
+  private @Nullable Integer retryIntervalMillis;
+
   @Override
   public GcsTransportConfig mergeWithNonNull(GcsTransportConfig other) {
     return new GcsTransportConfig(
         mergePropertyWith(projectId, other.projectId),
         mergePropertyWith(bucketName, other.bucketName),
         mergePropertyWith(credentialsFile, other.credentialsFile),
-        mergePropertyWith(fileNamePrefix, other.fileNamePrefix));
+        mergePropertyWith(fileNamePrefix, other.fileNamePrefix),
+        mergePropertyWith(maxRetries, other.maxRetries),
+        mergePropertyWith(retryIntervalMillis, other.retryIntervalMillis));
   }
 }

--- a/client/java/transports-gcs/src/test/java/io/openlineage/client/transports/gcs/GcsTransportTest.java
+++ b/client/java/transports-gcs/src/test/java/io/openlineage/client/transports/gcs/GcsTransportTest.java
@@ -7,6 +7,7 @@ package io.openlineage.client.transports.gcs;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -32,7 +33,7 @@ class GcsTransportTest {
   void shouldWriteEventToGcsWithNamePrefix() {
     Storage localStorage = LocalStorageHelper.getOptions().getService();
     GcsTransportConfig config =
-        new GcsTransportConfig("test_project", "test_bucket", null, "some_prefix");
+        new GcsTransportConfig("test_project", "test_bucket", null, "some_prefix", null, null);
     GcsTransport transport = new GcsTransport(localStorage, config);
     OpenLineageClient client = new OpenLineageClient(transport);
 
@@ -53,7 +54,7 @@ class GcsTransportTest {
   void shouldWriteEventToGcsWithPathPrefix() {
     Storage localStorage = LocalStorageHelper.getOptions().getService();
     GcsTransportConfig config =
-        new GcsTransportConfig("test_project", "test_bucket", null, "some/prefix/");
+        new GcsTransportConfig("test_project", "test_bucket", null, "some/prefix/", null, null);
     GcsTransport transport = new GcsTransport(localStorage, config);
     OpenLineageClient client = new OpenLineageClient(transport);
 
@@ -74,7 +75,7 @@ class GcsTransportTest {
   void shouldThrowIfObjectAlreadyExists() {
     Storage localStorage = LocalStorageHelper.getOptions().getService();
     GcsTransportConfig config =
-        new GcsTransportConfig("test_project", "test_bucket", null, "some/prefix/");
+        new GcsTransportConfig("test_project", "test_bucket", null, "some/prefix/", null, null);
     GcsTransport transport = new GcsTransport(localStorage, config);
     OpenLineageClient client = new OpenLineageClient(transport);
 
@@ -88,6 +89,22 @@ class GcsTransportTest {
                         ZonedDateTime.now(clock).toInstant().toEpochMilli())))
             .build());
     assertThrows(OpenLineageClientException.class, () -> client.emit(event));
+  }
+
+  @Test
+  void shouldConfigureRetrySettings() throws Exception {
+    GcsTransportConfig config = new GcsTransportConfig();
+    config.setProjectId("test_project");
+    config.setBucketName("test_bucket");
+    config.setMaxRetries(3);
+    config.setRetryIntervalMillis(2500);
+
+    GcsTransport transport = new GcsTransport(config);
+    RetrySettings retrySettings = transport.getStorage().getOptions().getRetrySettings();
+
+    assertEquals(3, retrySettings.getMaxAttempts());
+    assertEquals(2500L, retrySettings.getInitialRetryDelayDuration().toMillis());
+    assertEquals(2500L, retrySettings.getMaxRetryDelayDuration().toMillis());
   }
 
   public static OpenLineage.RunEvent runEvent(Clock clock) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Expose retry config in `GcsTransport`


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
The lineage producer used by `GcsTransport` has its retry policy configurable. Until now the transport just used the default one. Now the policy is configurable via transport config.

### Checklist
- [ ] AI was used in creating this PR
