### PR TITLE
dbt: read OPENLINEAGE_CONTEXT on the local-artifacts path

### DIFF
--- a/integration/dbt/src/openlineage/dbt/__init__.py
+++ b/integration/dbt/src/openlineage/dbt/__init__.py
@@ -271,13 +271,11 @@ def consume_local_artifacts(
 ):
     logger = logging.getLogger("openlineage.dbt")
     logger.info("This wrapper will send OpenLineage events at the end of dbt execution.")
-    parent_id = os.getenv("OPENLINEAGE_PARENT_ID")
-    parent_run_metadata = None
-    # We can get this if we have been orchestrated by an external system like airflow
     job_namespace = os.environ.get("OPENLINEAGE_NAMESPACE", "dbt")
-
-    if parent_id:
-        parent_run_metadata = get_parent_run_metadata()
+    # We can get this if we have been orchestrated by an external system like airflow.
+    # get_parent_run_metadata() reads OPENLINEAGE_CONTEXT first and only then the legacy
+    # OPENLINEAGE_PARENT_ID, so it must not be gated on the legacy variable being set.
+    parent_run_metadata = get_parent_run_metadata()
     client = OpenLineageClient()
 
     processor = DbtLocalArtifactProcessor(

--- a/integration/dbt/tests/test_main.py
+++ b/integration/dbt/tests/test_main.py
@@ -1,5 +1,6 @@
 # Copyright 2018-2026 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
+import json
 from unittest import mock
 
 import pytest
@@ -205,6 +206,44 @@ def test_consume_local_artifacts_propagates_root_parent_metadata(monkeypatch):
 
     # Child events use processor.dbt_run_metadata as their parent facet — root must
     # point at the orchestrator that started us, not be left blank.
+    md = processor.dbt_run_metadata
+    assert md.root_parent_run_id == parent_run_id
+    assert md.root_parent_job_name == parent_job
+    assert md.root_parent_job_namespace == parent_namespace
+
+
+def test_consume_local_artifacts_reads_parent_from_openlineage_context(monkeypatch):
+    """OPENLINEAGE_CONTEXT alone must identify the parent: it is the standardized
+    replacement for OPENLINEAGE_PARENT_ID, so an orchestrator that only sets the
+    new variable still has to end up as the parent of the dbt run."""
+    from openlineage.dbt import consume_local_artifacts
+
+    parent_namespace = "airflow"
+    parent_job = "airflow-dag.task"
+    parent_run_id = "dddddddd-0000-0000-0000-000000000004"
+    env = {
+        "OPENLINEAGE_NAMESPACE": "dbt",
+        "OPENLINEAGE_CONTEXT": json.dumps(
+            {
+                "parent": {
+                    "run": {"runId": parent_run_id},
+                    "job": {"namespace": parent_namespace, "name": parent_job},
+                }
+            }
+        ),
+    }
+    processor = _setup_local_artifacts_mocks(monkeypatch, env)
+
+    consume_local_artifacts(
+        args=["dbt", "run"],
+        target=None,
+        target_path=None,
+        project_dir="./",
+        profile_name=None,
+        model_selector=None,
+        models=[],
+    )
+
     md = processor.dbt_run_metadata
     assert md.root_parent_run_id == parent_run_id
     assert md.root_parent_job_name == parent_job


### PR DESCRIPTION
### One-line summary for changelog:
dbt: `dbt-ol` now honors `OPENLINEAGE_CONTEXT` on its default (local artifacts) path, not only with `--consume-structured-logs`.

### Meaningful description

`consume_local_artifacts()` reads `OPENLINEAGE_PARENT_ID` itself and only calls `get_parent_run_metadata()` when that legacy variable is set:

```python
parent_id = os.getenv("OPENLINEAGE_PARENT_ID")
parent_run_metadata = None
...
if parent_id:
    parent_run_metadata = get_parent_run_metadata()
```

Since #4682, `get_parent_run_metadata()` reads the standardized `OPENLINEAGE_CONTEXT` first and only falls back to `OPENLINEAGE_PARENT_ID`. The legacy guard therefore makes the new variable inert on this path: with only `OPENLINEAGE_CONTEXT` exported, the dbt-run wrapper events carry no `parent` facet, and `root` on every node event points back at the dbt run instead of the orchestrator.

`DbtStructuredLogsProcessor` calls the same helper unconditionally (`structured_logs.py:131`), so `dbt-ol --consume-structured-logs` was unaffected — only the default path was.

The documentation already promises the wrapper supports it (`website/docs/integrations/dbt.md`):

> Whether using the `dbt-ol` CLI wrapper, `DbtLocalArtifactProcessor`, or `DbtStructuredLogsProcessor`, you can link the dbt execution to a parent orchestrator run [...] Set the standardized `OPENLINEAGE_CONTEXT` environment variable

Fix: drop the guard and call `get_parent_run_metadata()` directly. It already returns `None` when neither variable is set, so the "no orchestrator" and "legacy `OPENLINEAGE_PARENT_ID` only" cases behave exactly as before.

**Testing**

- New regression test `test_consume_local_artifacts_reads_parent_from_openlineage_context` fails on current `main` (root is a freshly generated UUID instead of the context's `runId`) and passes with the fix.
- `integration/dbt`: `pytest tests/test_main.py` → 10 passed (9 before this PR).
- `integration/common`: `pytest tests/dbt/` → 242 passed. The 4 failures in `tests/great_expectations/` are pre-existing — the same 4 fail on a clean checkout of `main` without this change.
- `ruff check` / `ruff format --check` clean on both files.

related: #4412

### Checklist
- [x] AI was used in creating this PR
