### PR TITLE
dbt: set the data-quality assertion name on the structured-logs path

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -642,6 +642,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
 
         return dq.Assertion(
             assertion=name,
+            name=manifest_test_node.get("name"),
             success=success,
             column=column,
             severity=severity,

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -92,6 +92,7 @@ def node_finished_processor(adapter_type=Adapter.SNOWFLAKE, dataset_namespace="t
                 "database": "REPORTING",
                 "schema": "TEST_GENERAL_dbt_test__audit",
                 "alias": "not_null_orders_id",
+                "name": "not_null_orders_id",
                 "unique_id": "test.jaffle_shop.not_null_orders_id",
                 "columns": {},
                 "meta": {},
@@ -434,6 +435,25 @@ def test_node_finished_bigquery_missing_job_id_has_no_external_query():
     )
 
     assert "externalQuery" not in ol_event_to_dict(event)["run"]["facets"]
+
+
+def test_test_node_finished_assertion_carries_test_name():
+    # The run_results path sets Assertion.name from the manifest node; the structured-logs
+    # path has to produce the same facet.
+    processor = node_finished_processor()
+
+    event = processor.parse_node_finished_event(
+        node_finished_event(
+            unique_id="test.jaffle_shop.not_null_orders_id",
+            resource_type="test",
+            node_status="pass",
+        ),
+    )
+    assertions = ol_event_to_dict(event)["inputs"][0]["facets"]["dataQualityAssertions"]["assertions"]
+
+    assert len(assertions) == 1
+    assert assertions[0]["assertion"] == "not_null"
+    assert assertions[0]["name"] == "not_null_orders_id"
 
 
 def test_test_node_finished_has_no_external_query():


### PR DESCRIPTION
### One-line summary for changelog:
dbt: `dataQualityAssertions` emitted from `--consume-structured-logs` now carries the test name, matching the run_results processor.

### Meaningful description

#4777 added `name=test_node.get("name")` to the `Assertion` built in `parse_assertions` (the run_results path). `DbtStructuredLogsProcessor._get_assertion` builds the same `DataQualityAssertionsDatasetFacet` for the same dbt tests, but its `dq.Assertion(...)` call has no `name` argument at all — so the field is not "sometimes missing" there, it can never be set.

The two goldens in this repo show the divergence directly:

```
integration/common/tests/dbt/no_test_metadata/result.json          (run_results path)
  {"assertion": "unique", "success": false, "column": "customer_id",
   "severity": "error", "name": "unique_customers_customer_id"}

.../structured_logs/postgres/test/results/test_ol_events.json      (structured-logs path)
  {"assertion": "accepted_values", "success": false, "column": "first_name"}
```

So a consumer reading `Assertion.name` gets the test's identity from `dbt-ol` but not from `dbt-ol --consume-structured-logs`. `_get_assertion` already holds `manifest_test_node`, so this is one argument.

Only `name` is affected: the `column` fallback #4777 added (`or test_node.get("column_name")`) has no counterpart gap here — across the 396 test nodes in this repo's manifest fixtures, `test_metadata.kwargs.column_name` and the node-level `column_name` diverge exactly once, and in the direction the existing lookup already handles.

**Testing**

- New `test_test_node_finished_assertion_carries_test_name` fails on `main` with `AssertionError: assert None == 'not_null_orders_id'` and passes with the fix. The shared `node_finished_processor` manifest fixture gains the node-level `name` key that real dbt manifests carry.
- `integration/common`: `pytest tests/dbt/` → 243 passed (242 before this PR).
- Whole package: 354 passed, 3 failed — the 3 failures are in `tests/great_expectations/` and are identical on a clean checkout of the same commit without this change.
- `ruff check` / `ruff format --check` clean.

The `test_parse` goldens are matched as a subset, so they still pass unchanged; I left them alone to keep the diff small rather than re-record them.

### Checklist
- [x] AI was used in creating this PR
