### PR TITLE
great_expectations: stop forwarding data_context to the 1.x ValidationAction

### DIFF
--- a/integration/common/src/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/src/openlineage/common/provider/great_expectations/action.py
@@ -117,9 +117,13 @@ class OpenLineageValidationAction(ValidationAction):
         return v or str(generate_new_uuid())
 
     def __init__(self, data_context=None, **data):
-        # data_context is required by ValidationAction in some GE versions
-        # but we don't use it directly
-        super().__init__(data_context=data_context, **data)
+        # data_context is required by ValidationAction in some GE versions but we don't use it
+        # directly. Since 1.0 the base action is a pydantic model that forbids extra fields and
+        # declares no data_context, so forwarding it unconditionally makes the action impossible
+        # to construct — only pass it on where the base actually accepts it.
+        if "data_context" in getattr(ValidationAction, "__fields__", {}):
+            data["data_context"] = data_context
+        super().__init__(**data)
 
         # Initialize OpenLineage client
         if self.openlineage_host is not None:


### PR DESCRIPTION
### One-line summary for changelog:
Fix `OpenLineageValidationAction` failing to construct on Great Expectations 1.x, which made the GE integration unusable.

### Meaningful description

`OpenLineageValidationAction.__init__` forwarded `data_context` to `ValidationAction.__init__` unconditionally:

```python
def __init__(self, data_context=None, **data):
    # data_context is required by ValidationAction in some GE versions
    # but we don't use it directly
    super().__init__(data_context=data_context, **data)
```

On Great Expectations 1.x the base class is a pydantic model that rejects unknown fields and no longer declares `data_context`, so every construction raises:

```
pydantic.v1.error_wrappers.ValidationError: 1 validation error for OpenLineageValidationAction
data_context
  extra fields not permitted (type=value_error.extra)
```

`OpenLineageValidationAction` is the module's only public export and the class users are told to register in their checkpoint config (`website/docs/integrations/great-expectations.md`), so on GE 1.x the integration could not be used at all — while `integration/common/pyproject.toml` pins its own `great_expectations` extra to `>=1.0.0`, i.e. exactly the range where this breaks.

The comment was right that some versions need the argument, so this keeps forwarding it — just only when the base model actually declares it. Versions that require `data_context` behave exactly as before.

### Verification

`great-expectations==1.19.1`, `sqlalchemy==1.4.54`, Python 3.12, `integration/common[dev]`.

The GE suite is excluded from the default run (`addopts = "-p no:warnings --ignore=tests/great_expectations"`, from #3078), so it has to be run explicitly:

```
# before, on this branch's base commit
$ pytest tests/great_expectations/ -o addopts=""
3 failed, 6 passed
  test_dataset_from_sql_source_v3_api
  test_dataset_from_sql_custom_query_v3_api
  test_dataset_from_pandas_source_v3_api        # all three: data_context extra fields not permitted

# after
$ pytest tests/great_expectations/ -o addopts=""
9 passed
```

Whole package, no regressions:

```
$ pytest tests/ -o addopts=""
357 passed, 2 skipped
```

`ruff check` and `ruff format --check` clean at the pinned `v0.12.3`.

**Note on CI:** because of the `--ignore` above, and because `great_expectations` isn't in the tox extras, none of this runs in CI — a green build here does not exercise the change. The numbers above are from a local run and are re-runnable from the diff. I've left the suspension from #3078 alone rather than re-enabling the suite as part of a bug fix; happy to look at that separately if it would be useful.

### Checklist
- [x] AI was used in creating this PR
