### PR TITLE
fix(spark): skip ResolvedIdentifier silently in InputFieldsCollector

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -158,7 +158,11 @@ public class InputFieldsCollector {
     } else if (node instanceof OneRowRelation
         || node instanceof LocalRelation
         || node instanceof ExternalRDD
-        || node instanceof LogicalRDD) {
+        || node instanceof LogicalRDD
+        // ResolvedIdentifier (Spark 3.4+) is a write target, not an input source — skip silently.
+        // Class name check avoids a compile-time dependency on Spark 3.4+ APIs.
+        || "org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier"
+            .equals(node.getClass().getCanonicalName())) {
       // skip without warning
     } else if (node instanceof LeafNode) {
       log.warn("Could not extract dataset identifier from {}", node.getClass().getCanonicalName());


### PR DESCRIPTION
## Summary

When running on Spark 3.4+, `InputFieldsCollector` traverses the full logical plan tree during column-level lineage collection. `ResolvedIdentifier` (`org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier`) nodes appear in these plans — they are write targets resolved by Spark's analyzer — but were not in the known-skip list. Because `ResolvedIdentifier` is a `LeafNode`, every occurrence fell through to the warn branch:

```
log.warn("Could not extract dataset identifier from {}", node.getClass().getCanonicalName());
// → "Could not extract dataset identifier from
//    org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier"
```

This warning fires on every write operation that uses a branch-qualified Iceberg table reference on Spark 3.4+.

## Fix

Add `ResolvedIdentifier` to the skip-without-warning condition in `InputFieldsCollector`. The check uses a class-name string comparison so the `spark3` module — which compiles against Spark 3.2.4 where the class does not exist — has no compile-time dependency on Spark 3.4+ APIs:

```java
|| "org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier"
    .equals(node.getClass().getCanonicalName())
```

## Out of scope

The related issue (missing output datasets when writing to Iceberg named branches) was initially attributed to `AppendData.table()` returning a `ResolvedIdentifier`. Investigation showed this is not the case: `AppendData.table()` is statically typed as `NamedRelation` and `ResolvedIdentifier` does not implement `NamedRelation`. The root cause of the missing output dataset remains under investigation and will be addressed in a separate PR.

## Test plan

- [x] `InputFieldsCollectorTest` passes (10 tests)
- [x] No new compile-time dependency on Spark 3.4+ APIs in the `spark3` module

Closes #4803 (partially — spurious warning fix only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)