### PR TITLE
client/java: support TNS format in Oracle JDBC extractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -6,9 +6,11 @@
 package io.openlineage.client.utils.jdbc;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -33,9 +35,54 @@ public class OracleJdbcExtractor implements JdbcExtractor {
     String uri = rawUri.replaceFirst(URI_START, "").replaceAll(URI_END, "");
 
     if (uri.contains("(")) {
-      throw new URISyntaxException(uri, "TNS format is unsupported for now");
+      return extractTns(uri, properties);
     }
     return extractUri(uri, properties);
+  }
+
+  /**
+   * Handles TNS connect descriptors, e.g. {@code
+   * (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=s)))}.
+   * Pulls out every ADDRESS (host/port) and the CONNECT_DATA identifier, then reuses
+   * OverridingJdbcExtractor for the actual formatting instead of duplicating it here.
+   */
+  private JdbcLocation extractTns(String uri, Properties properties) throws URISyntaxException {
+    TnsDescriptor root = TnsDescriptor.parse(uri);
+
+    List<String> hostPorts = new ArrayList<>();
+    for (TnsDescriptor address : root.findAll("ADDRESS")) {
+      Optional<String> host = address.childValue("HOST");
+      if (!host.isPresent()) {
+        continue;
+      }
+      Optional<String> port = address.childValue("PORT");
+      hostPorts.add(port.map(p -> host.get() + ":" + p).orElseGet(host::get));
+    }
+    if (hostPorts.isEmpty()) {
+      throw new URISyntaxException(uri, "No ADDRESS entries found in TNS descriptor");
+    }
+
+    String identifier =
+        root.findAll("CONNECT_DATA").stream()
+            .findFirst()
+            .flatMap(
+                cd ->
+                    cd.childValue("SERVICE_NAME")
+                        .map(Optional::of)
+                        .orElseGet(
+                            () ->
+                                cd.childValue("SID")
+                                    .map(Optional::of)
+                                    .orElseGet(() -> cd.childValue("INSTANCE_NAME"))))
+            .orElse(null);
+
+    String normalizedUri =
+        SCHEME
+            + "://"
+            + StringUtils.join(hostPorts, ",")
+            + (identifier != null ? "/" + identifier : "");
+
+    return new OverridingJdbcExtractor(SCHEME, DEFAULT_PORT).extract(normalizedUri, properties);
   }
 
   @SuppressWarnings("PMD")

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -55,8 +55,8 @@ public class OracleJdbcExtractor implements JdbcExtractor {
       if (!host.isPresent()) {
         continue;
       }
-      Optional<String> port = address.childValue("PORT");
-      hostPorts.add(port.map(p -> host.get() + ":" + p).orElseGet(host::get));
+      String port = address.childValue("PORT").orElse(DEFAULT_PORT);
+      hostPorts.add(host.get() + ":" + port);
     }
     if (hostPorts.isEmpty()) {
       throw new URISyntaxException(uri, "No ADDRESS entries found in TNS descriptor");

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/TnsDescriptor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/TnsDescriptor.java
@@ -1,0 +1,116 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Minimal parser for Oracle TNS connect descriptors, e.g. {@code
+ * (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=s)))}.
+ *
+ * <p>Only extracts the pieces needed to build a JDBC-style namespace/name: HOST+PORT of every
+ * ADDRESS node (wherever nested, e.g. directly under DESCRIPTION or under an ADDRESS_LIST), and
+ * SERVICE_NAME/SID/INSTANCE_NAME from CONNECT_DATA.
+ */
+final class TnsDescriptor {
+
+  private final String key;
+  private String value;
+  private final List<TnsDescriptor> children = new ArrayList<>();
+
+  private TnsDescriptor(String key) {
+    this.key = key;
+  }
+
+  static TnsDescriptor parse(String s) throws URISyntaxException {
+    int[] pos = {0};
+    skipWs(s, pos);
+    if (pos[0] >= s.length() || s.charAt(pos[0]) != '(') {
+      throw new URISyntaxException(s, "Expected TNS descriptor to start with '('");
+    }
+    TnsDescriptor root = parseNode(s, pos);
+    skipWs(s, pos);
+    if (pos[0] < s.length()) {
+      // Trailing unbalanced/garbage content after the root group - treat the whole
+      // descriptor as malformed rather than silently returning a partial parse.
+      throw new URISyntaxException(s, "Unexpected trailing content after TNS descriptor");
+    }
+    return root;
+  }
+
+  // pos is a single-element mutable cursor passed by reference, not a variable-length
+  // argument list, so varargs would be the wrong fit here.
+  @SuppressWarnings("PMD.UseVarargs")
+  private static TnsDescriptor parseNode(String s, int[] pos) throws URISyntaxException {
+    expect(s, pos, '(');
+    skipWs(s, pos);
+    int keyStart = pos[0];
+    while (pos[0] < s.length() && s.charAt(pos[0]) != '=' && s.charAt(pos[0]) != ')') {
+      pos[0]++;
+    }
+    String key = s.substring(keyStart, pos[0]).trim().toUpperCase(Locale.ROOT);
+    TnsDescriptor node = new TnsDescriptor(key);
+
+    if (pos[0] < s.length() && s.charAt(pos[0]) == '=') {
+      pos[0]++; // consume '='
+      skipWs(s, pos);
+      if (pos[0] < s.length() && s.charAt(pos[0]) == '(') {
+        while (pos[0] < s.length() && s.charAt(pos[0]) == '(') {
+          node.children.add(parseNode(s, pos));
+          skipWs(s, pos);
+        }
+      } else {
+        int valStart = pos[0];
+        while (pos[0] < s.length() && s.charAt(pos[0]) != ')') {
+          pos[0]++;
+        }
+        node.value = s.substring(valStart, pos[0]).trim();
+      }
+    }
+    skipWs(s, pos);
+    expect(s, pos, ')');
+    return node;
+  }
+
+  private static void expect(String s, int[] pos, char c) throws URISyntaxException {
+    if (pos[0] >= s.length() || s.charAt(pos[0]) != c) {
+      throw new URISyntaxException(s, "Expected '" + c + "' at position " + pos[0]);
+    }
+    pos[0]++;
+  }
+
+  @SuppressWarnings("PMD.UseVarargs")
+  private static void skipWs(String s, int[] pos) {
+    while (pos[0] < s.length() && Character.isWhitespace(s.charAt(pos[0]))) {
+      pos[0]++;
+    }
+  }
+
+  /** Recursively collects every descendant (including self) with the given key. */
+  List<TnsDescriptor> findAll(String wantedKey) {
+    List<TnsDescriptor> result = new ArrayList<>();
+    if (this.key.equals(wantedKey)) {
+      result.add(this);
+    }
+    for (TnsDescriptor child : children) {
+      result.addAll(child.findAll(wantedKey));
+    }
+    return result;
+  }
+
+  /** Direct-child lookup, case-insensitive on already-uppercased keys. */
+  Optional<String> childValue(String wantedKey) {
+    return children.stream()
+        .filter(c -> c.key.equals(wantedKey))
+        .map(c -> c.value)
+        .filter(v -> v != null)
+        .findFirst();
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -195,7 +195,50 @@ class JdbcDatasetUtilsTestForOracle {
 
   @Test
   void testGetDatasetIdentifierWithTnsFormat() {
-    // Currently TNS format is not parsed properly. Just drop credentials
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
+        .hasFieldOrPropertyWithValue("name", "ORCL.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:oci@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
+        .hasFieldOrPropertyWithValue("name", "ORCL.schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithTnsFormatLowercaseAndServiceName() {
+    // Matches the exact connection string reported in
+    // https://github.com/OpenLineage/OpenLineage/issues/4122
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=hostname))(connect_data=(service_name=servicename)))",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
+        .hasFieldOrPropertyWithValue("name", "servicename.schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithTnsFormatMissingPortOnSomeAddresses() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=host1))(ADDRESS=(PROTOCOL=tcp)(HOST=host2)(PORT=1522)))(CONNECT_DATA=(SID=orcl)))",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://host1:1521,host2:1522")
+        .hasFieldOrPropertyWithValue("name", "orcl.schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithMalformedTnsFormat() {
+    // Falls back to sanitize-and-passthrough behavior, same as other unparseable URLs.
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))",
@@ -204,16 +247,6 @@ class JdbcDatasetUtilsTestForOracle {
         .hasFieldOrPropertyWithValue(
             "namespace",
             "oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))")
-        .hasFieldOrPropertyWithValue("name", "schema.table1");
-
-    assertThat(
-            JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:oci@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))",
-                "schema.table1",
-                new Properties()))
-        .hasFieldOrPropertyWithValue(
-            "namespace",
-            "oracle:oci@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -225,9 +258,8 @@ class JdbcDatasetUtilsTestForOracle {
                 "schema.table1",
                 new Properties()))
         .hasFieldOrPropertyWithValue(
-            "namespace",
-            "oracle:thin:@(DESCRIPTION= (ADDRESS_LIST= (LOAD_BALANCE=ON) (ADDRESS=(PROTOCOL=tcp)(HOST=salesserver1)(PORT=1521)) (ADDRESS=(PROTOCOL=tcp)(HOST=salesserver2)(PORT=1522))(ADDRESS=(PROTOCOL=tcp)(HOST=salesserver3)(PORT=1522)))(CONNECT_DATA=(SERVICE_NAME=sales.us.example.com)))")
-        .hasFieldOrPropertyWithValue("name", "schema.table1");
+            "namespace", "oracle://salesserver1:1521,salesserver2:1522,salesserver3:1522")
+        .hasFieldOrPropertyWithValue("name", "sales.us.example.com.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
@@ -235,9 +267,8 @@ class JdbcDatasetUtilsTestForOracle {
                 "schema.table1",
                 new Properties()))
         .hasFieldOrPropertyWithValue(
-            "namespace",
-            "oracle:oci@(DESCRIPTION= (ADDRESS_LIST= (LOAD_BALANCE=ON) (ADDRESS=(PROTOCOL=tcp)(HOST=salesserver1)(PORT=1521)) (ADDRESS=(PROTOCOL=tcp)(HOST=salesserver2)(PORT=1522))(ADDRESS=(PROTOCOL=tcp)(HOST=salesserver3)(PORT=1522)))(CONNECT_DATA=(SERVICE_NAME=sales.us.example.com)))")
-        .hasFieldOrPropertyWithValue("name", "schema.table1");
+            "namespace", "oracle://salesserver1:1521,salesserver2:1522,salesserver3:1522")
+        .hasFieldOrPropertyWithValue("name", "sales.us.example.com.schema.table1");
   }
 
   @Test


### PR DESCRIPTION
closes: #4122
closes: #1759

### One-line summary for changelog:
Oracle TNS connect descriptors (used for RAC/failover connections) now resolve to a proper `oracle://host:port` namespace instead of falling back to the raw URL.

### Meaningful description
`OracleJdbcExtractor` threw whenever a JDBC URL contained a TNS connect descriptor, e.g. `(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=s)))`. That exception was caught upstream in `JdbcDatasetUtils`, so any TNS-format connection silently fell back to using the sanitized raw URL as the dataset namespace, instead of a proper `oracle://` one — reported in #4122 with a real-world Oracle ADW connection string, and #1759 covers the same root cause.

This adds a small parser (`TnsDescriptor`) that walks the descriptor and:
- collects every `ADDRESS` entry (host/port), whether it's a bare `ADDRESS` directly under `DESCRIPTION` or multiple `ADDRESS` entries nested under an `ADDRESS_LIST` (failover/load-balanced connections)
- pulls the database identifier from `CONNECT_DATA`, preferring `SERVICE_NAME`, then `SID`, then `INSTANCE_NAME`

The parsed result is reassembled into the same `scheme://host1:port1,host2:port2/identifier` form the existing non-TNS path already produces, and handed to `OverridingJdbcExtractor`, so default-port and multi-host handling isn't duplicated.

Malformed/unbalanced descriptors (the parser now validates there's no unconsumed trailing content) fail parsing explicitly and fall back to the existing sanitize-and-passthrough behavior, rather than silently returning a partial result.

Two previously-existing tests documented the old "TNS unsupported" fallback behavior; I updated them to assert the real parsed output instead, added a test for the malformed-input fallback path, and added a couple more covering lowercase keys / mixed ports / SID.

### Checklist
- [x] AI was used in creating this PR