### PR TITLE
add retry configuration to http transport

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -56,6 +56,16 @@ public final class HttpConfig implements TransportConfig, MergeConfig<HttpConfig
   @Setter
   private @Nullable HttpSslContextConfig sslContextConfig;
 
+  @JsonProperty("maxRetries")
+  @Getter
+  @Setter
+  private @Nullable Integer maxRetries;
+
+  @JsonProperty("retryIntervalMillis")
+  @Getter
+  @Setter
+  private @Nullable Integer retryIntervalMillis;
+
   @Override
   public HttpConfig mergeWithNonNull(HttpConfig other) {
     return new HttpConfig(
@@ -66,6 +76,8 @@ public final class HttpConfig implements TransportConfig, MergeConfig<HttpConfig
         mergePropertyWith(urlParams, other.urlParams),
         mergePropertyWith(headers, other.headers),
         mergePropertyWith(compression, other.compression),
-        mergePropertyWith(sslContextConfig, other.sslContextConfig));
+        mergePropertyWith(sslContextConfig, other.sslContextConfig),
+        mergePropertyWith(maxRetries, other.maxRetries),
+        mergePropertyWith(retryIntervalMillis, other.retryIntervalMillis));
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -66,6 +66,16 @@ public final class HttpConfig implements TransportConfig, MergeConfig<HttpConfig
   @Setter
   private @Nullable Integer retryIntervalMillis;
 
+  @JsonProperty("retryIntervalMultiplier")
+  @Getter
+  @Setter
+  private @Nullable Double retryIntervalMultiplier;
+
+  @JsonProperty("maxRetryIntervalMillis")
+  @Getter
+  @Setter
+  private @Nullable Integer maxRetryIntervalMillis;
+
   @Override
   public HttpConfig mergeWithNonNull(HttpConfig other) {
     return new HttpConfig(
@@ -78,6 +88,8 @@ public final class HttpConfig implements TransportConfig, MergeConfig<HttpConfig
         mergePropertyWith(compression, other.compression),
         mergePropertyWith(sslContextConfig, other.sslContextConfig),
         mergePropertyWith(maxRetries, other.maxRetries),
-        mergePropertyWith(retryIntervalMillis, other.retryIntervalMillis));
+        mergePropertyWith(retryIntervalMillis, other.retryIntervalMillis),
+        mergePropertyWith(retryIntervalMultiplier, other.retryIntervalMultiplier),
+        mergePropertyWith(maxRetryIntervalMillis, other.maxRetryIntervalMillis));
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -17,20 +17,26 @@ import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.experimental.Delegate;
@@ -46,6 +52,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -377,10 +384,25 @@ public final class HttpTransport extends Transport {
         long baseRetryIntervalMillis,
         double retryIntervalMultiplier,
         long maxRetryIntervalMillis) {
-      super(maxRetries, TimeValue.ofMilliseconds(baseRetryIntervalMillis));
+      super(
+          maxRetries,
+          TimeValue.ZERO_MILLISECONDS,
+          Arrays.asList(
+              InterruptedIOException.class,
+              UnknownHostException.class,
+              ConnectException.class,
+              ConnectionClosedException.class,
+              NoRouteToHostException.class,
+              SSLException.class),
+          Arrays.asList(500, 502, 503, 504));
       this.baseRetryIntervalMillis = baseRetryIntervalMillis;
       this.retryIntervalMultiplier = retryIntervalMultiplier;
       this.maxRetryIntervalMillis = maxRetryIntervalMillis;
+    }
+
+    @Override
+    protected boolean handleAsIdempotent(final HttpRequest request) {
+      return true;
     }
 
     @Override

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
@@ -52,6 +53,7 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.pool.PoolReusePolicy;
 import org.apache.hc.core5.ssl.SSLContexts;
+import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
 @Slf4j
@@ -109,9 +111,16 @@ public final class HttpTransport extends Transport {
             .setResponseTimeout(timeout)
             .build();
 
+    int maxRetries = httpConfig.getMaxRetries() != null ? httpConfig.getMaxRetries() : 1;
+    long retryInterval =
+        httpConfig.getRetryIntervalMillis() != null ? httpConfig.getRetryIntervalMillis() : 1000L;
+
     return HttpClientBuilder.create()
         .setDefaultRequestConfig(requestConfig)
         .setConnectionManager(connectionManagerBuilder.build())
+        .setRetryStrategy(
+            new DefaultHttpRequestRetryStrategy(
+                maxRetries, TimeValue.ofMilliseconds(retryInterval)))
         .setDefaultRequestConfig(requestConfig)
         .build();
   }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -24,9 +24,11 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import lombok.NonNull;
@@ -42,13 +44,19 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.pool.PoolReusePolicy;
@@ -60,6 +68,11 @@ import org.apache.hc.core5.util.Timeout;
 @ToString
 public final class HttpTransport extends Transport {
   private static final String API_V1 = "/api/v1";
+  private static final int DEFAULT_MAX_RETRIES = 1;
+  private static final long DEFAULT_RETRY_INTERVAL_MILLIS = 1000L;
+  private static final double DEFAULT_RETRY_INTERVAL_MULTIPLIER = 2.0d;
+  private static final long DEFAULT_MAX_RETRY_INTERVAL_MILLIS = 60000L;
+  private static final long MAX_RETRY_DELAY_MILLIS = Long.MAX_VALUE - 1;
 
   private final CloseableHttpClient http;
   private final URI uri;
@@ -111,16 +124,27 @@ public final class HttpTransport extends Transport {
             .setResponseTimeout(timeout)
             .build();
 
-    int maxRetries = httpConfig.getMaxRetries() != null ? httpConfig.getMaxRetries() : 1;
-    long retryInterval =
-        httpConfig.getRetryIntervalMillis() != null ? httpConfig.getRetryIntervalMillis() : 1000L;
+    int maxRetries =
+        httpConfig.getMaxRetries() != null ? httpConfig.getMaxRetries() : DEFAULT_MAX_RETRIES;
+    long retryIntervalMillis =
+        httpConfig.getRetryIntervalMillis() != null
+            ? httpConfig.getRetryIntervalMillis()
+            : DEFAULT_RETRY_INTERVAL_MILLIS;
+    double retryIntervalMultiplier =
+        httpConfig.getRetryIntervalMultiplier() != null
+            ? httpConfig.getRetryIntervalMultiplier()
+            : DEFAULT_RETRY_INTERVAL_MULTIPLIER;
+    long maxRetryIntervalMillis =
+        httpConfig.getMaxRetryIntervalMillis() != null
+            ? httpConfig.getMaxRetryIntervalMillis()
+            : DEFAULT_MAX_RETRY_INTERVAL_MILLIS;
 
     return HttpClientBuilder.create()
         .setDefaultRequestConfig(requestConfig)
         .setConnectionManager(connectionManagerBuilder.build())
         .setRetryStrategy(
-            new DefaultHttpRequestRetryStrategy(
-                maxRetries, TimeValue.ofMilliseconds(retryInterval)))
+            new ExponentialJitterRetryStrategy(
+                maxRetries, retryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis))
         .setDefaultRequestConfig(requestConfig)
         .build();
   }
@@ -340,6 +364,84 @@ public final class HttpTransport extends Transport {
         return new HttpTransport(httpClient, httpConfig);
       }
       return new HttpTransport(httpConfig);
+    }
+  }
+
+  static final class ExponentialJitterRetryStrategy extends DefaultHttpRequestRetryStrategy {
+    private final long baseRetryIntervalMillis;
+    private final double retryIntervalMultiplier;
+    private final long maxRetryIntervalMillis;
+
+    ExponentialJitterRetryStrategy(
+        int maxRetries,
+        long baseRetryIntervalMillis,
+        double retryIntervalMultiplier,
+        long maxRetryIntervalMillis) {
+      super(maxRetries, TimeValue.ofMilliseconds(baseRetryIntervalMillis));
+      this.baseRetryIntervalMillis = baseRetryIntervalMillis;
+      this.retryIntervalMultiplier = retryIntervalMultiplier;
+      this.maxRetryIntervalMillis = maxRetryIntervalMillis;
+    }
+
+    @Override
+    public TimeValue getRetryInterval(
+        HttpRequest request, IOException exception, int execCount, HttpContext context) {
+      return getExponentialBackoffWithJitter(
+          baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, execCount);
+    }
+
+    @Override
+    public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
+      TimeValue retryAfter = getRetryAfterInterval(response);
+      if (TimeValue.isPositive(retryAfter)) {
+        return retryAfter;
+      }
+      return getExponentialBackoffWithJitter(
+          baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, execCount);
+    }
+
+    static TimeValue getExponentialBackoffWithJitter(
+        long baseRetryIntervalMillis,
+        double retryIntervalMultiplier,
+        long maxRetryIntervalMillis,
+        int execCount) {
+      if (baseRetryIntervalMillis <= 0
+          || retryIntervalMultiplier <= 0
+          || maxRetryIntervalMillis <= 0) {
+        return TimeValue.ZERO_MILLISECONDS;
+      }
+
+      int retryNumber = Math.max(execCount - 1, 0);
+      double exponentiatedDelay =
+          baseRetryIntervalMillis * Math.pow(retryIntervalMultiplier, retryNumber);
+      long cappedDelayMillis =
+          (long)
+              Math.min(
+                  Math.min(exponentiatedDelay, maxRetryIntervalMillis),
+                  (double) MAX_RETRY_DELAY_MILLIS);
+
+      long jitteredDelay = ThreadLocalRandom.current().nextLong(cappedDelayMillis + 1);
+      return TimeValue.ofMilliseconds(jitteredDelay);
+    }
+
+    private static @Nullable TimeValue getRetryAfterInterval(HttpResponse response) {
+      Header header = response.getFirstHeader(HttpHeaders.RETRY_AFTER);
+      if (header == null) {
+        return null;
+      }
+
+      String value = header.getValue();
+      TimeValue retryAfter = null;
+      try {
+        retryAfter = TimeValue.ofSeconds(Long.parseLong(value));
+      } catch (NumberFormatException ignore) {
+        Instant retryAfterDate = DateUtils.parseStandardDate(value);
+        if (retryAfterDate != null) {
+          retryAfter =
+              TimeValue.ofMilliseconds(retryAfterDate.toEpochMilli() - System.currentTimeMillis());
+        }
+      }
+      return retryAfter;
     }
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -312,13 +312,17 @@ class ConfigTest {
     HttpConfig overwriteHttpConfig = new HttpConfig();
 
     baseHttpConfig.setEndpoint("endpoint1");
+    baseHttpConfig.setMaxRetries(2);
     overwriteHttpConfig.setEndpoint("endpoint2");
+    overwriteHttpConfig.setRetryIntervalMillis(2500);
 
     base.setTransportConfig(baseHttpConfig);
     overwrite.setTransportConfig(overwriteHttpConfig);
 
     OpenLineageConfig config = (OpenLineageConfig) base.mergeWith(overwrite);
     assertThat(((HttpConfig) config.getTransportConfig()).getEndpoint()).isEqualTo("endpoint2");
+    assertThat(((HttpConfig) config.getTransportConfig()).getMaxRetries()).isEqualTo(2);
+    assertThat(((HttpConfig) config.getTransportConfig()).getRetryIntervalMillis()).isEqualTo(2500);
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -313,8 +313,10 @@ class ConfigTest {
 
     baseHttpConfig.setEndpoint("endpoint1");
     baseHttpConfig.setMaxRetries(2);
+    baseHttpConfig.setRetryIntervalMultiplier(3.0);
     overwriteHttpConfig.setEndpoint("endpoint2");
     overwriteHttpConfig.setRetryIntervalMillis(2500);
+    overwriteHttpConfig.setMaxRetryIntervalMillis(10000);
 
     base.setTransportConfig(baseHttpConfig);
     overwrite.setTransportConfig(overwriteHttpConfig);
@@ -322,7 +324,11 @@ class ConfigTest {
     OpenLineageConfig config = (OpenLineageConfig) base.mergeWith(overwrite);
     assertThat(((HttpConfig) config.getTransportConfig()).getEndpoint()).isEqualTo("endpoint2");
     assertThat(((HttpConfig) config.getTransportConfig()).getMaxRetries()).isEqualTo(2);
+    assertThat(((HttpConfig) config.getTransportConfig()).getRetryIntervalMultiplier())
+        .isEqualTo(3.0);
     assertThat(((HttpConfig) config.getTransportConfig()).getRetryIntervalMillis()).isEqualTo(2500);
+    assertThat(((HttpConfig) config.getTransportConfig()).getMaxRetryIntervalMillis())
+        .isEqualTo(10000);
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -40,16 +40,21 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import lombok.SneakyThrows;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -234,23 +239,35 @@ class HttpTransportTest {
   void retryIntervalUsesExponentialBackoffWithJitter() {
     long baseRetryIntervalMillis = 100L;
     double retryIntervalMultiplier = 2.0;
-    long maxRetryIntervalMillis = 250L;
+    long maxRetryIntervalMillis = 10000L;
 
-    for (int i = 0; i < 100; i++) {
-      TimeValue firstRetry =
-          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
-              baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 1);
-      TimeValue secondRetry =
-          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
-              baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 2);
-      TimeValue thirdRetry =
-          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
-              baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 3);
-
-      assertThat(firstRetry.toMilliseconds()).isBetween(0L, 100L);
-      assertThat(secondRetry.toMilliseconds()).isBetween(0L, 200L);
-      assertThat(thirdRetry.toMilliseconds()).isBetween(0L, 250L);
+    long maxFirst = 0L;
+    long maxSecond = 0L;
+    long maxThird = 0L;
+    for (int i = 0; i < 1000; i++) {
+      maxFirst =
+          Math.max(
+              maxFirst,
+              HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                      baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 1)
+                  .toMilliseconds());
+      maxSecond =
+          Math.max(
+              maxSecond,
+              HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                      baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 2)
+                  .toMilliseconds());
+      maxThird =
+          Math.max(
+              maxThird,
+              HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                      baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 3)
+                  .toMilliseconds());
     }
+
+    assertThat(maxFirst).isGreaterThan(80L);
+    assertThat(maxSecond).isGreaterThan(160L);
+    assertThat(maxThird).isGreaterThan(320L);
   }
 
   @Test
@@ -267,6 +284,63 @@ class HttpTransportTest {
             HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
                 100, 2.0, 0, 1))
         .isEqualTo(TimeValue.ZERO_MILLISECONDS);
+  }
+
+  @Test
+  void retryIntervalHonorsMaxIntervalCap() {
+    long baseRetryIntervalMillis = 100L;
+    double retryIntervalMultiplier = 2.0;
+    long maxRetryIntervalMillis = 250L;
+
+    long observedMax = 0L;
+    for (int i = 0; i < 1000; i++) {
+      long value =
+          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                  baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 3)
+              .toMilliseconds();
+      assertThat(value).isBetween(0L, maxRetryIntervalMillis);
+      observedMax = Math.max(observedMax, value);
+    }
+
+    assertThat(observedMax).isGreaterThan(220L);
+  }
+
+  @Test
+  void retryDecisionDoesNotDependOnBaseRetryIntervalVsTimeout() {
+    HttpTransport.ExponentialJitterRetryStrategy strategy =
+        new HttpTransport.ExponentialJitterRetryStrategy(5, 10_000L, 2.0, 60_000L);
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getCode()).thenReturn(503);
+
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequestConfig(
+        RequestConfig.custom().setResponseTimeout(Timeout.ofMilliseconds(5000)).build());
+
+    assertThat(strategy.retryRequest(response, 1, context)).isTrue();
+  }
+
+  @Test
+  void retryDecisionRetriesPostTransportErrorsUpToMaxRetries() {
+    HttpTransport.ExponentialJitterRetryStrategy strategy =
+        new HttpTransport.ExponentialJitterRetryStrategy(1, 1000L, 2.0, 60_000L);
+    BasicHttpRequest post = new BasicHttpRequest("POST", "/api/v1/lineage");
+
+    assertThat(strategy.retryRequest(post, new IOException("Connection dropped"), 1, null))
+        .isTrue();
+    assertThat(strategy.retryRequest(post, new IOException("Connection dropped"), 2, null))
+        .isFalse();
+  }
+
+  @Test
+  void retryDecisionUsesExpectedStatusCodes() {
+    HttpTransport.ExponentialJitterRetryStrategy strategy =
+        new HttpTransport.ExponentialJitterRetryStrategy(1, 1000L, 2.0, 60_000L);
+
+    assertStatusRetry(strategy, 500, true);
+    assertStatusRetry(strategy, 502, true);
+    assertStatusRetry(strategy, 503, true);
+    assertStatusRetry(strategy, 504, true);
+    assertStatusRetry(strategy, 429, false);
   }
 
   @Test
@@ -309,6 +383,13 @@ class HttpTransportTest {
     } finally {
       server.stop(0);
     }
+  }
+
+  private static void assertStatusRetry(
+      HttpTransport.ExponentialJitterRetryStrategy strategy, int statusCode, boolean expected) {
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getCode()).thenReturn(statusCode);
+    assertThat(strategy.retryRequest(response, 1, null)).isEqualTo(expected);
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -22,17 +22,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.sun.net.httpserver.HttpServer;
 import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.OpenLineageClientException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import lombok.SneakyThrows;
@@ -187,6 +191,42 @@ class HttpTransportTest {
     assertThrows(OpenLineageClientException.class, () -> client.emit(runEvent()));
 
     verify(http, times(1)).execute(any(), any(HttpClientResponseHandler.class));
+  }
+
+  @Test
+  void httpTransportRetriesOnServiceUnavailable() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    AtomicInteger requests = new AtomicInteger();
+    final int firstRequest = 1;
+    server.createContext(
+        "/api/v1/lineage",
+        exchange -> {
+          byte[] responseBody;
+          if (requests.incrementAndGet() == firstRequest) {
+            responseBody = "retry".getBytes();
+            exchange.sendResponseHeaders(503, responseBody.length);
+          } else {
+            responseBody = "ok".getBytes();
+            exchange.sendResponseHeaders(200, responseBody.length);
+          }
+          try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(responseBody);
+          }
+        });
+    server.start();
+    try {
+      HttpConfig config = new HttpConfig();
+      config.setUrl(URI.create("http://localhost:" + server.getAddress().getPort()));
+      config.setMaxRetries(1);
+      config.setRetryIntervalMillis(1);
+
+      OpenLineageClient client = new OpenLineageClient(new HttpTransport(config));
+      client.emit(runEvent());
+
+      assertThat(requests.get()).isEqualTo(2);
+    } finally {
+      server.stop(0);
+    }
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -49,6 +49,7 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.TimeValue;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -224,6 +225,87 @@ class HttpTransportTest {
       client.emit(runEvent());
 
       assertThat(requests.get()).isEqualTo(2);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void retryIntervalUsesExponentialBackoffWithJitter() {
+    long baseRetryIntervalMillis = 100L;
+    double retryIntervalMultiplier = 2.0;
+    long maxRetryIntervalMillis = 250L;
+
+    for (int i = 0; i < 100; i++) {
+      TimeValue firstRetry =
+          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+              baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 1);
+      TimeValue secondRetry =
+          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+              baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 2);
+      TimeValue thirdRetry =
+          HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+              baseRetryIntervalMillis, retryIntervalMultiplier, maxRetryIntervalMillis, 3);
+
+      assertThat(firstRetry.toMilliseconds()).isBetween(0L, 100L);
+      assertThat(secondRetry.toMilliseconds()).isBetween(0L, 200L);
+      assertThat(thirdRetry.toMilliseconds()).isBetween(0L, 250L);
+    }
+  }
+
+  @Test
+  void retryIntervalReturnsZeroForNonPositiveValues() {
+    assertThat(
+            HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                0, 2.0, 100, 1))
+        .isEqualTo(TimeValue.ZERO_MILLISECONDS);
+    assertThat(
+            HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                100, 0.0, 100, 1))
+        .isEqualTo(TimeValue.ZERO_MILLISECONDS);
+    assertThat(
+            HttpTransport.ExponentialJitterRetryStrategy.getExponentialBackoffWithJitter(
+                100, 2.0, 0, 1))
+        .isEqualTo(TimeValue.ZERO_MILLISECONDS);
+  }
+
+  @Test
+  void httpTransportRetriesUsingRetryAfterHeader() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    AtomicInteger requests = new AtomicInteger();
+    final int firstRequest = 1;
+    server.createContext(
+        "/api/v1/lineage",
+        exchange -> {
+          byte[] responseBody;
+          if (requests.incrementAndGet() == firstRequest) {
+            responseBody = "retry".getBytes();
+            exchange.getResponseHeaders().add("Retry-After", "1");
+            exchange.sendResponseHeaders(503, responseBody.length);
+          } else {
+            responseBody = "ok".getBytes();
+            exchange.sendResponseHeaders(200, responseBody.length);
+          }
+          try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(responseBody);
+          }
+        });
+    server.start();
+    try {
+      HttpConfig config = new HttpConfig();
+      config.setUrl(URI.create("http://localhost:" + server.getAddress().getPort()));
+      config.setMaxRetries(1);
+      config.setRetryIntervalMillis(1);
+      config.setRetryIntervalMultiplier(2.0);
+      config.setMaxRetryIntervalMillis(10);
+
+      OpenLineageClient client = new OpenLineageClient(new HttpTransport(config));
+      long startNanos = System.nanoTime();
+      client.emit(runEvent());
+      long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+
+      assertThat(requests.get()).isEqualTo(2);
+      assertThat(elapsedMillis).isGreaterThanOrEqualTo(900L);
     } finally {
       server.stop(0);
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Expose retry config in `HttpTransport`


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
The client used by `HttpTransport` has its retry policy configurable. Until now the transport just used the default one. Now the policy is configurable via transport config.



### Checklist
- [x] AI was used in creating this PR
