### PR TITLE
spark: fix Databricks CTAS output and DML input lineage

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -20,6 +20,8 @@ import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
@@ -35,6 +37,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.column.JdbcColumnLineageVisitor;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.column.MergeIntoDelta11ColumnLineageVisitor;
@@ -65,6 +68,8 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2ScanRelationOnEndInputDatasetBuilder(context, datasetFactory))
             .add(new SubqueryAliasInputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
+            .add(new TableContentChangeInputDatasetBuilder(context))
             .add(new ViewInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
@@ -87,6 +92,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -28,6 +28,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnSta
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnEndInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnStartInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DeleteUpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeInputDatasetBuilder;
@@ -93,6 +94,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))
+            .add(new DeleteUpdateCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -12,6 +12,7 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetBuilder;
@@ -42,6 +43,7 @@ public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -14,6 +14,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DeleteUpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1InputDatasetBuilder;
@@ -44,6 +45,7 @@ public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))
+            .add(new DeleteUpdateCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -17,6 +17,8 @@ import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
@@ -33,6 +35,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeInputDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
@@ -65,6 +68,8 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new SubqueryAliasInputDatasetBuilder(context))
             .add(new CreateReplaceInputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
+            .add(new TableContentChangeInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new ViewInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
@@ -88,6 +93,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new DropTableDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -24,6 +24,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnSta
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnEndInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnStartInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DeleteUpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeInputDatasetBuilder;
@@ -94,6 +95,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))
+            .add(new DeleteUpdateCommandOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new DropTableDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -16,6 +16,8 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
@@ -32,6 +34,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeInputDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
@@ -64,6 +67,8 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new CreateReplaceInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
+            .add(new TableContentChangeInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
 
@@ -85,6 +90,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -23,6 +23,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnSta
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnEndInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnStartInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DeleteUpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeInputDatasetBuilder;
@@ -91,6 +92,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))
+            .add(new DeleteUpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -25,6 +25,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnSta
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnEndInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnStartInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DeleteUpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeInputDatasetBuilder;
@@ -84,6 +85,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))
+            .add(new DeleteUpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -17,6 +17,8 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
@@ -32,6 +34,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.column.JdbcColumnLineageVisitor;
 import io.openlineage.spark31.agent.lifecycle.plan.AlterTableDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.column.MergeIntoDelta11ColumnLineageVisitor;
@@ -58,6 +61,8 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
+            .add(new TableContentChangeInputDatasetBuilder(context))
             .add(new SubqueryAliasInputDatasetBuilder(context));
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {
@@ -78,6 +83,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -17,6 +17,8 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
@@ -33,6 +35,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeInputDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
@@ -67,6 +70,8 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new CreateReplaceInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
+            .add(new TableContentChangeInputDatasetBuilder(context))
             .add(new StreamingDataSourceV2ScanRelationDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
@@ -89,6 +94,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -24,6 +24,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnSta
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnEndInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnStartInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DeleteUpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeInputDatasetBuilder;
@@ -95,6 +96,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))
+            .add(new DeleteUpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitorTest.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.execution.command.LoadDataCommand;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+class LoadDataCommandInputVisitorTest {
+
+  @Test
+  void testLoadDataCommandSourcePathIsAnInput() {
+    SparkSession session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+    String database = session.catalog().currentDatabase();
+
+    LoadDataCommandInputVisitor visitor =
+        new LoadDataCommandInputVisitor(SparkAgentTestExtension.newContext(session));
+
+    LoadDataCommand command =
+        new LoadDataCommand(
+            TableIdentifier$.MODULE$.apply("table", Option.apply(database)),
+            "/path/to/data",
+            true,
+            false,
+            Option.empty());
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+
+    List<OpenLineage.InputDataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/path/to/data")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -29,6 +29,7 @@ import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveDirVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveTableVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.KafkaRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.KustoRelationVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandInputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
@@ -78,6 +79,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     }
 
     inputVisitors.add(new ExternalRDDVisitor(context));
+    inputVisitors.add(new LoadDataCommandInputVisitor(context));
     return inputVisitors;
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitor.java
@@ -41,7 +41,7 @@ public class LoadDataCommandInputVisitor
       return Collections.singletonList(
           inputDataset().sparkDatasetBuilder().dataset(PathUtils.fromPath(new Path(path))).build());
     } catch (Exception e) {
-      // A LOAD DATA path may be a glob or an otherwise unparseable location
+      // A LOAD DATA path may be a glob or an otherwise unparsable location
       log.warn("Could not build an input dataset from LOAD DATA path {}", path, e);
       return Collections.emptyList();
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitor.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.LoadDataCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches a {@link LoadDataCommand} and extracts the source
+ * location being read as an input {@link OpenLineage.Dataset}. The target table is emitted as the
+ * output by {@link LoadDataCommandVisitor}.
+ */
+@Slf4j
+public class LoadDataCommandInputVisitor
+    extends QueryPlanVisitor<LoadDataCommand, OpenLineage.InputDataset> {
+
+  public LoadDataCommandInputVisitor(OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<OpenLineage.InputDataset> apply(LogicalPlan x) {
+    String path = ((LoadDataCommand) x).path();
+    if (StringUtils.isBlank(path)) {
+      return Collections.emptyList();
+    }
+
+    try {
+      return Collections.singletonList(
+          inputDataset().sparkDatasetBuilder().dataset(PathUtils.fromPath(new Path(path))).build());
+    } catch (Exception e) {
+      // A LOAD DATA path may be a glob or an otherwise unparseable location
+      log.warn("Could not build an input dataset from LOAD DATA path {}", path, e);
+      return Collections.emptyList();
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
@@ -8,6 +8,7 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Collections;
@@ -19,9 +20,10 @@ import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 
 /**
- * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand}. The source is
- * typically a file path (e.g., S3, ADLS, DBFS). Since the class belongs to the Databricks runtime,
- * reflection is used to access source-related methods.
+ * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
+ * CopyIntoCommandEdge}. The source is typically a file path (e.g., S3, ADLS, DBFS, Unity Catalog
+ * Volumes). Since these classes belong to the Databricks runtime, reflection is used to access
+ * source-related methods.
  */
 @Slf4j
 public class CopyIntoCommandInputDatasetBuilder
@@ -33,9 +35,7 @@ public class CopyIntoCommandInputDatasetBuilder
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return x.getClass()
-        .getCanonicalName()
-        .endsWith("sql.transaction.tahoe.commands.CopyIntoCommand");
+    return CopyIntoCommandUtils.isCopyIntoCommand(x);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
@@ -10,6 +10,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import io.openlineage.spark3.agent.utils.CopyIntoSqlUtils;
 import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -21,23 +22,36 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
  * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
  * CopyIntoCommandEdge}. The source is typically a file path (e.g., S3, ADLS, DBFS, Unity Catalog
  * Volumes). Since these classes belong to the Databricks runtime, reflection is used to access
- * source-related members.
+ * source-related members, with SQL parsing as a fallback.
  */
 @Slf4j
 public class CopyIntoCommandInputDatasetBuilder
     extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
 
   public CopyIntoCommandInputDatasetBuilder(OpenLineageContext context) {
-    super(context, false);
+    super(context, true);
   }
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return CopyIntoCommandUtils.isCopyIntoCommand(x);
+    return CopyIntoCommandUtils.isCopyIntoCommand(x) || isOptimizedRootWithCopyIntoSql(x);
   }
 
   @Override
   protected List<InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (CopyIntoCommandUtils.isCopyIntoCommand(x)) {
+      List<InputDataset> datasets = datasetsFromCommand(event, x);
+      if (!datasets.isEmpty()) {
+        return datasets;
+      }
+      log.warn(
+          "Matched COPY INTO command {} but extracted no input datasets",
+          x.getClass().getCanonicalName());
+    }
+    return datasetsFromSql();
+  }
+
+  private List<InputDataset> datasetsFromCommand(SparkListenerEvent event, LogicalPlan x) {
     return CopyIntoCommandUtils.sourcePath(x)
         .flatMap(this::inputDatasetFromPath)
         .map(Collections::singletonList)
@@ -48,10 +62,28 @@ public class CopyIntoCommandInputDatasetBuilder
                     .orElse(Collections.emptyList()));
   }
 
+  private List<InputDataset> datasetsFromSql() {
+    return CopyIntoCommandUtils.sqlText(context)
+        .flatMap(CopyIntoSqlUtils::sourcePath)
+        .flatMap(this::inputDatasetFromPath)
+        .map(Collections::singletonList)
+        .orElse(Collections.emptyList());
+  }
+
+  private boolean isOptimizedRootWithCopyIntoSql(LogicalPlan x) {
+    return context.getQueryExecution().map(qe -> qe.optimizedPlan() == x).orElse(false)
+        && CopyIntoCommandUtils.sqlText(context)
+            .filter(CopyIntoSqlUtils::isCopyIntoStatement)
+            .isPresent();
+  }
+
   private java.util.Optional<InputDataset> inputDatasetFromPath(String sourcePath) {
     try {
       return java.util.Optional.of(
-          inputDataset().sparkDatasetBuilder().dataset(PathUtils.fromPath(new Path(sourcePath))).build());
+          inputDataset()
+              .sparkDatasetBuilder()
+              .dataset(PathUtils.fromPath(new Path(sourcePath)))
+              .build());
     } catch (Exception e) {
       log.warn("Failed to construct input dataset from COPY INTO source path: {}", sourcePath, e);
       return java.util.Optional.empty();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
@@ -1,0 +1,98 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand}. The source is
+ * typically a file path (e.g., S3, ADLS, DBFS). Since the class belongs to the Databricks runtime,
+ * reflection is used to access source-related methods.
+ */
+@Slf4j
+public class CopyIntoCommandInputDatasetBuilder
+    extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
+
+  public CopyIntoCommandInputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return x.getClass()
+        .getCanonicalName()
+        .endsWith("sql.transaction.tahoe.commands.CopyIntoCommand");
+  }
+
+  @Override
+  protected List<InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    String sourcePath = extractSourcePath(x);
+    if (sourcePath != null && !sourcePath.isEmpty()) {
+      try {
+        return Collections.singletonList(
+            inputDataset().sparkDatasetBuilder().dataset(URI.create(sourcePath)).build());
+      } catch (Exception e) {
+        log.warn("Failed to construct input dataset from COPY INTO source path: {}", sourcePath, e);
+      }
+    }
+
+    LogicalPlan query = extractQuery(x);
+    if (query != null) {
+      return delegate(query, event);
+    }
+
+    return Collections.emptyList();
+  }
+
+  @SuppressWarnings("unchecked")
+  private String extractSourcePath(LogicalPlan x) {
+    try {
+      Object options = MethodUtils.invokeExactMethod(x, "sourceOptions", new Object[] {});
+      if (options instanceof Map) {
+        Object path = ((Map<String, String>) options).get("path");
+        if (path instanceof String) {
+          return (String) path;
+        }
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Cannot extract sourceOptions from Databricks CopyIntoCommand", e);
+    }
+
+    try {
+      Object result = MethodUtils.invokeExactMethod(x, "sourcePath", new Object[] {});
+      if (result instanceof String) {
+        return (String) result;
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Cannot extract sourcePath from Databricks CopyIntoCommand", e);
+    }
+
+    return null;
+  }
+
+  private LogicalPlan extractQuery(LogicalPlan x) {
+    try {
+      Object result = MethodUtils.invokeExactMethod(x, "query", new Object[] {});
+      if (result instanceof LogicalPlan) {
+        return (LogicalPlan) result;
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Cannot extract query from Databricks CopyIntoCommand", e);
+    }
+    return null;
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
@@ -6,16 +6,14 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 
@@ -23,7 +21,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
  * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
  * CopyIntoCommandEdge}. The source is typically a file path (e.g., S3, ADLS, DBFS, Unity Catalog
  * Volumes). Since these classes belong to the Databricks runtime, reflection is used to access
- * source-related methods.
+ * source-related members.
  */
 @Slf4j
 public class CopyIntoCommandInputDatasetBuilder
@@ -40,59 +38,23 @@ public class CopyIntoCommandInputDatasetBuilder
 
   @Override
   protected List<InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
-    String sourcePath = extractSourcePath(x);
-    if (sourcePath != null && !sourcePath.isEmpty()) {
-      try {
-        return Collections.singletonList(
-            inputDataset().sparkDatasetBuilder().dataset(URI.create(sourcePath)).build());
-      } catch (Exception e) {
-        log.warn("Failed to construct input dataset from COPY INTO source path: {}", sourcePath, e);
-      }
-    }
-
-    LogicalPlan query = extractQuery(x);
-    if (query != null) {
-      return delegate(query, event);
-    }
-
-    return Collections.emptyList();
+    return CopyIntoCommandUtils.sourcePath(x)
+        .flatMap(this::inputDatasetFromPath)
+        .map(Collections::singletonList)
+        .orElseGet(
+            () ->
+                CopyIntoCommandUtils.sourceQuery(x)
+                    .map(query -> delegate(query, event))
+                    .orElse(Collections.emptyList()));
   }
 
-  @SuppressWarnings("unchecked")
-  private String extractSourcePath(LogicalPlan x) {
+  private java.util.Optional<InputDataset> inputDatasetFromPath(String sourcePath) {
     try {
-      Object options = MethodUtils.invokeExactMethod(x, "sourceOptions", new Object[] {});
-      if (options instanceof Map) {
-        Object path = ((Map<String, String>) options).get("path");
-        if (path instanceof String) {
-          return (String) path;
-        }
-      }
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      log.debug("Cannot extract sourceOptions from Databricks CopyIntoCommand", e);
+      return java.util.Optional.of(
+          inputDataset().sparkDatasetBuilder().dataset(PathUtils.fromPath(new Path(sourcePath))).build());
+    } catch (Exception e) {
+      log.warn("Failed to construct input dataset from COPY INTO source path: {}", sourcePath, e);
+      return java.util.Optional.empty();
     }
-
-    try {
-      Object result = MethodUtils.invokeExactMethod(x, "sourcePath", new Object[] {});
-      if (result instanceof String) {
-        return (String) result;
-      }
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      log.debug("Cannot extract sourcePath from Databricks CopyIntoCommand", e);
-    }
-
-    return null;
-  }
-
-  private LogicalPlan extractQuery(LogicalPlan x) {
-    try {
-      Object result = MethodUtils.invokeExactMethod(x, "query", new Object[] {});
-      if (result instanceof LogicalPlan) {
-        return (LogicalPlan) result;
-      }
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      log.debug("Cannot extract query from Databricks CopyIntoCommand", e);
-    }
-    return null;
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -8,6 +8,7 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
@@ -19,9 +20,9 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 
 /**
- * Extracts output datasets from the Databricks-specific {@code CopyIntoCommand}. Since the class
- * belongs to the Databricks runtime and is not available at compile time, reflection is used to
- * access its {@code target()} method.
+ * Extracts output datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
+ * CopyIntoCommandEdge}. Since these classes belong to the Databricks runtime and are not available
+ * at compile time, reflection is used to access their {@code target()} method.
  */
 @Slf4j
 public class CopyIntoCommandOutputDatasetBuilder
@@ -33,9 +34,7 @@ public class CopyIntoCommandOutputDatasetBuilder
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return x.getClass()
-        .getCanonicalName()
-        .endsWith("sql.transaction.tahoe.commands.CopyIntoCommand");
+    return CopyIntoCommandUtils.isCopyIntoCommand(x);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -9,20 +9,17 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
-import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 
 /**
  * Extracts output datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
  * CopyIntoCommandEdge}. Since these classes belong to the Databricks runtime and are not available
- * at compile time, reflection is used to access their {@code target()} method.
+ * at compile time, reflection is used to access their target relation.
  */
 @Slf4j
 public class CopyIntoCommandOutputDatasetBuilder
@@ -39,45 +36,22 @@ public class CopyIntoCommandOutputDatasetBuilder
 
   @Override
   protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
-    LogicalPlan target = extractTarget(x);
-    if (target == null) {
-      return Collections.emptyList();
-    }
-
-    if (target instanceof SubqueryAlias) {
-      return delegate(((SubqueryAlias) target).child(), event);
-    }
-    return delegate(target, event);
+    return CopyIntoCommandUtils.target(x)
+        .map(target -> delegate(target, event))
+        .orElse(Collections.emptyList());
   }
 
   @Override
   public Optional<String> jobNameSuffix(LogicalPlan plan) {
-    LogicalPlan target = extractTarget(plan);
-    if (target == null) {
-      return Optional.empty();
-    }
-    if (target instanceof SubqueryAlias) {
-      target = ((SubqueryAlias) target).child();
-    }
-    LogicalPlan finalTarget = target;
-    return context.getOutputDatasetBuilders().stream()
-        .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
-        .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
-        .map(b -> b.jobNameSuffixFromLogicalPlan(finalTarget))
-        .filter(Optional::isPresent)
-        .map(o -> (String) o.get())
-        .findFirst();
-  }
-
-  private LogicalPlan extractTarget(LogicalPlan x) {
-    try {
-      Object result = MethodUtils.invokeExactMethod(x, "target", new Object[] {});
-      if (result instanceof LogicalPlan) {
-        return (LogicalPlan) result;
-      }
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      log.error("Cannot extract target from Databricks CopyIntoCommand", e);
-    }
-    return null;
+    return CopyIntoCommandUtils.target(plan)
+        .flatMap(
+            target ->
+                context.getOutputDatasetBuilders().stream()
+                    .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
+                    .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
+                    .map(b -> b.jobNameSuffixFromLogicalPlan(target))
+                    .filter(Optional::isPresent)
+                    .map(o -> (String) o.get())
+                    .findFirst());
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -1,0 +1,84 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+
+/**
+ * Extracts output datasets from the Databricks-specific {@code CopyIntoCommand}. Since the class
+ * belongs to the Databricks runtime and is not available at compile time, reflection is used to
+ * access its {@code target()} method.
+ */
+@Slf4j
+public class CopyIntoCommandOutputDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public CopyIntoCommandOutputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return x.getClass()
+        .getCanonicalName()
+        .endsWith("sql.transaction.tahoe.commands.CopyIntoCommand");
+  }
+
+  @Override
+  protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    LogicalPlan target = extractTarget(x);
+    if (target == null) {
+      return Collections.emptyList();
+    }
+
+    if (target instanceof SubqueryAlias) {
+      return delegate(((SubqueryAlias) target).child(), event);
+    }
+    return delegate(target, event);
+  }
+
+  @Override
+  public Optional<String> jobNameSuffix(LogicalPlan plan) {
+    LogicalPlan target = extractTarget(plan);
+    if (target == null) {
+      return Optional.empty();
+    }
+    if (target instanceof SubqueryAlias) {
+      target = ((SubqueryAlias) target).child();
+    }
+    LogicalPlan finalTarget = target;
+    return context.getOutputDatasetBuilders().stream()
+        .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
+        .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
+        .map(b -> b.jobNameSuffixFromLogicalPlan(finalTarget))
+        .filter(Optional::isPresent)
+        .map(o -> (String) o.get())
+        .findFirst();
+  }
+
+  private LogicalPlan extractTarget(LogicalPlan x) {
+    try {
+      Object result = MethodUtils.invokeExactMethod(x, "target", new Object[] {});
+      if (result instanceof LogicalPlan) {
+        return (LogicalPlan) result;
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.error("Cannot extract target from Databricks CopyIntoCommand", e);
+    }
+    return null;
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -6,52 +6,271 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import io.openlineage.spark3.agent.utils.CopyIntoSqlUtils;
+import io.openlineage.spark3.agent.utils.UnityCatalogTableDatasetUtils;
+import io.openlineage.spark3.agent.utils.UnityCatalogTableDatasetUtils.ResolvedTableDataset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import scala.Option;
 
 /**
  * Extracts output datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
  * CopyIntoCommandEdge}. Since these classes belong to the Databricks runtime and are not available
- * at compile time, reflection is used to access their target relation.
+ * at compile time, reflection is used to access their target relation, with SQL parsing as a
+ * fallback.
  */
 @Slf4j
 public class CopyIntoCommandOutputDatasetBuilder
     extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
 
+  private static final int CATALOG_SCHEMA_TABLE_PARTS = 3;
+  private static final int SCHEMA_TABLE_PARTS = 2;
+
   public CopyIntoCommandOutputDatasetBuilder(OpenLineageContext context) {
-    super(context, false);
+    super(context, true);
   }
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return CopyIntoCommandUtils.isCopyIntoCommand(x);
+    return CopyIntoCommandUtils.isCopyIntoCommand(x) || isOptimizedRootWithCopyIntoSql(x);
   }
 
   @Override
   protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
-    return CopyIntoCommandUtils.target(x)
-        .map(target -> delegate(target, event))
-        .orElse(Collections.emptyList());
+    if (CopyIntoCommandUtils.isCopyIntoCommand(x)) {
+      List<OutputDataset> datasets = datasetsFromCommand(event, x);
+      if (!datasets.isEmpty()) {
+        return datasets;
+      }
+      log.warn(
+          "Matched COPY INTO command {} but extracted no output datasets",
+          x.getClass().getCanonicalName());
+    } else if (isOptimizedRootWithCopyIntoSql(x)) {
+      for (LogicalPlan command : CopyIntoCommandUtils.findAllCommands(context)) {
+        List<OutputDataset> datasets = datasetsFromCommand(event, command);
+        if (!datasets.isEmpty()) {
+          return datasets;
+        }
+      }
+    } else {
+      return Collections.emptyList();
+    }
+    return datasetsFromSql(event);
   }
 
   @Override
   public Optional<String> jobNameSuffix(LogicalPlan plan) {
-    return CopyIntoCommandUtils.target(plan)
-        .flatMap(
-            target ->
-                context.getOutputDatasetBuilders().stream()
-                    .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
-                    .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
-                    .map(b -> b.jobNameSuffixFromLogicalPlan(target))
-                    .filter(Optional::isPresent)
-                    .map(o -> (String) o.get())
-                    .findFirst());
+    Optional<String> suffix =
+        CopyIntoCommandUtils.target(plan)
+            .flatMap(
+                target ->
+                    context.getOutputDatasetBuilders().stream()
+                        .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
+                        .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
+                        .map(b -> b.jobNameSuffixFromLogicalPlan(target))
+                        .filter(Optional::isPresent)
+                        .map(o -> (String) o.get())
+                        .findFirst());
+    if (suffix.isPresent()) {
+      return suffix;
+    }
+    if (isOptimizedRootWithCopyIntoSql(plan)) {
+      return CopyIntoCommandUtils.sqlText(context)
+          .flatMap(CopyIntoSqlUtils::targetTable)
+          .map(table -> table.replace(".", "_"));
+    }
+    return Optional.empty();
+  }
+
+  private List<OutputDataset> datasetsFromCommand(SparkListenerEvent event, LogicalPlan command) {
+    List<OutputDataset> fromTarget =
+        CopyIntoCommandUtils.target(command)
+            .map(target -> delegate(target, event))
+            .orElse(Collections.emptyList());
+    if (!fromTarget.isEmpty()) {
+      return fromTarget;
+    }
+    List<OutputDataset> fromRelation =
+        CopyIntoCommandUtils.findTableRelation(command)
+            .map(relation -> delegate(relation, event))
+            .orElse(Collections.emptyList());
+    if (fromRelation.isEmpty()) {
+      log.warn(
+          "COPY INTO: no output dataset from command members or plan tree. {}",
+          CopyIntoCommandUtils.describeMembers(command));
+    }
+    return fromRelation;
+  }
+
+  private List<OutputDataset> datasetsFromSql(SparkListenerEvent event) {
+    return CopyIntoCommandUtils.sqlText(context)
+        .flatMap(CopyIntoSqlUtils::targetTable)
+        .map(tableName -> outputDatasetsFromTableName(tableName, event))
+        .orElse(Collections.emptyList());
+  }
+
+  /**
+   * Resolves the COPY INTO target from parsed SQL text. Does not call {@code session.table()}: on
+   * Databricks that re-analyzes the table in the SparkListener thread and fails with {@code
+   * MissingCredentialScopeException}.
+   */
+  private List<OutputDataset> outputDatasetsFromTableName(
+      String tableName, SparkListenerEvent event) {
+    return sparkSession()
+        .map(
+            session -> {
+              TableIdentifier identifier =
+                  parseTableIdentifier(tableName.replace("`", "").trim(), session);
+              try {
+                return outputDatasetFromTableName(tableName, event, session, identifier)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+              } catch (Exception e) {
+                log.warn(
+                    "COPY INTO: catalog resolution failed for target {}, falling back to name-only identity",
+                    identifier,
+                    e);
+                return outputDatasetFromTableNameFallback(tableName, session, identifier)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+              }
+            })
+        .orElse(Collections.emptyList());
+  }
+
+  private boolean isOptimizedRootWithCopyIntoSql(LogicalPlan x) {
+    return context.getQueryExecution().map(qe -> qe.optimizedPlan() == x).orElse(false)
+        && CopyIntoCommandUtils.sqlText(context)
+            .filter(CopyIntoSqlUtils::isCopyIntoStatement)
+            .isPresent();
+  }
+
+  private Optional<OutputDataset> outputDatasetFromTableName(
+      String tableName,
+      SparkListenerEvent event,
+      SparkSession session,
+      TableIdentifier identifier) {
+    Optional<OutputDataset> fromV2Catalog =
+        UnityCatalogTableDatasetUtils.resolve(context, session, identifier)
+            .map(resolved -> buildOutputDataset(resolved, event));
+    if (fromV2Catalog.isPresent()) {
+      return fromV2Catalog;
+    }
+
+    try {
+      CatalogTable catalogTable = session.sessionState().catalog().getTableMetadata(identifier);
+      return Optional.of(outputDataset().sparkDatasetBuilder().dataset(catalogTable).build());
+    } catch (Exception e) {
+      log.debug(
+          "Legacy catalog lookup failed for COPY INTO target {}, trying name-only fallback",
+          tableName,
+          e);
+    }
+
+    return outputDatasetFromTableNameFallback(tableName, session, identifier);
+  }
+
+  private Optional<OutputDataset> outputDatasetFromTableNameFallback(
+      String tableName, SparkSession session, TableIdentifier identifier) {
+    if (DatabricksUtils.isDatabricksUnityCatalogEnabled(session.sparkContext().getConf())) {
+      return Optional.of(
+          outputDataset()
+              .sparkDatasetBuilder()
+              .dataset(
+                  DatabricksUtils.qualifiedUnityCatalogTableName(identifier),
+                  DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE)
+              .build());
+    }
+    log.warn("Unable to resolve COPY INTO target table {}", tableName);
+    return Optional.empty();
+  }
+
+  private Optional<SparkSession> sparkSession() {
+    return context.getSparkSession().or(SparkSessionUtils::activeSession);
+  }
+
+  private OutputDataset buildOutputDataset(
+      ResolvedTableDataset resolved, SparkListenerEvent event) {
+    SparkDatasetBuilder<OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(resolved.getDatasetIdentifier())
+            .schema(resolved.getSchema());
+    try {
+      if (includeDatasetVersion(event)) {
+        CatalogUtils.getDatasetVersion(
+                context, resolved.getCatalog(), resolved.getIdentifier(), resolved.getProperties())
+            .ifPresent(sparkBuilder::version);
+      }
+      CatalogUtils.addStorageAndCatalogFacets(
+          context, resolved.getCatalog(), resolved.getProperties(), sparkBuilder.getInner());
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn(
+          "Could not add catalog facets for COPY INTO target {}",
+          resolved.getDatasetIdentifier().getName(),
+          e);
+    }
+    return sparkBuilder.build();
+  }
+
+  private TableIdentifier parseTableIdentifier(String normalized, SparkSession session) {
+    String[] parts = normalized.split("\\.");
+    String defaultDatabase = session.catalog().currentDatabase();
+    Optional<String> defaultCatalog = currentCatalog(session);
+
+    if (parts.length == CATALOG_SCHEMA_TABLE_PARTS) {
+      return tableIdentifier(parts[2], parts[1], Optional.of(parts[0]));
+    }
+    if (parts.length == SCHEMA_TABLE_PARTS) {
+      return tableIdentifier(parts[1], parts[0], defaultCatalog);
+    }
+    return tableIdentifier(parts[0], defaultDatabase, defaultCatalog);
+  }
+
+  private TableIdentifier tableIdentifier(String table, String database, Optional<String> catalog) {
+    if (catalog.filter(StringUtils::isNotBlank).isPresent()) {
+      try {
+        return (TableIdentifier)
+            MethodUtils.invokeMethod(
+                TableIdentifier$.MODULE$,
+                "apply",
+                table,
+                Option.apply(database),
+                Option.apply(catalog.get()));
+      } catch (Exception e) {
+        log.debug(
+            "Could not build TableIdentifier with catalog {}, falling back to schema only",
+            catalog.get(),
+            e);
+      }
+    }
+    return TableIdentifier$.MODULE$.apply(table, Option.apply(database));
+  }
+
+  private Optional<String> currentCatalog(SparkSession session) {
+    try {
+      return Optional.ofNullable(
+              (String) MethodUtils.invokeMethod(session.catalog(), "currentCatalog"))
+          .filter(StringUtils::isNotBlank);
+    } catch (Exception e) {
+      return Optional.empty();
+    }
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DeleteUpdateCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DeleteUpdateCommandOutputDatasetBuilder.java
@@ -1,0 +1,62 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DeleteUpdateCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Extracts the modified table of a Databricks {@code DELETE FROM} or {@code UPDATE} as an output
+ * dataset.
+ *
+ * <p>{@link TableContentChangeDatasetBuilder} covers the catalyst {@code DeleteFromTable} / {@code
+ * UpdateTable} nodes, which Databricks never produces - the runtime resolves the statement to a
+ * Delta command instead. Without this builder those statements emit an event with no datasets at
+ * all: nothing matches the plan, so the target is missing from {@code outputs} and the job name
+ * carries no table suffix either.
+ */
+@Slf4j
+public class DeleteUpdateCommandOutputDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public DeleteUpdateCommandOutputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return DeleteUpdateCommandUtils.isDeleteOrUpdateCommand(x);
+  }
+
+  @Override
+  protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    return DeleteUpdateCommandUtils.target(x)
+        .map(target -> delegate(target, event))
+        .orElse(Collections.emptyList());
+  }
+
+  @Override
+  public Optional<String> jobNameSuffix(LogicalPlan plan) {
+    return DeleteUpdateCommandUtils.target(plan)
+        .flatMap(
+            target ->
+                context.getOutputDatasetBuilders().stream()
+                    .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
+                    .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
+                    .map(b -> b.jobNameSuffixFromLogicalPlan(target))
+                    .filter(Optional::isPresent)
+                    .map(o -> (String) o.get())
+                    .findFirst());
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeInputDatasetBuilder.java
@@ -9,6 +9,7 @@ import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DeleteUpdateCommandUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.spark.scheduler.SparkListenerEvent;
@@ -17,8 +18,8 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
 
 /**
- * Extracts input datasets from the subqueries of a {@link DeleteFromTable} or an {@link
- * UpdateTable}.
+ * Extracts input datasets from the subqueries of a {@link DeleteFromTable}, an {@link UpdateTable}
+ * or of the Databricks Delta command the same statement is resolved to.
  *
  * <p>Tables referenced from a WHERE clause or from an UPDATE assignment live inside expressions,
  * not inside the children of the plan node:
@@ -30,7 +31,9 @@ import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
  *                +- plan: the subquery reading another table
  * </pre>
  *
- * The regular traversal only walks children, so those tables were missing from the event.
+ * The regular traversal only walks children, so those tables were missing from the event. {@code
+ * subqueries()} is available on the Databricks commands as well, because the condition is one of
+ * their expressions.
  */
 public class TableContentChangeInputDatasetBuilder
     extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
@@ -41,7 +44,9 @@ public class TableContentChangeInputDatasetBuilder
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return (x instanceof DeleteFromTable) || (x instanceof UpdateTable);
+    return (x instanceof DeleteFromTable)
+        || (x instanceof UpdateTable)
+        || DeleteUpdateCommandUtils.isDeleteOrUpdateCommand(x);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeInputDatasetBuilder.java
@@ -1,0 +1,67 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+
+/**
+ * Extracts input datasets from the subqueries of a {@link DeleteFromTable} or an {@link
+ * UpdateTable}.
+ *
+ * <p>Tables referenced from a WHERE clause or from an UPDATE assignment live inside expressions,
+ * not inside the children of the plan node:
+ *
+ * <pre>
+ * DeleteFromTable
+ * +- table: DataSourceV2Relation           (visited, emitted as output)
+ * +- condition: InSubquery(id, ListQuery)  (not a child, never visited)
+ *                +- plan: the subquery reading another table
+ * </pre>
+ *
+ * The regular traversal only walks children, so those tables were missing from the event.
+ */
+public class TableContentChangeInputDatasetBuilder
+    extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
+
+  public TableContentChangeInputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof DeleteFromTable) || (x instanceof UpdateTable);
+  }
+
+  @Override
+  public List<InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    // subqueries() returns the plans held by the expressions of this node only, so the children of
+    // the node are left to the regular traversal
+    return ScalaConversionUtils.<LogicalPlan>fromSeq(x.subqueries()).stream()
+        .flatMap(subquery -> collectInputs(subquery, event).stream())
+        .collect(Collectors.toList());
+  }
+
+  private List<InputDataset> collectInputs(LogicalPlan subquery, SparkListenerEvent event) {
+    return ScalaConversionUtils.fromSeq(
+            subquery.collect(
+                delegate(
+                    context.getInputDatasetQueryPlanVisitors(),
+                    context.getInputDatasetBuilders(),
+                    event)))
+        .stream()
+        .flatMap(datasets -> datasets.stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
@@ -6,18 +6,28 @@
 package io.openlineage.spark3.agent.utils;
 
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import scala.Option;
 
 /**
  * Recognises the Databricks Delta commands that a {@code COPY INTO} statement is turned into, and
@@ -26,31 +36,56 @@ import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
  * <p>On newer Databricks runtimes (Spark 4.0+) the logical plan is {@code CopyIntoCommandEdge}
  * rather than {@code CopyIntoCommand}. Neither class is on the compile classpath, so builders match
  * by canonical class name suffix and reach into the command reflectively, with fallbacks for the
- * member names and shapes seen across runtimes.
+ * member names and shapes seen across runtimes. When the command is not the optimized-plan root, or
+ * reflection still fails, SQL text from the logical plan origin is parsed as a last resort.
  */
 @Slf4j
 public class CopyIntoCommandUtils {
 
-  private static final List<String> COMMAND_CLASS_NAMES =
+  private static final List<String> COMMAND_CLASS_SUFFIXES =
       Arrays.asList(
           "sql.transaction.tahoe.commands.CopyIntoCommand",
           "sql.transaction.tahoe.commands.CopyIntoCommandEdge");
 
   private static final List<String> TARGET_METHOD_NAMES =
-      Arrays.asList("target", "targetTable", "table");
+      Arrays.asList("target", "targetTable", "table", "copyIntoTarget", "copyIntoTable");
 
   private static final List<String> TARGET_FIELD_NAMES =
-      Arrays.asList("target", "targetTable", "table");
+      Arrays.asList("target", "targetTable", "table", "copyIntoTarget", "copyIntoTable");
 
   private static final List<String> SOURCE_PATH_METHOD_NAMES =
-      Arrays.asList("sourcePath", "path", "sourceLocation", "location");
+      Arrays.asList(
+          "sourcePath",
+          "path",
+          "sourceLocation",
+          "location",
+          "sourceUri",
+          "inputPath",
+          "copyIntoSourcePath",
+          "from");
 
   private static final List<String> SOURCE_PATH_FIELD_NAMES =
-      Arrays.asList("sourcePath", "path", "sourceLocation", "location");
+      Arrays.asList(
+          "sourcePath",
+          "path",
+          "sourceLocation",
+          "location",
+          "sourceUri",
+          "inputPath",
+          "copyIntoSourcePath",
+          "from");
 
-  private static final List<String> SOURCE_QUERY_METHOD_NAMES = Arrays.asList("query", "source");
+  private static final String SOURCE_MEMBER = "source";
 
-  private static final List<String> SOURCE_QUERY_FIELD_NAMES = Arrays.asList("query", "source");
+  private static final List<String> SOURCE_QUERY_METHOD_NAMES =
+      Arrays.asList("query", SOURCE_MEMBER, "copyIntoSource", "sourceQuery");
+
+  private static final List<String> SOURCE_QUERY_FIELD_NAMES =
+      Arrays.asList("query", SOURCE_MEMBER, "copyIntoSource", "sourceQuery");
+
+  private static final List<String> NESTED_SOURCE_MEMBERS =
+      Arrays.asList(
+          "sourceOptions", "copyIntoOptions", "options", "readerOptions", "formatOptions");
 
   private CopyIntoCommandUtils() {}
 
@@ -60,7 +95,141 @@ public class CopyIntoCommandUtils {
 
   /** Package-visible for tests; Databricks command classes are not on the classpath. */
   static boolean matchesCommandClassName(String canonicalName) {
-    return canonicalName != null && COMMAND_CLASS_NAMES.stream().anyMatch(canonicalName::endsWith);
+    if (canonicalName == null) {
+      return false;
+    }
+    if (COMMAND_CLASS_SUFFIXES.stream().anyMatch(canonicalName::endsWith)) {
+      return true;
+    }
+    return canonicalName.contains("CopyInto")
+        && (canonicalName.endsWith("CommandEdge")
+            || canonicalName.endsWith("Command")
+            || canonicalName.endsWith("CopyIntoCommandEdge")
+            || canonicalName.endsWith("CopyIntoCommand"));
+  }
+
+  /** Finds every COPY INTO command node across optimized, analyzed, and logical plans. */
+  public static List<LogicalPlan> findAllCommands(OpenLineageContext context) {
+    return context
+        .getQueryExecution()
+        .map(CopyIntoCommandUtils::findAllCommands)
+        .orElse(Collections.emptyList());
+  }
+
+  private static List<LogicalPlan> findAllCommands(QueryExecution queryExecution) {
+    Set<LogicalPlan> commands = new LinkedHashSet<>();
+    findInTree(queryExecution.optimizedPlan()).ifPresent(commands::add);
+    findInTree(queryExecution.analyzed()).ifPresent(commands::add);
+    findInTree(queryExecution.logical()).ifPresent(commands::add);
+    return new ArrayList<>(commands);
+  }
+
+  public static Optional<LogicalPlan> findInTree(LogicalPlan root) {
+    if (root == null) {
+      return Optional.empty();
+    }
+    java.util.ArrayDeque<LogicalPlan> stack = new java.util.ArrayDeque<>();
+    stack.push(root);
+    while (!stack.isEmpty()) {
+      LogicalPlan plan = stack.pop();
+      if (isCopyIntoCommand(plan)) {
+        return Optional.of(plan);
+      }
+      ScalaConversionUtils.fromSeq(plan.children()).forEach(stack::push);
+    }
+    return Optional.empty();
+  }
+
+  /** Finds a table scan relation under a COPY INTO command for delegate-based extraction. */
+  public static Optional<LogicalPlan> findTableRelation(LogicalPlan root) {
+    Optional<LogicalPlan> dataSourceV2Relation = findDataSourceV2Relation(root);
+    if (dataSourceV2Relation.isPresent()) {
+      return dataSourceV2Relation;
+    }
+    return findLogicalRelation(root);
+  }
+
+  /**
+   * Finds a {@link DataSourceV2Relation} under a COPY INTO command for delegate-based extraction.
+   */
+  public static Optional<LogicalPlan> findDataSourceV2Relation(LogicalPlan root) {
+    return findInTreeByType(root, DataSourceV2Relation.class);
+  }
+
+  private static Optional<LogicalPlan> findLogicalRelation(LogicalPlan root) {
+    return findInTreeByType(root, LogicalRelation.class);
+  }
+
+  private static Optional<LogicalPlan> findInTreeByType(LogicalPlan root, Class<?> type) {
+    if (root == null) {
+      return Optional.empty();
+    }
+    java.util.ArrayDeque<LogicalPlan> stack = new java.util.ArrayDeque<>();
+    stack.push(root);
+    while (!stack.isEmpty()) {
+      LogicalPlan plan = stack.pop();
+      if (type.isInstance(plan)) {
+        return Optional.of(plan);
+      }
+      ScalaConversionUtils.fromSeq(plan.children()).forEach(stack::push);
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<String> sqlText(OpenLineageContext context) {
+    return context
+        .getQueryExecution()
+        .flatMap(
+            qe ->
+                firstOf(
+                    () -> sqlFromPlanTree(qe.logical()),
+                    () -> sqlFromPlanTree(qe.analyzed()),
+                    () -> sqlFromPlanTree(qe.optimizedPlan())))
+        .filter(CopyIntoSqlUtils::isCopyIntoStatement);
+  }
+
+  private static Optional<String> sqlFromPlanTree(LogicalPlan root) {
+    if (root == null) {
+      return Optional.empty();
+    }
+    java.util.ArrayDeque<LogicalPlan> stack = new java.util.ArrayDeque<>();
+    stack.push(root);
+    while (!stack.isEmpty()) {
+      LogicalPlan plan = stack.pop();
+      Optional<String> sql = sqlFromOrigin(plan);
+      if (sql.isPresent()) {
+        return sql;
+      }
+      ScalaConversionUtils.fromSeq(plan.children()).forEach(stack::push);
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> sqlFromOrigin(LogicalPlan plan) {
+    if (plan.origin() == null) {
+      return Optional.empty();
+    }
+    Object origin = plan.origin();
+    return firstOf(
+        () -> stringFromOriginMember(invoke(origin, "sqlText")),
+        () -> stringFromOriginMember(invoke(origin, "sql")),
+        () -> stringFromOriginMember(readField(origin, "sqlText")),
+        () -> stringFromOriginMember(readField(origin, "sql")));
+  }
+
+  private static Optional<String> stringFromOriginMember(Optional<Object> value) {
+    if (value.isEmpty()) {
+      return Optional.empty();
+    }
+    Object object = value.get();
+    if (object instanceof Option) {
+      Option<?> option = (Option<?>) object;
+      if (option.isDefined() && option.get() instanceof String) {
+        return Optional.of((String) option.get()).filter(StringUtils::isNotBlank);
+      }
+      return Optional.empty();
+    }
+    return stringValue(Optional.of(object));
   }
 
   /**
@@ -68,32 +237,200 @@ public class CopyIntoCommandUtils {
    * statement uses a table alias.
    */
   public static Optional<LogicalPlan> target(LogicalPlan plan) {
+    return targetFromCommand(plan);
+  }
+
+  /**
+   * Package-visible so tests can pass a stand-in for the Databricks command, which cannot extend
+   * {@link LogicalPlan} from Java.
+   */
+  static Optional<LogicalPlan> targetFromCommand(Object command) {
     Optional<LogicalPlan> target =
         firstOf(
-            () -> logicalPlanFromMethods(plan, TARGET_METHOD_NAMES),
-            () -> logicalPlanFromFields(plan, TARGET_FIELD_NAMES));
+            () -> logicalPlanFromMethods(command, TARGET_METHOD_NAMES),
+            () -> logicalPlanFromFields(command, TARGET_FIELD_NAMES),
+            () -> targetFromAnyMember(command));
 
     return target.map(CopyIntoCommandUtils::unwrapSubqueryAlias);
   }
 
+  /**
+   * Picks the target out of the runtime-only members when none of the known accessor names match.
+   * Databricks renames these members between runtimes, and a miss costs the whole output dataset:
+   * the builder then falls back to the table name alone, which is a different lineage node than the
+   * storage location that DELETE and CTAS resolve for the same table.
+   */
+  private static Optional<LogicalPlan> targetFromAnyMember(Object command) {
+    // Only a catalog-backed relation is accepted. Falling back to "any plan member" would let the
+    // source scan be reported as the table the statement wrote to, which is worse than degrading to
+    // the SQL text.
+    return logicalPlanMembers(command).stream()
+        .filter(plan -> findCatalogRelation(plan).isPresent())
+        .findFirst();
+  }
+
+  /**
+   * Reads every {@link LogicalPlan} held by the command, in declaration order. Only fields are
+   * read: the command also declares methods such as {@code run}, and invoking those to discover a
+   * member would re-execute the statement.
+   */
+  private static List<LogicalPlan> logicalPlanMembers(Object command) {
+    List<LogicalPlan> plans = new ArrayList<>();
+    for (java.lang.reflect.Field field : runtimeFields(command)) {
+      readField(command, field).flatMap(CopyIntoCommandUtils::asLogicalPlan).ifPresent(plans::add);
+    }
+    return plans;
+  }
+
+  /**
+   * Fields declared by the command itself and its runtime-specific supertypes. Spark and Scala base
+   * classes are skipped: their members are tree bookkeeping, never the COPY INTO operands.
+   */
+  private static List<java.lang.reflect.Field> runtimeFields(Object command) {
+    List<java.lang.reflect.Field> fields = new ArrayList<>();
+    Class<?> type = command.getClass();
+    while (type != null && isRuntimeClass(type)) {
+      fields.addAll(Arrays.asList(type.getDeclaredFields()));
+      type = type.getSuperclass();
+    }
+    return fields;
+  }
+
+  private static boolean isRuntimeClass(Class<?> type) {
+    String name = type.getName();
+    return !name.startsWith("org.apache.spark.")
+        && !name.startsWith("scala.")
+        && !name.startsWith("java.");
+  }
+
+  private static Optional<LogicalPlan> asLogicalPlan(Object value) {
+    if (value instanceof LogicalPlan) {
+      return Optional.of((LogicalPlan) value);
+    }
+    if (value instanceof Option) {
+      Option<?> option = (Option<?>) value;
+      return option.isDefined() ? asLogicalPlan(option.get()) : Optional.empty();
+    }
+    return Optional.empty();
+  }
+
+  /** A relation that a catalog can resolve, which is what distinguishes the target from a scan. */
+  private static Optional<DataSourceV2Relation> findCatalogRelation(LogicalPlan plan) {
+    return findInTreeByType(plan, DataSourceV2Relation.class)
+        .map(DataSourceV2Relation.class::cast)
+        .filter(relation -> relation.identifier() != null && relation.identifier().isDefined());
+  }
+
+  private static Optional<Object> readField(Object target, java.lang.reflect.Field field) {
+    try {
+      return Optional.ofNullable(FieldUtils.readField(field, target, true));
+    } catch (IllegalAccessException | RuntimeException e) {
+      log.debug("Could not read {} from {}", field.getName(), target.getClass().getName(), e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Lists the zero-argument methods and fields declared by a runtime-only command class. The
+   * Databricks classes are not on the compile classpath, so when every known accessor name misses
+   * this is the only way to learn the real member names from a driver log.
+   */
+  public static String describeMembers(Object plan) {
+    if (plan == null) {
+      return "<null>";
+    }
+    Class<?> type = plan.getClass();
+    String methods =
+        Arrays.stream(type.getDeclaredMethods())
+            .filter(method -> method.getParameterCount() == 0)
+            .map(method -> method.getName() + ":" + method.getReturnType().getSimpleName())
+            .sorted()
+            .collect(Collectors.joining(", "));
+    String fields =
+        Arrays.stream(type.getDeclaredFields())
+            .map(field -> field.getName() + ":" + field.getType().getSimpleName())
+            .sorted()
+            .collect(Collectors.joining(", "));
+    return type.getCanonicalName() + " methods=[" + methods + "] fields=[" + fields + "]";
+  }
+
   /** Reads the source file path when the command stores it as a string or in reader options. */
   public static Optional<String> sourcePath(LogicalPlan plan) {
+    return sourcePathFromCommand(plan);
+  }
+
+  /** Package-visible for tests; see {@link #targetFromCommand(Object)}. */
+  static Optional<String> sourcePathFromCommand(Object command) {
     return firstOf(
-        () -> stringFromMethods(plan, SOURCE_PATH_METHOD_NAMES),
-        () -> stringFromFields(plan, SOURCE_PATH_FIELD_NAMES),
-        () -> pathFromOptions(invoke(plan, "sourceOptions")),
-        () -> pathFromOptions(readField(plan, "sourceOptions")),
-        () -> stringFromSourceMember(plan));
+        () -> stringFromMethods(command, SOURCE_PATH_METHOD_NAMES),
+        () -> stringFromFields(command, SOURCE_PATH_FIELD_NAMES),
+        () -> pathFromNestedMembers(command),
+        () -> pathFromOptions(invoke(command, "sourceOptions")),
+        () -> pathFromOptions(readField(command, "sourceOptions")),
+        () -> stringFromSourceMember(command),
+        () -> pathFromAnyMember(command));
+  }
+
+  /**
+   * Picks the source location out of the runtime-only members when none of the known accessor names
+   * match. Only values shaped like a location are considered, so sibling members such as the file
+   * format are not mistaken for a path.
+   */
+  private static Optional<String> pathFromAnyMember(Object command) {
+    for (java.lang.reflect.Field field : runtimeFields(command)) {
+      Optional<String> path =
+          readField(command, field)
+              .flatMap(value -> stringValue(Optional.of(value)))
+              .filter(CopyIntoCommandUtils::looksLikeLocation);
+      if (path.isPresent()) {
+        return path;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean looksLikeLocation(String value) {
+    return value.startsWith("/") || value.contains("://");
   }
 
   /** Reads a nested select over the source when the command does not expose a plain path. */
   public static Optional<LogicalPlan> sourceQuery(LogicalPlan plan) {
-    return firstOf(
-        () -> logicalPlanFromMethods(plan, SOURCE_QUERY_METHOD_NAMES),
-        () -> logicalPlanFromFields(plan, SOURCE_QUERY_FIELD_NAMES));
+    return sourceQueryFromCommand(plan);
   }
 
-  private static Optional<LogicalPlan> logicalPlanFromMethods(Object plan, List<String> methodNames) {
+  /** Package-visible for tests; see {@link #targetFromCommand(Object)}. */
+  static Optional<LogicalPlan> sourceQueryFromCommand(Object command) {
+    return firstOf(
+        () -> logicalPlanFromMethods(command, SOURCE_QUERY_METHOD_NAMES),
+        () -> logicalPlanFromFields(command, SOURCE_QUERY_FIELD_NAMES),
+        () -> sourceQueryFromAnyMember(command));
+  }
+
+  /** The plan member that is not the target, so a source select is not reported as the output. */
+  private static Optional<LogicalPlan> sourceQueryFromAnyMember(Object command) {
+    Optional<LogicalPlan> target = targetFromAnyMember(command);
+    return logicalPlanMembers(command).stream()
+        .filter(plan -> !target.filter(t -> t == plan).isPresent())
+        .findFirst();
+  }
+
+  private static Optional<String> pathFromNestedMembers(Object plan) {
+    for (String member : NESTED_SOURCE_MEMBERS) {
+      Optional<String> path =
+          firstOf(
+              () -> pathFromOptions(invoke(plan, member)),
+              () -> pathFromOptions(readField(plan, member)),
+              () -> stringValue(invoke(plan, member)),
+              () -> stringValue(readField(plan, member)));
+      if (path.isPresent()) {
+        return path;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<LogicalPlan> logicalPlanFromMethods(
+      Object plan, List<String> methodNames) {
     for (String methodName : methodNames) {
       Optional<LogicalPlan> logicalPlan = logicalPlan(invoke(plan, methodName));
       if (logicalPlan.isPresent()) {
@@ -133,8 +470,9 @@ public class CopyIntoCommandUtils {
     return Optional.empty();
   }
 
-  private static Optional<String> stringFromSourceMember(LogicalPlan plan) {
-    return stringValue(firstOf(() -> invoke(plan, "source"), () -> readField(plan, "source")));
+  private static Optional<String> stringFromSourceMember(Object plan) {
+    return stringValue(
+        firstOf(() -> invoke(plan, SOURCE_MEMBER), () -> readField(plan, SOURCE_MEMBER)));
   }
 
   private static Optional<String> pathFromOptions(Optional<Object> options) {
@@ -143,7 +481,10 @@ public class CopyIntoCommandUtils {
 
   private static Optional<String> pathFromOptionsMap(Object options) {
     Map<String, String> optionMap = toJavaMap(options);
-    return Optional.ofNullable(optionMap.get("path")).filter(StringUtils::isNotBlank);
+    return firstOf(
+        () -> Optional.ofNullable(optionMap.get("path")).filter(StringUtils::isNotBlank),
+        () -> Optional.ofNullable(optionMap.get("location")).filter(StringUtils::isNotBlank),
+        () -> Optional.ofNullable(optionMap.get("uri")).filter(StringUtils::isNotBlank));
   }
 
   private static Optional<Object> invoke(Object target, String methodName) {
@@ -181,11 +522,15 @@ public class CopyIntoCommandUtils {
     return firstOf(
         () -> logicalPlan(invoke(object, "table")),
         () -> logicalPlan(invoke(object, "child")),
-        () -> logicalPlan(invoke(object, "plan")));
+        () -> logicalPlan(invoke(object, "plan")),
+        () -> logicalPlan(invoke(object, "target")));
   }
 
   private static Optional<String> stringValue(Optional<Object> value) {
-    return value.filter(String.class::isInstance).map(String.class::cast).filter(StringUtils::isNotBlank);
+    return value
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .filter(StringUtils::isNotBlank);
   }
 
   private static LogicalPlan unwrapSubqueryAlias(LogicalPlan plan) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
@@ -1,0 +1,36 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Recognises the Databricks Delta commands that a {@code COPY INTO} statement is turned into.
+ *
+ * <p>On newer Databricks runtimes (Spark 4.0+) the logical plan is {@code CopyIntoCommandEdge}
+ * rather than {@code CopyIntoCommand}. Neither class is on the compile classpath, so builders match
+ * by canonical class name suffix, the same approach used for other tahoe command nodes.
+ */
+public class CopyIntoCommandUtils {
+
+  private static final List<String> COMMAND_CLASS_NAMES =
+      Arrays.asList(
+          "sql.transaction.tahoe.commands.CopyIntoCommand",
+          "sql.transaction.tahoe.commands.CopyIntoCommandEdge");
+
+  private CopyIntoCommandUtils() {}
+
+  public static boolean isCopyIntoCommand(LogicalPlan plan) {
+    return matchesCommandClassName(plan.getClass().getCanonicalName());
+  }
+
+  /** Package-visible for tests; Databricks command classes are not on the classpath. */
+  static boolean matchesCommandClassName(String canonicalName) {
+    return canonicalName != null && COMMAND_CLASS_NAMES.stream().anyMatch(canonicalName::endsWith);
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
@@ -5,23 +5,52 @@
 
 package io.openlineage.spark3.agent.utils;
 
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 
 /**
- * Recognises the Databricks Delta commands that a {@code COPY INTO} statement is turned into.
+ * Recognises the Databricks Delta commands that a {@code COPY INTO} statement is turned into, and
+ * reads their target relation and source location.
  *
  * <p>On newer Databricks runtimes (Spark 4.0+) the logical plan is {@code CopyIntoCommandEdge}
  * rather than {@code CopyIntoCommand}. Neither class is on the compile classpath, so builders match
- * by canonical class name suffix, the same approach used for other tahoe command nodes.
+ * by canonical class name suffix and reach into the command reflectively, with fallbacks for the
+ * member names and shapes seen across runtimes.
  */
+@Slf4j
 public class CopyIntoCommandUtils {
 
   private static final List<String> COMMAND_CLASS_NAMES =
       Arrays.asList(
           "sql.transaction.tahoe.commands.CopyIntoCommand",
           "sql.transaction.tahoe.commands.CopyIntoCommandEdge");
+
+  private static final List<String> TARGET_METHOD_NAMES =
+      Arrays.asList("target", "targetTable", "table");
+
+  private static final List<String> TARGET_FIELD_NAMES =
+      Arrays.asList("target", "targetTable", "table");
+
+  private static final List<String> SOURCE_PATH_METHOD_NAMES =
+      Arrays.asList("sourcePath", "path", "sourceLocation", "location");
+
+  private static final List<String> SOURCE_PATH_FIELD_NAMES =
+      Arrays.asList("sourcePath", "path", "sourceLocation", "location");
+
+  private static final List<String> SOURCE_QUERY_METHOD_NAMES = Arrays.asList("query", "source");
+
+  private static final List<String> SOURCE_QUERY_FIELD_NAMES = Arrays.asList("query", "source");
 
   private CopyIntoCommandUtils() {}
 
@@ -32,5 +61,158 @@ public class CopyIntoCommandUtils {
   /** Package-visible for tests; Databricks command classes are not on the classpath. */
   static boolean matchesCommandClassName(String canonicalName) {
     return canonicalName != null && COMMAND_CLASS_NAMES.stream().anyMatch(canonicalName::endsWith);
+  }
+
+  /**
+   * Reads the target relation, unwrapping the {@link SubqueryAlias} the command keeps when the
+   * statement uses a table alias.
+   */
+  public static Optional<LogicalPlan> target(LogicalPlan plan) {
+    Optional<LogicalPlan> target =
+        firstOf(
+            () -> logicalPlanFromMethods(plan, TARGET_METHOD_NAMES),
+            () -> logicalPlanFromFields(plan, TARGET_FIELD_NAMES));
+
+    return target.map(CopyIntoCommandUtils::unwrapSubqueryAlias);
+  }
+
+  /** Reads the source file path when the command stores it as a string or in reader options. */
+  public static Optional<String> sourcePath(LogicalPlan plan) {
+    return firstOf(
+        () -> stringFromMethods(plan, SOURCE_PATH_METHOD_NAMES),
+        () -> stringFromFields(plan, SOURCE_PATH_FIELD_NAMES),
+        () -> pathFromOptions(invoke(plan, "sourceOptions")),
+        () -> pathFromOptions(readField(plan, "sourceOptions")),
+        () -> stringFromSourceMember(plan));
+  }
+
+  /** Reads a nested select over the source when the command does not expose a plain path. */
+  public static Optional<LogicalPlan> sourceQuery(LogicalPlan plan) {
+    return firstOf(
+        () -> logicalPlanFromMethods(plan, SOURCE_QUERY_METHOD_NAMES),
+        () -> logicalPlanFromFields(plan, SOURCE_QUERY_FIELD_NAMES));
+  }
+
+  private static Optional<LogicalPlan> logicalPlanFromMethods(Object plan, List<String> methodNames) {
+    for (String methodName : methodNames) {
+      Optional<LogicalPlan> logicalPlan = logicalPlan(invoke(plan, methodName));
+      if (logicalPlan.isPresent()) {
+        return logicalPlan;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<LogicalPlan> logicalPlanFromFields(Object plan, List<String> fieldNames) {
+    for (String fieldName : fieldNames) {
+      Optional<LogicalPlan> logicalPlan = logicalPlan(readField(plan, fieldName));
+      if (logicalPlan.isPresent()) {
+        return logicalPlan;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> stringFromMethods(Object plan, List<String> methodNames) {
+    for (String methodName : methodNames) {
+      Optional<String> value = stringValue(invoke(plan, methodName));
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> stringFromFields(Object plan, List<String> fieldNames) {
+    for (String fieldName : fieldNames) {
+      Optional<String> value = stringValue(readField(plan, fieldName));
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> stringFromSourceMember(LogicalPlan plan) {
+    return stringValue(firstOf(() -> invoke(plan, "source"), () -> readField(plan, "source")));
+  }
+
+  private static Optional<String> pathFromOptions(Optional<Object> options) {
+    return options.flatMap(CopyIntoCommandUtils::pathFromOptionsMap);
+  }
+
+  private static Optional<String> pathFromOptionsMap(Object options) {
+    Map<String, String> optionMap = toJavaMap(options);
+    return Optional.ofNullable(optionMap.get("path")).filter(StringUtils::isNotBlank);
+  }
+
+  private static Optional<Object> invoke(Object target, String methodName) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(MethodUtils.invokeMethod(target, methodName));
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.debug("Could not call {} on {}", methodName, target.getClass().getCanonicalName(), e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Object> readField(Object target, String fieldName) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(FieldUtils.readField(target, fieldName, true));
+    } catch (IllegalAccessException | IllegalArgumentException e) {
+      log.debug("Could not read {} from {}", fieldName, target.getClass().getCanonicalName(), e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<LogicalPlan> logicalPlan(Optional<Object> value) {
+    if (value.isEmpty()) {
+      return Optional.empty();
+    }
+    Object object = value.get();
+    if (object instanceof LogicalPlan) {
+      return Optional.of((LogicalPlan) object);
+    }
+    return firstOf(
+        () -> logicalPlan(invoke(object, "table")),
+        () -> logicalPlan(invoke(object, "child")),
+        () -> logicalPlan(invoke(object, "plan")));
+  }
+
+  private static Optional<String> stringValue(Optional<Object> value) {
+    return value.filter(String.class::isInstance).map(String.class::cast).filter(StringUtils::isNotBlank);
+  }
+
+  private static LogicalPlan unwrapSubqueryAlias(LogicalPlan plan) {
+    if (plan instanceof SubqueryAlias) {
+      return ((SubqueryAlias) plan).child();
+    }
+    return plan;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> toJavaMap(Object map) {
+    if (map instanceof scala.collection.immutable.Map) {
+      return ScalaConversionUtils.fromMap((scala.collection.immutable.Map<String, String>) map);
+    } else if (map instanceof Map) {
+      return new HashMap<>((Map<String, String>) map);
+    }
+    return new HashMap<>();
+  }
+
+  @SafeVarargs
+  private static <T> Optional<T> firstOf(Supplier<Optional<T>>... suppliers) {
+    for (Supplier<Optional<T>> supplier : suppliers) {
+      Optional<T> value = supplier.get();
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
@@ -1,0 +1,55 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+/** Parses {@code COPY INTO} statements when tahoe command reflection is unavailable. */
+public class CopyIntoSqlUtils {
+
+  private static final Pattern COPY_INTO_TARGET =
+      Pattern.compile("(?is)\\bCOPY\\s+INTO\\s+([`\\w.]+)");
+  private static final Pattern COPY_INTO_SOURCE =
+      Pattern.compile("(?is)\\bFROM\\s+'([^']+)'|\\bFROM\\s+\"([^\"]+)\"");
+
+  private CopyIntoSqlUtils() {}
+
+  public static boolean isCopyIntoStatement(String sql) {
+    return sql != null && COPY_INTO_TARGET.matcher(sql).find();
+  }
+
+  public static Optional<String> targetTable(String sql) {
+    if (StringUtils.isBlank(sql)) {
+      return Optional.empty();
+    }
+    Matcher matcher = COPY_INTO_TARGET.matcher(sql);
+    if (!matcher.find()) {
+      return Optional.empty();
+    }
+    return Optional.of(stripQuotes(matcher.group(1)));
+  }
+
+  public static Optional<String> sourcePath(String sql) {
+    if (StringUtils.isBlank(sql)) {
+      return Optional.empty();
+    }
+    Matcher matcher = COPY_INTO_SOURCE.matcher(sql);
+    if (!matcher.find()) {
+      return Optional.empty();
+    }
+    String singleQuoted = matcher.group(1);
+    String doubleQuoted = matcher.group(2);
+    return Optional.ofNullable(StringUtils.firstNonBlank(singleQuoted, doubleQuoted))
+        .filter(StringUtils::isNotBlank);
+  }
+
+  private static String stripQuotes(String value) {
+    return value.replace("`", "").trim();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -242,7 +242,7 @@ public class DataSourceV2RelationDatasetExtractor {
   /**
    * Unity Catalog managed tables may have no resolvable storage location. Fall back to the
    * qualified {@code catalog.schema.table} name in the {@code unity-catalog} namespace, matching
-   * {@link io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder}.
+   * {@code CreateReplaceOutputDatasetBuilder}.
    */
   private static Optional<DatasetIdentifier> unityCatalogIdentifier(
       OpenLineageContext context, TableCatalog tableCatalog, Identifier identifier) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -240,9 +240,9 @@ public class DataSourceV2RelationDatasetExtractor {
   }
 
   /**
-   * Unity Catalog managed tables may have no resolvable storage location. Fall back to the qualified
-   * {@code catalog.schema.table} name in the {@code unity-catalog} namespace, matching {@link
-   * io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder}.
+   * Unity Catalog managed tables may have no resolvable storage location. Fall back to the
+   * qualified {@code catalog.schema.table} name in the {@code unity-catalog} namespace, matching
+   * {@link io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder}.
    */
   private static Optional<DatasetIdentifier> unityCatalogIdentifier(
       OpenLineageContext context, TableCatalog tableCatalog, Identifier identifier) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -12,6 +12,7 @@ import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
@@ -84,8 +86,12 @@ public class DataSourceV2RelationDatasetExtractor {
                 }
 
                 Map<String, String> tableProperties = relation.table().properties();
-                CatalogUtils.addStorageAndCatalogFacets(
-                    context, tableCatalog, tableProperties, datasetFacetsBuilder);
+                try {
+                  CatalogUtils.addStorageAndCatalogFacets(
+                      context, tableCatalog, tableProperties, datasetFacetsBuilder);
+                } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+                  log.warn("Could not add catalog facets of table {}", identifier.getName(), e);
+                }
               }
               datasetFacetsBuilder
                   .getFacets()
@@ -209,10 +215,54 @@ public class DataSourceV2RelationDatasetExtractor {
     TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
     Map<String, String> tableProperties = relation.table().properties();
 
-    // Get the dataset identifier
-    return PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties)
+    Optional<DatasetIdentifier> datasetIdentifier =
+        resolveDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+    if (datasetIdentifier.isPresent()) {
+      return Collections.singletonList(datasetIdentifier.get());
+    }
+
+    return unityCatalogIdentifier(context, tableCatalog, identifier)
         .map(Collections::singletonList)
         .orElse(Collections.emptyList());
+  }
+
+  private static Optional<DatasetIdentifier> resolveDatasetIdentifier(
+      OpenLineageContext context,
+      TableCatalog tableCatalog,
+      Identifier identifier,
+      Map<String, String> tableProperties) {
+    try {
+      return PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not resolve dataset identifier of table {}", identifier, e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Unity Catalog managed tables may have no resolvable storage location. Fall back to the qualified
+   * {@code catalog.schema.table} name in the {@code unity-catalog} namespace, matching {@link
+   * io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder}.
+   */
+  private static Optional<DatasetIdentifier> unityCatalogIdentifier(
+      OpenLineageContext context, TableCatalog tableCatalog, Identifier identifier) {
+    boolean unityCatalogEnabled =
+        context
+            .getSparkContext()
+            .map(SparkContext::getConf)
+            .map(DatabricksUtils::isDatabricksUnityCatalogEnabled)
+            .orElse(false);
+
+    if (!unityCatalogEnabled) {
+      return Optional.empty();
+    }
+
+    String name = DatabricksUtils.qualifiedUnityCatalogTableName(tableCatalog, identifier);
+    log.warn(
+        "Could not resolve the location of Unity Catalog table {}, falling back to its qualified name",
+        name);
+    return Optional.of(
+        new DatasetIdentifier(name, DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE));
   }
 
   private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DeleteUpdateCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DeleteUpdateCommandUtils.java
@@ -1,0 +1,69 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+
+/**
+ * Recognises the Databricks Delta commands that a {@code DELETE FROM} or an {@code UPDATE}
+ * statement is turned into, and reads their target relation.
+ *
+ * <p>On Databricks the catalyst nodes {@code DeleteFromTable} / {@code UpdateTable} never reach the
+ * dataset builders: the runtime resolves the statement straight to a command under {@code
+ * com.databricks.sql.transaction.tahoe.commands}, so neither the optimized nor the analyzed plan
+ * holds the catalyst node. Those commands are not on the compile classpath, hence the match by
+ * class name and the reflective member access, the same approach {@code MergeIntoCommandEdge} and
+ * {@code CopyIntoCommand} already use.
+ */
+@Slf4j
+public class DeleteUpdateCommandUtils {
+
+  private static final List<String> COMMAND_CLASS_NAMES =
+      Arrays.asList(
+          "sql.transaction.tahoe.commands.DeleteCommand",
+          "sql.transaction.tahoe.commands.DeleteCommandEdge",
+          "sql.transaction.tahoe.commands.UpdateCommand",
+          "sql.transaction.tahoe.commands.UpdateCommandEdge");
+
+  private DeleteUpdateCommandUtils() {}
+
+  public static boolean isDeleteOrUpdateCommand(LogicalPlan plan) {
+    return matchesCommandClassName(plan.getClass().getCanonicalName());
+  }
+
+  /** Package-visible for tests; Databricks command classes are not on the classpath. */
+  static boolean matchesCommandClassName(String canonicalName) {
+    return canonicalName != null && COMMAND_CLASS_NAMES.stream().anyMatch(canonicalName::endsWith);
+  }
+
+  /**
+   * Reads the modified relation from {@code target()}, unwrapping the {@link SubqueryAlias} the
+   * command keeps when the statement uses a table alias.
+   */
+  public static Optional<LogicalPlan> target(LogicalPlan plan) {
+    Object target;
+    try {
+      target = MethodUtils.invokeExactMethod(plan, "target", new Object[] {});
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.warn("Cannot extract target from Databricks command {}", plan.getClass(), e);
+      return Optional.empty();
+    }
+
+    if (target instanceof SubqueryAlias) {
+      return Optional.of(((SubqueryAlias) target).child());
+    } else if (target instanceof LogicalPlan) {
+      return Optional.of((LogicalPlan) target);
+    }
+    return Optional.empty();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
@@ -1,0 +1,153 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+import scala.Option;
+
+/**
+ * Resolves Unity Catalog table identity through the V2 catalog API when legacy {@code
+ * getTableMetadata} is unavailable, matching the path used by {@code DataSourceV2Relation} and
+ * {@link io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder}.
+ */
+@Slf4j
+public final class UnityCatalogTableDatasetUtils {
+
+  private UnityCatalogTableDatasetUtils() {}
+
+  @Value
+  public static class ResolvedTableDataset {
+    DatasetIdentifier datasetIdentifier;
+    TableCatalog catalog;
+    Identifier identifier;
+    Map<String, String> properties;
+    StructType schema;
+  }
+
+  public static Optional<ResolvedTableDataset> resolve(
+      OpenLineageContext context, SparkSession session, TableIdentifier identifier) {
+    Optional<String> catalogName =
+        tableIdentifierCatalog(identifier).or(() -> currentCatalog(session));
+    if (catalogName.isEmpty() || !identifier.database().isDefined()) {
+      return Optional.empty();
+    }
+
+    String schema = identifier.database().get();
+    String table = identifier.table();
+    Optional<CatalogPlugin> catalogPlugin = SparkSessionUtils.catalog(session, catalogName.get());
+    if (catalogPlugin.isEmpty() || !(catalogPlugin.get() instanceof TableCatalog)) {
+      log.warn(
+          "COPY INTO: catalog {} resolved to {}, which is not a TableCatalog",
+          catalogName.get(),
+          catalogPlugin.map(plugin -> plugin.getClass().getCanonicalName()).orElse("<empty>"));
+      return Optional.empty();
+    }
+
+    TableCatalog tableCatalog = (TableCatalog) catalogPlugin.get();
+    Identifier v2Identifier = Identifier.of(new String[] {schema}, table);
+    try {
+      Table loadedTable = tableCatalog.loadTable(v2Identifier);
+      Map<String, String> properties = loadedTable.properties();
+      Optional<DatasetIdentifier> datasetIdentifier =
+          datasetIdentifier(context, tableCatalog, v2Identifier, properties);
+      if (datasetIdentifier.isEmpty()) {
+        log.warn(
+            "COPY INTO: no catalog handler resolved {} from catalog {}",
+            v2Identifier,
+            tableCatalog.getClass().getCanonicalName());
+        return Optional.empty();
+      }
+      return Optional.of(
+          new ResolvedTableDataset(
+              datasetIdentifier.get(),
+              tableCatalog,
+              v2Identifier,
+              properties,
+              loadedTable.schema()));
+    } catch (NoSuchTableException e) {
+      log.debug(
+          "Unity Catalog table {}.{} not found in catalog {}", schema, table, catalogName.get());
+      return Optional.empty();
+    } catch (Exception e) {
+      log.warn(
+          "Unable to load Unity Catalog table {}.{} from catalog {}",
+          schema,
+          table,
+          catalogName.get(),
+          e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<DatasetIdentifier> datasetIdentifier(
+      OpenLineageContext context,
+      TableCatalog catalog,
+      Identifier identifier,
+      Map<String, String> properties) {
+    try {
+      return PlanUtils3.getDatasetIdentifier(context, catalog, identifier, properties);
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not resolve dataset identifier of table {}", identifier, e);
+      return unityCatalogIdentifier(context, catalog, identifier);
+    }
+  }
+
+  private static Optional<DatasetIdentifier> unityCatalogIdentifier(
+      OpenLineageContext context, TableCatalog catalog, Identifier identifier) {
+    boolean unityCatalogEnabled =
+        context
+            .getSparkContext()
+            .map(SparkContext::getConf)
+            .map(DatabricksUtils::isDatabricksUnityCatalogEnabled)
+            .orElse(false);
+    if (!unityCatalogEnabled) {
+      return Optional.empty();
+    }
+    String name = DatabricksUtils.qualifiedUnityCatalogTableName(catalog, identifier);
+    return Optional.of(
+        new DatasetIdentifier(name, DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE));
+  }
+
+  private static Optional<String> tableIdentifierCatalog(TableIdentifier identifier) {
+    try {
+      Option<String> catalog = (Option<String>) MethodUtils.invokeMethod(identifier, "catalog");
+      if (catalog != null && catalog.isDefined()) {
+        return Optional.of(catalog.get()).filter(StringUtils::isNotBlank);
+      }
+    } catch (Exception e) {
+      // TableIdentifier.catalog() is unavailable on older Spark versions
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> currentCatalog(SparkSession session) {
+    try {
+      return Optional.ofNullable(
+              (String) MethodUtils.invokeMethod(session.catalog(), "currentCatalog"))
+          .filter(StringUtils::isNotBlank);
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
@@ -29,7 +29,7 @@ import scala.Option;
 /**
  * Resolves Unity Catalog table identity through the V2 catalog API when legacy {@code
  * getTableMetadata} is unavailable, matching the path used by {@code DataSourceV2Relation} and
- * {@link io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder}.
+ * {@code CreateReplaceOutputDatasetBuilder}.
  */
 @Slf4j
 public final class UnityCatalogTableDatasetUtils {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/V2CreateTablePlanUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/V2CreateTablePlanUtils.java
@@ -1,0 +1,131 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Reflective accessors for {@code V2CreateTablePlan} nodes: {@code CreateTableAsSelect}, {@code
+ * ReplaceTableAsSelect}, {@code CreateTable} and {@code ReplaceTable}.
+ *
+ * <p>Databricks runtimes ship a catalyst whose signatures for these nodes differ from the Apache
+ * Spark release the runtime is based on - {@code tableSpec()} returning {@code TableSpec} instead
+ * of {@code TableSpecBase} is the best known example. Calling such a member through the compile
+ * time API throws {@link NoSuchMethodError}, which the builder framework swallows, so the event is
+ * still emitted but without any output dataset. Resolving the members reflectively, with fallbacks
+ * for the shapes seen across runtimes, keeps output extraction working on those platforms.
+ */
+@Slf4j
+public class V2CreateTablePlanUtils {
+
+  private V2CreateTablePlanUtils() {}
+
+  /**
+   * Resolves the catalog the table is created in. Since Spark 3.3 the catalog is reachable through
+   * the {@code ResolvedIdentifier} held in {@code name()}; older plans expose {@code catalog()}
+   * directly.
+   */
+  public static Optional<TableCatalog> catalog(LogicalPlan plan) {
+    return firstOf(
+        () ->
+            cast(invoke(plan, "name").flatMap(name -> invoke(name, "catalog")), TableCatalog.class),
+        () -> cast(invoke(plan, "catalog"), TableCatalog.class));
+  }
+
+  /** Resolves the identifier of the table being created or replaced. */
+  public static Optional<Identifier> identifier(LogicalPlan plan) {
+    return firstOf(
+        () -> cast(invoke(plan, "tableName"), Identifier.class),
+        () ->
+            cast(
+                invoke(plan, "name").flatMap(name -> invoke(name, "identifier")),
+                Identifier.class));
+  }
+
+  /**
+   * Table properties declared by the command, with the write options merged on top of them. Both
+   * are used to resolve the dataset location, so a missing one must not prevent the other from
+   * being read.
+   */
+  public static Map<String, String> properties(LogicalPlan plan) {
+    Map<String, String> properties = new LinkedHashMap<>();
+    Optional<Object> specProperties =
+        invoke(plan, "tableSpec").flatMap(spec -> invoke(spec, "properties"));
+
+    if (specProperties.isPresent()) {
+      properties.putAll(toJavaMap(specProperties.get()));
+    } else {
+      invoke(plan, "properties").ifPresent(p -> properties.putAll(toJavaMap(p)));
+    }
+
+    invoke(plan, "writeOptions").ifPresent(options -> properties.putAll(toJavaMap(options)));
+    return properties;
+  }
+
+  /**
+   * Schema of the table being created. Falls back to the schema of the select query for plans that
+   * do not expose {@code tableSchema()}, and to an empty schema when neither is available.
+   */
+  public static StructType schema(LogicalPlan plan) {
+    return firstOf(
+            () -> cast(invoke(plan, "tableSchema"), StructType.class),
+            () ->
+                cast(
+                    invoke(plan, "query").flatMap(query -> invoke(query, "schema")),
+                    StructType.class))
+        .orElseGet(StructType::new);
+  }
+
+  private static Optional<Object> invoke(Object target, String methodName) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(MethodUtils.invokeMethod(target, methodName));
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.debug("Could not call {} on {}", methodName, target.getClass().getCanonicalName(), e);
+      return Optional.empty();
+    }
+  }
+
+  private static <T> Optional<T> cast(Optional<Object> value, Class<T> type) {
+    return value.filter(type::isInstance).map(type::cast);
+  }
+
+  @SafeVarargs
+  private static <T> Optional<T> firstOf(Supplier<Optional<T>>... suppliers) {
+    for (Supplier<Optional<T>> supplier : suppliers) {
+      Optional<T> value = supplier.get();
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> toJavaMap(Object map) {
+    if (map instanceof scala.collection.immutable.Map) {
+      return ScalaConversionUtils.<String, String>fromMap(
+          (scala.collection.immutable.Map<String, String>) map);
+    } else if (map instanceof Map) {
+      return new HashMap<>((Map<String, String>) map);
+    }
+    log.debug("Unsupported properties type {}", map.getClass().getCanonicalName());
+    return new HashMap<>();
+  }
+}

--- a/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
+++ b/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
@@ -1,0 +1,40 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package com.databricks.sql.transaction.tahoe.commands;
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Stands in for the Databricks {@code CopyIntoCommandEdge} that a {@code COPY INTO} statement is
+ * resolved to on Spark 4.0 runtimes. The real class is not on any compile classpath, so extraction
+ * has to work by reflection and cannot assume the member names.
+ *
+ * <p>The members are deliberately named nothing like {@code target} or {@code sourcePath}, and the
+ * format name is declared before the location, so a test using this class only passes when
+ * extraction is genuinely name-independent.
+ *
+ * <p>This is not a {@link LogicalPlan}: Java cannot extend the Scala plan classes because of the
+ * covariant {@code withNewChildrenInternal} override. The reflective extraction works on plain
+ * objects, so the fixture exercises the same code the runtime hits.
+ */
+public class CopyIntoCommandEdge {
+
+  private final String fileFormatName;
+  private final LogicalPlan copyIntoTargetRelation;
+  private final LogicalPlan copyIntoSourceRelation;
+  private final String ingestLocationUri;
+
+  public CopyIntoCommandEdge(
+      String fileFormatName,
+      LogicalPlan copyIntoTargetRelation,
+      LogicalPlan copyIntoSourceRelation,
+      String ingestLocationUri) {
+    this.fileFormatName = fileFormatName;
+    this.copyIntoTargetRelation = copyIntoTargetRelation;
+    this.copyIntoSourceRelation = copyIntoSourceRelation;
+    this.ingestLocationUri = ingestLocationUri;
+  }
+}

--- a/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
+++ b/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
@@ -20,6 +20,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
  * covariant {@code withNewChildrenInternal} override. The reflective extraction works on plain
  * objects, so the fixture exercises the same code the runtime hits.
  */
+@SuppressWarnings("PMD.UnusedPrivateField") // fields are read by CopyIntoCommandUtils via reflection
 public class CopyIntoCommandEdge {
 
   private final String fileFormatName;

--- a/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
+++ b/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
@@ -20,7 +20,8 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
  * covariant {@code withNewChildrenInternal} override. The reflective extraction works on plain
  * objects, so the fixture exercises the same code the runtime hits.
  */
-@SuppressWarnings("PMD.UnusedPrivateField") // fields are read by CopyIntoCommandUtils via reflection
+@SuppressWarnings(
+    "PMD.UnusedPrivateField") // fields are read by CopyIntoCommandUtils via reflection
 public class CopyIntoCommandEdge {
 
   private final String fileFormatName;

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.junit.jupiter.api.Test;
+
+class CopyIntoCommandInputDatasetBuilderTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  CopyIntoCommandInputDatasetBuilder builder = new CopyIntoCommandInputDatasetBuilder(context);
+
+  @Test
+  void testIsNotDefinedForNonCopyIntoPlans() {
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
@@ -5,22 +5,80 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
 
 class CopyIntoCommandInputDatasetBuilderTest {
 
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
   OpenLineageContext context = mock(OpenLineageContext.class);
   CopyIntoCommandInputDatasetBuilder builder = new CopyIntoCommandInputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
 
   @Test
   void testIsNotDefinedForNonCopyIntoPlans() {
     assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
     assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+  }
+
+  @Test
+  void testApplyDelegatesWhenOnlySourceQueryIsPresent() {
+    LogicalPlan command = mock(LogicalPlan.class);
+    LogicalPlan sourceQuery = mock(LogicalPlan.class);
+    givenInputVisitorReturning("source_table", "unity-catalog");
+
+    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.sourcePath(command)).thenReturn(Optional.empty());
+      utils.when(() -> CopyIntoCommandUtils.sourceQuery(command)).thenReturn(Optional.of(sourceQuery));
+
+      List<InputDataset> inputs = builder.apply(event, command);
+
+      assertThat(inputs)
+          .singleElement()
+          .hasFieldOrPropertyWithValue("name", "source_table")
+          .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  private void givenInputVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<InputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<InputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return true;
+          }
+
+          @Override
+          public List<InputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newInputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getInputDatasetQueryPlanVisitors())
+        .thenReturn(Collections.singletonList(visitor));
+    when(context.getInputDatasetBuilders()).thenReturn(Collections.emptyList());
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
@@ -50,8 +50,11 @@ class CopyIntoCommandInputDatasetBuilderTest {
     givenInputVisitorReturning("source_table", "unity-catalog");
 
     try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.isCopyIntoCommand(command)).thenReturn(true);
       utils.when(() -> CopyIntoCommandUtils.sourcePath(command)).thenReturn(Optional.empty());
-      utils.when(() -> CopyIntoCommandUtils.sourceQuery(command)).thenReturn(Optional.of(sourceQuery));
+      utils
+          .when(() -> CopyIntoCommandUtils.sourceQuery(command))
+          .thenReturn(Optional.of(sourceQuery));
 
       List<InputDataset> inputs = builder.apply(event, command);
 
@@ -77,8 +80,7 @@ class CopyIntoCommandInputDatasetBuilderTest {
           }
         };
 
-    when(context.getInputDatasetQueryPlanVisitors())
-        .thenReturn(Collections.singletonList(visitor));
+    when(context.getInputDatasetQueryPlanVisitors()).thenReturn(Collections.singletonList(visitor));
     when(context.getInputDatasetBuilders()).thenReturn(Collections.emptyList());
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
@@ -50,6 +50,7 @@ class CopyIntoCommandOutputDatasetBuilderTest {
     LogicalPlan command = mock(LogicalPlan.class);
 
     try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.isCopyIntoCommand(command)).thenReturn(true);
       utils
           .when(() -> CopyIntoCommandUtils.target(command))
           .thenReturn(Optional.of(new OneRowRelation()));
@@ -60,17 +61,6 @@ class CopyIntoCommandOutputDatasetBuilderTest {
           .singleElement()
           .hasFieldOrPropertyWithValue("name", "copy_into_table")
           .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
-    }
-  }
-
-  @Test
-  void testApplyWhenTargetIsMissing() {
-    LogicalPlan command = mock(LogicalPlan.class);
-
-    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
-      utils.when(() -> CopyIntoCommandUtils.target(command)).thenReturn(Optional.empty());
-
-      assertThat(builder.apply(event, command)).isEmpty();
     }
   }
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.junit.jupiter.api.Test;
+
+class CopyIntoCommandOutputDatasetBuilderTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  CopyIntoCommandOutputDatasetBuilder builder = new CopyIntoCommandOutputDatasetBuilder(context);
+
+  @Test
+  void testIsNotDefinedForNonCopyIntoPlans() {
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
@@ -5,22 +5,92 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
 
 class CopyIntoCommandOutputDatasetBuilderTest {
 
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
   OpenLineageContext context = mock(OpenLineageContext.class);
   CopyIntoCommandOutputDatasetBuilder builder = new CopyIntoCommandOutputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
 
   @Test
   void testIsNotDefinedForNonCopyIntoPlans() {
     assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
     assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+  }
+
+  @Test
+  void testApplyEmitsTargetAsOutput() {
+    givenTargetVisitorReturning("copy_into_table", "unity-catalog");
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils
+          .when(() -> CopyIntoCommandUtils.target(command))
+          .thenReturn(Optional.of(new OneRowRelation()));
+
+      List<OutputDataset> outputs = builder.apply(event, command);
+
+      assertThat(outputs)
+          .singleElement()
+          .hasFieldOrPropertyWithValue("name", "copy_into_table")
+          .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  @Test
+  void testApplyWhenTargetIsMissing() {
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.target(command)).thenReturn(Optional.empty());
+
+      assertThat(builder.apply(event, command)).isEmpty();
+    }
+  }
+
+  private void givenTargetVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<OutputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<OutputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return x instanceof OneRowRelation;
+          }
+
+          @Override
+          public List<OutputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newOutputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getOutputDatasetQueryPlanVisitors())
+        .thenReturn(Collections.singletonList(visitor));
+    when(context.getOutputDatasetBuilders()).thenReturn(Collections.emptyList());
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DeleteUpdateCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DeleteUpdateCommandOutputDatasetBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DeleteUpdateCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
+
+class DeleteUpdateCommandOutputDatasetBuilderTest {
+
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  DeleteUpdateCommandOutputDatasetBuilder builder =
+      new DeleteUpdateCommandOutputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+
+  @Test
+  void testIsNotDefinedAtOtherPlans() {
+    assertFalse(builder.isDefinedAtLogicalPlan(new OneRowRelation()));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(DeleteFromTable.class)));
+  }
+
+  @Test
+  void testApplyEmitsTargetAsOutput() {
+    givenTargetVisitorReturning("delete_table", "unity-catalog");
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<DeleteUpdateCommandUtils> utils =
+        mockStatic(DeleteUpdateCommandUtils.class)) {
+      utils
+          .when(() -> DeleteUpdateCommandUtils.target(command))
+          .thenReturn(Optional.of(new OneRowRelation()));
+
+      List<OutputDataset> outputs = builder.apply(event, command);
+
+      assertThat(outputs)
+          .singleElement()
+          .hasFieldOrPropertyWithValue("name", "delete_table")
+          .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  @Test
+  void testApplyWhenTargetIsMissing() {
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<DeleteUpdateCommandUtils> utils =
+        mockStatic(DeleteUpdateCommandUtils.class)) {
+      utils.when(() -> DeleteUpdateCommandUtils.target(command)).thenReturn(Optional.empty());
+
+      assertThat(builder.apply(event, command)).isEmpty();
+    }
+  }
+
+  private void givenTargetVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<OutputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<OutputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return x instanceof OneRowRelation;
+          }
+
+          @Override
+          public List<OutputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newOutputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getOutputDatasetQueryPlanVisitors())
+        .thenReturn(Collections.singletonList(visitor));
+    when(context.getOutputDatasetBuilders()).thenReturn(Collections.emptyList());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeInputDatasetBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
+
+class TableContentChangeInputDatasetBuilderTest {
+
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  TableContentChangeInputDatasetBuilder builder =
+      new TableContentChangeInputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+
+  @Test
+  void testIsDefinedAtLogicalPlan() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(DeleteFromTable.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(UpdateTable.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyCollectsInputsFromSubqueries() {
+    givenSubqueryVisitorReturning("subquery_table", "subquery_namespace");
+
+    DeleteFromTable plan = mock(DeleteFromTable.class);
+    when(plan.subqueries())
+        .thenReturn(
+            ScalaConversionUtils.fromList(
+                Collections.<LogicalPlan>singletonList(new OneRowRelation())));
+
+    List<InputDataset> inputs = builder.apply(event, plan);
+
+    assertThat(inputs)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "subquery_table")
+        .hasFieldOrPropertyWithValue("namespace", "subquery_namespace");
+  }
+
+  @Test
+  void testApplyWithoutSubqueries() {
+    givenSubqueryVisitorReturning("subquery_table", "subquery_namespace");
+
+    UpdateTable plan = mock(UpdateTable.class);
+    when(plan.subqueries()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
+
+    assertThat(builder.apply(event, plan)).isEmpty();
+  }
+
+  /**
+   * Registers a visitor that turns the subquery plan node into a known dataset, standing in for the
+   * relation builders that resolve a real table.
+   */
+  private void givenSubqueryVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<InputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<InputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return x instanceof OneRowRelation;
+          }
+
+          @Override
+          public List<InputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newInputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getInputDatasetQueryPlanVisitors()).thenReturn(Collections.singletonList(visitor));
+    when(context.getInputDatasetBuilders()).thenReturn(Collections.emptyList());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
@@ -85,7 +85,8 @@ class CopyIntoCommandUtilsTest {
   @Test
   void testTargetIsEmptyWhenNoMemberIsCatalogBacked() {
     CopyIntoCommandEdge command =
-        new CopyIntoCommandEdge(FILE_FORMAT, new OneRowRelation(), new OneRowRelation(), VOLUME_PATH);
+        new CopyIntoCommandEdge(
+            FILE_FORMAT, new OneRowRelation(), new OneRowRelation(), VOLUME_PATH);
 
     assertThat(CopyIntoCommandUtils.targetFromCommand(command)).isEmpty();
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
@@ -18,6 +18,7 @@ import scala.Option;
 
 class CopyIntoCommandUtilsTest {
 
+  private static final String FILE_FORMAT = "CSV";
   private static final String VOLUME_PATH =
       "/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input";
 
@@ -57,7 +58,7 @@ class CopyIntoCommandUtilsTest {
   void testTargetFromMemberWithUnknownName() {
     DataSourceV2Relation targetRelation = catalogRelation();
     CopyIntoCommandEdge command =
-        new CopyIntoCommandEdge("CSV", targetRelation, new OneRowRelation(), VOLUME_PATH);
+        new CopyIntoCommandEdge(FILE_FORMAT, targetRelation, new OneRowRelation(), VOLUME_PATH);
 
     assertThat(CopyIntoCommandUtils.targetFromCommand(command)).contains(targetRelation);
   }
@@ -65,7 +66,7 @@ class CopyIntoCommandUtilsTest {
   @Test
   void testSourcePathFromMemberWithUnknownName() {
     CopyIntoCommandEdge command =
-        new CopyIntoCommandEdge("CSV", catalogRelation(), new OneRowRelation(), VOLUME_PATH);
+        new CopyIntoCommandEdge(FILE_FORMAT, catalogRelation(), new OneRowRelation(), VOLUME_PATH);
 
     assertThat(CopyIntoCommandUtils.sourcePathFromCommand(command)).contains(VOLUME_PATH);
   }
@@ -75,7 +76,7 @@ class CopyIntoCommandUtilsTest {
     DataSourceV2Relation targetRelation = catalogRelation();
     OneRowRelation sourceRelation = new OneRowRelation();
     CopyIntoCommandEdge command =
-        new CopyIntoCommandEdge("CSV", targetRelation, sourceRelation, VOLUME_PATH);
+        new CopyIntoCommandEdge(FILE_FORMAT, targetRelation, sourceRelation, VOLUME_PATH);
 
     assertThat(CopyIntoCommandUtils.sourceQueryFromCommand(command)).contains(sourceRelation);
   }
@@ -84,7 +85,7 @@ class CopyIntoCommandUtilsTest {
   @Test
   void testTargetIsEmptyWhenNoMemberIsCatalogBacked() {
     CopyIntoCommandEdge command =
-        new CopyIntoCommandEdge("CSV", new OneRowRelation(), new OneRowRelation(), VOLUME_PATH);
+        new CopyIntoCommandEdge(FILE_FORMAT, new OneRowRelation(), new OneRowRelation(), VOLUME_PATH);
 
     assertThat(CopyIntoCommandUtils.targetFromCommand(command)).isEmpty();
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
@@ -1,0 +1,27 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CopyIntoCommandUtilsTest {
+
+  @Test
+  void testMatchesCommandClassName() {
+    assertThat(
+            CopyIntoCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.CopyIntoCommand"))
+        .isTrue();
+    assertThat(
+            CopyIntoCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.CopyIntoCommandEdge"))
+        .isTrue();
+    assertThat(CopyIntoCommandUtils.matchesCommandClassName("AppendData")).isFalse();
+    assertThat(CopyIntoCommandUtils.matchesCommandClassName(null)).isFalse();
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
@@ -7,7 +7,9 @@ package io.openlineage.spark3.agent.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class CopyIntoCommandUtilsTest {
 
@@ -23,5 +25,13 @@ class CopyIntoCommandUtilsTest {
         .isTrue();
     assertThat(CopyIntoCommandUtils.matchesCommandClassName("AppendData")).isFalse();
     assertThat(CopyIntoCommandUtils.matchesCommandClassName(null)).isFalse();
+  }
+
+  @Test
+  void testTargetWhenCommandHasNoSuchMember() {
+    LogicalPlan plan = Mockito.mock(LogicalPlan.class);
+    assertThat(CopyIntoCommandUtils.target(plan)).isEmpty();
+    assertThat(CopyIntoCommandUtils.sourcePath(plan)).isEmpty();
+    assertThat(CopyIntoCommandUtils.sourceQuery(plan)).isEmpty();
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
@@ -7,11 +7,19 @@ package io.openlineage.spark3.agent.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.databricks.sql.transaction.tahoe.commands.CopyIntoCommandEdge;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import scala.Option;
 
 class CopyIntoCommandUtilsTest {
+
+  private static final String VOLUME_PATH =
+      "/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input";
 
   @Test
   void testMatchesCommandClassName() {
@@ -23,6 +31,10 @@ class CopyIntoCommandUtilsTest {
             CopyIntoCommandUtils.matchesCommandClassName(
                 "com.databricks.sql.transaction.tahoe.commands.CopyIntoCommandEdge"))
         .isTrue();
+    assertThat(
+            CopyIntoCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.edge.CopyIntoCommandEdge"))
+        .isTrue();
     assertThat(CopyIntoCommandUtils.matchesCommandClassName("AppendData")).isFalse();
     assertThat(CopyIntoCommandUtils.matchesCommandClassName(null)).isFalse();
   }
@@ -33,5 +45,56 @@ class CopyIntoCommandUtilsTest {
     assertThat(CopyIntoCommandUtils.target(plan)).isEmpty();
     assertThat(CopyIntoCommandUtils.sourcePath(plan)).isEmpty();
     assertThat(CopyIntoCommandUtils.sourceQuery(plan)).isEmpty();
+  }
+
+  /**
+   * On Databricks the emitted event carried a name-only {@code unity-catalog} dataset instead of
+   * the storage location that {@code DELETE} produces for the same table. That happens when the
+   * target relation is never found and the builder degrades to parsing the SQL text, so extraction
+   * must not depend on the command spelling its members {@code target} / {@code sourcePath}.
+   */
+  @Test
+  void testTargetFromMemberWithUnknownName() {
+    DataSourceV2Relation targetRelation = catalogRelation();
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge("CSV", targetRelation, new OneRowRelation(), VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.targetFromCommand(command)).contains(targetRelation);
+  }
+
+  @Test
+  void testSourcePathFromMemberWithUnknownName() {
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge("CSV", catalogRelation(), new OneRowRelation(), VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.sourcePathFromCommand(command)).contains(VOLUME_PATH);
+  }
+
+  @Test
+  void testSourceQueryIsNotTheTargetRelation() {
+    DataSourceV2Relation targetRelation = catalogRelation();
+    OneRowRelation sourceRelation = new OneRowRelation();
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge("CSV", targetRelation, sourceRelation, VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.sourceQueryFromCommand(command)).contains(sourceRelation);
+  }
+
+  /** A source scan must never be reported as the table the statement wrote to. */
+  @Test
+  void testTargetIsEmptyWhenNoMemberIsCatalogBacked() {
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge("CSV", new OneRowRelation(), new OneRowRelation(), VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.targetFromCommand(command)).isEmpty();
+  }
+
+  /** A catalog-backed target, which is what makes the delegate emit Unity Catalog identity. */
+  private static DataSourceV2Relation catalogRelation() {
+    DataSourceV2Relation relation = Mockito.mock(DataSourceV2Relation.class);
+    Mockito.when(relation.identifier())
+        .thenReturn(
+            Option.apply(Identifier.of(new String[] {"openlineage_dml"}, "copy_into_table")));
+    return relation;
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CopyIntoSqlUtilsTest {
+
+  private static final String SQL =
+      "COPY INTO copy_into_table\n"
+          + "FROM '/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input'\n"
+          + "FILEFORMAT = CSV\n"
+          + "FORMAT_OPTIONS (\n"
+          + "    'header' = 'true',\n"
+          + "    'inferSchema' = 'true'\n"
+          + ")";
+
+  @Test
+  void testParsesTargetTable() {
+    assertThat(CopyIntoSqlUtils.targetTable(SQL)).contains("copy_into_table");
+  }
+
+  @Test
+  void testParsesSourcePath() {
+    assertThat(CopyIntoSqlUtils.sourcePath(SQL))
+        .contains("/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input");
+  }
+
+  @Test
+  void testDetectsCopyIntoStatement() {
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement(SQL)).isTrue();
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement("SELECT 1")).isFalse();
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -49,6 +49,8 @@ import org.mockito.MockedStatic;
 import scala.Option;
 
 class DataSourceV2RelationDatasetExtractorTest {
+  private static final String NAME = "name";
+
   OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
   SparkSession sparkSession = mock(SparkSession.class);
   DatasetFactory<Dataset> datasetFactory = mock(DatasetFactory.class);
@@ -80,7 +82,7 @@ class DataSourceV2RelationDatasetExtractorTest {
       try (MockedStatic<PlanUtils> mockedPlanUtils = mockStatic(PlanUtils.class)) {
         DatasetIdentifier di = mock(DatasetIdentifier.class);
         when(di.getNamespace()).thenReturn("file://tmp");
-        when(di.getName()).thenReturn("name");
+        when(di.getName()).thenReturn(NAME);
 
         OpenLineage.DatasetFacets datasetFacets = mock(OpenLineage.DatasetFacets.class);
         OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
@@ -218,7 +220,7 @@ class DataSourceV2RelationDatasetExtractorTest {
 
     assertEquals(1, result.size());
     assertThat(result.get(0))
-        .hasFieldOrPropertyWithValue("name", "some-name")
+        .hasFieldOrPropertyWithValue(NAME, "some-name")
         .hasFieldOrPropertyWithValue("namespace", "some-namespace");
 
     OpenLineage.DatasetFacet datasetFacet =
@@ -264,7 +266,7 @@ class DataSourceV2RelationDatasetExtractorTest {
 
     assertEquals(1, result.size());
     assertThat(result.get(0))
-        .hasFieldOrPropertyWithValue("name", "bigquery-public-data.samples.shakespeare")
+        .hasFieldOrPropertyWithValue(NAME, "bigquery-public-data.samples.shakespeare")
         .hasFieldOrPropertyWithValue("namespace", "bigquery");
   }
 
@@ -303,7 +305,7 @@ class DataSourceV2RelationDatasetExtractorTest {
 
           assertEquals(1, result.size());
           assertThat(result.get(0))
-              .hasFieldOrPropertyWithValue("name", "catalog.db.table")
+              .hasFieldOrPropertyWithValue(NAME, "catalog.db.table")
               .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
         }
       }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -292,7 +292,8 @@ class DataSourceV2RelationDatasetExtractorTest {
                   () ->
                       PlanUtils3.getDatasetIdentifier(
                           openLineageContext, tableCatalog, identifier, tableProperties))
-              .thenThrow(new IllegalStateException("no default path for a unity catalog namespace"));
+              .thenThrow(
+                  new IllegalStateException("no default path for a unity catalog namespace"));
 
           DatasetFactory<OpenLineage.OutputDataset> outputFactory =
               DatasetFactory.output(openLineageContext);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -20,6 +20,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -31,6 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -263,6 +266,47 @@ class DataSourceV2RelationDatasetExtractorTest {
     assertThat(result.get(0))
         .hasFieldOrPropertyWithValue("name", "bigquery-public-data.samples.shakespeare")
         .hasFieldOrPropertyWithValue("namespace", "bigquery");
+  }
+
+  @Test
+  void testExtractFallsBackToUnityCatalogNameWhenLocationResolutionFails() {
+    SparkConf sparkConf = new SparkConf();
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    when(dataSourceV2Relation.schema()).thenReturn(new StructType());
+
+    try (MockedStatic<PlanUtils3> planUtils = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic<DatabricksUtils> databricks = mockStatic(DatabricksUtils.class)) {
+        try (MockedStatic<PlanUtils> mockedPlanUtils = mockStatic(PlanUtils.class)) {
+          databricks
+              .when(() -> DatabricksUtils.isDatabricksUnityCatalogEnabled(sparkConf))
+              .thenReturn(true);
+          databricks
+              .when(() -> DatabricksUtils.qualifiedUnityCatalogTableName(tableCatalog, identifier))
+              .thenReturn("catalog.db.table");
+          planUtils
+              .when(
+                  () ->
+                      PlanUtils3.getDatasetIdentifier(
+                          openLineageContext, tableCatalog, identifier, tableProperties))
+              .thenThrow(new IllegalStateException("no default path for a unity catalog namespace"));
+
+          DatasetFactory<OpenLineage.OutputDataset> outputFactory =
+              DatasetFactory.output(openLineageContext);
+          List<OpenLineage.OutputDataset> result =
+              DataSourceV2RelationDatasetExtractor.extract(
+                  outputFactory, openLineageContext, dataSourceV2Relation, false);
+
+          assertEquals(1, result.size());
+          assertThat(result.get(0))
+              .hasFieldOrPropertyWithValue("name", "catalog.db.table")
+              .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+        }
+      }
+    }
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DeleteUpdateCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DeleteUpdateCommandUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.junit.jupiter.api.Test;
+
+class DeleteUpdateCommandUtilsTest {
+
+  @Test
+  void testMatchesCommandClassName() {
+    assertThat(
+            DeleteUpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.DeleteCommandEdge"))
+        .isTrue();
+    assertThat(
+            DeleteUpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.UpdateCommandEdge"))
+        .isTrue();
+    assertThat(
+            DeleteUpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.DeleteCommand"))
+        .isTrue();
+    assertThat(
+            DeleteUpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.UpdateCommand"))
+        .isTrue();
+    assertThat(DeleteUpdateCommandUtils.matchesCommandClassName("DeleteFromTable")).isFalse();
+    assertThat(DeleteUpdateCommandUtils.matchesCommandClassName(null)).isFalse();
+  }
+
+  @Test
+  void testTargetWhenCommandHasNoSuchMember() {
+    assertThat(DeleteUpdateCommandUtils.target(new OneRowRelation())).isEmpty();
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+class UnityCatalogTableDatasetUtilsTest {
+
+  private static final String CATALOG = "sangeeta_catalog";
+  private static final String SCHEMA = "openlineage_dml";
+  private static final String TABLE = "copy_into_table";
+
+  @Test
+  void resolveUsesV2CatalogWhenLegacyLookupIsUnavailable() throws Exception {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    SparkSession session = mock(SparkSession.class);
+    TableCatalog tableCatalog = mock(TableCatalog.class);
+    Table table = mock(Table.class);
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    Identifier v2Identifier = Identifier.of(new String[] {SCHEMA}, TABLE);
+    DatasetIdentifier datasetIdentifier =
+        new DatasetIdentifier("unity-catalog/path", "s3://bucket");
+
+    when(tableIdentifier.database()).thenReturn(Option.apply(SCHEMA));
+    when(tableIdentifier.table()).thenReturn(TABLE);
+    when(table.properties()).thenReturn(Collections.singletonMap("location", "s3://bucket/path"));
+    when(table.schema()).thenReturn(new StructType());
+    when(tableCatalog.loadTable(v2Identifier)).thenReturn(table);
+
+    try (MockedStatic<SparkSessionUtils> sparkSessionUtils = mockStatic(SparkSessionUtils.class);
+        MockedStatic<PlanUtils3> planUtils3 = mockStatic(PlanUtils3.class);
+        MockedStatic<MethodUtils> methodUtils = mockStatic(MethodUtils.class)) {
+      methodUtils
+          .when(() -> MethodUtils.invokeMethod(tableIdentifier, "catalog"))
+          .thenReturn(Option.apply(CATALOG));
+      sparkSessionUtils
+          .when(() -> SparkSessionUtils.catalog(session, CATALOG))
+          .thenReturn(Optional.of(tableCatalog));
+      planUtils3
+          .when(
+              () ->
+                  PlanUtils3.getDatasetIdentifier(
+                      context, tableCatalog, v2Identifier, table.properties()))
+          .thenReturn(Optional.of(datasetIdentifier));
+
+      Optional<UnityCatalogTableDatasetUtils.ResolvedTableDataset> resolved =
+          UnityCatalogTableDatasetUtils.resolve(context, session, tableIdentifier);
+
+      assertThat(resolved).isPresent();
+      assertThat(resolved.get().getDatasetIdentifier()).isEqualTo(datasetIdentifier);
+      assertThat(resolved.get().getIdentifier()).isEqualTo(v2Identifier);
+    }
+  }
+}

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -9,19 +9,18 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
-import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
-import java.lang.reflect.InvocationTargetException;
+import io.openlineage.spark3.agent.utils.V2CreateTablePlanUtils;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
@@ -38,6 +37,10 @@ import org.apache.spark.sql.types.StructType;
  * {@link LogicalPlan} visitor that matches an {@link CreateTableAsSelect} and extracts the output
  * {@link OpenLineage.Dataset} being written. Although the builder is within spark35 package, it's
  * added as a dataset builder for Spark 3.4 on Databricks runtime.
+ *
+ * <p>Plan members are read through {@link V2CreateTablePlanUtils} because Databricks runtimes
+ * change the signatures of these nodes, and a {@link NoSuchMethodError} here would leave the event
+ * without any output dataset.
  */
 @Slf4j
 public class CreateReplaceOutputDatasetBuilder
@@ -62,88 +65,28 @@ public class CreateReplaceOutputDatasetBuilder
 
   @Override
   protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
-    if (plan instanceof CreateTableAsSelect) {
-      return apply(event, (CreateTableAsSelect) plan);
-    } else if (plan instanceof ReplaceTableAsSelect) {
-      return apply(event, (ReplaceTableAsSelect) plan);
-    } else if (plan instanceof CreateTable) {
-      return apply(event, (CreateTable) plan);
-    } else {
-      return apply(event, (ReplaceTable) plan);
+    Optional<TableCatalog> catalog = V2CreateTablePlanUtils.catalog(plan);
+    Optional<Identifier> identifier = V2CreateTablePlanUtils.identifier(plan);
+
+    if (!catalog.isPresent() || !identifier.isPresent()) {
+      log.warn(
+          "Could not obtain catalog and identifier from {}", plan.getClass().getCanonicalName());
+      return Collections.emptyList();
     }
+
+    return apply(
+        event,
+        catalog.get(),
+        V2CreateTablePlanUtils.properties(plan),
+        identifier.get(),
+        V2CreateTablePlanUtils.schema(plan),
+        lifecycleStateChange(plan));
   }
 
-  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, CreateTable plan) {
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.CREATE))
-        .orElse(Collections.emptyList());
-  }
-
-  protected List<OpenLineage.OutputDataset> apply(
-      SparkListenerEvent event, CreateTableAsSelect plan) {
-    Map<String, String> tableProperties =
-        new HashMap(ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()));
-    tableProperties.putAll(ScalaConversionUtils.<String, String>fromMap(plan.writeOptions()));
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    tableProperties,
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.CREATE))
-        .orElse(Collections.emptyList());
-  }
-
-  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, ReplaceTable plan) {
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.OVERWRITE))
-        .orElse(Collections.emptyList());
-  }
-
-  protected List<OpenLineage.OutputDataset> apply(
-      SparkListenerEvent event, ReplaceTableAsSelect plan) {
-    Map<String, String> tableProperties =
-        new HashMap(ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()));
-    tableProperties.putAll(ScalaConversionUtils.<String, String>fromMap(plan.writeOptions()));
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    tableProperties,
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.OVERWRITE))
-        .orElse(Collections.emptyList());
-  }
-
-  private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
-    try {
-      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", (Object[]) null));
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-      log.error("Could not obtain catalog plugin", e);
-      return Optional.empty();
-    }
+  private static LifecycleStateChange lifecycleStateChange(LogicalPlan plan) {
+    return (plan instanceof ReplaceTable || plan instanceof ReplaceTableAsSelect)
+        ? LifecycleStateChange.OVERWRITE
+        : LifecycleStateChange.CREATE;
   }
 
   private List<OpenLineage.OutputDataset> apply(
@@ -154,8 +97,7 @@ public class CreateReplaceOutputDatasetBuilder
       StructType schema,
       LifecycleStateChange lifecycleStateChange) {
 
-    Optional<DatasetIdentifier> di =
-        PlanUtils3.getDatasetIdentifier(context, catalog, identifier, tableProperties);
+    Optional<DatasetIdentifier> di = datasetIdentifier(catalog, identifier, tableProperties);
 
     if (!di.isPresent()) {
       return Collections.emptyList();
@@ -168,14 +110,70 @@ public class CreateReplaceOutputDatasetBuilder
             .schema(schema)
             .lifecycleStateChange(lifecycleStateChange);
 
-    if (includeDatasetVersion(event)) {
-      CatalogUtils.getDatasetVersion(context, catalog, identifier, tableProperties)
-          .ifPresent(sparkBuilder::version);
+    // A catalog that cannot describe the table must not cost the output dataset itself
+    try {
+      if (includeDatasetVersion(event)) {
+        CatalogUtils.getDatasetVersion(context, catalog, identifier, tableProperties)
+            .ifPresent(sparkBuilder::version);
+      }
+      CatalogUtils.addStorageAndCatalogFacets(
+          context, catalog, tableProperties, sparkBuilder.getInner());
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not add catalog facets of table {}", identifier, e);
     }
 
-    CatalogUtils.addStorageAndCatalogFacets(
-        context, catalog, tableProperties, sparkBuilder.getInner());
     return Collections.singletonList(sparkBuilder.build());
+  }
+
+  private Optional<DatasetIdentifier> datasetIdentifier(
+      TableCatalog catalog, Identifier identifier, Map<String, String> tableProperties) {
+    Optional<DatasetIdentifier> di;
+    try {
+      di = PlanUtils3.getDatasetIdentifier(context, catalog, identifier, tableProperties);
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not resolve dataset identifier of table {}", identifier, e);
+      di = Optional.empty();
+    }
+
+    if (di.isPresent()) {
+      return di;
+    }
+
+    Optional<DatasetIdentifier> fallback = unityCatalogIdentifier(catalog, identifier);
+    if (!fallback.isPresent()) {
+      log.warn(
+          "No dataset identifier resolved for table {} of catalog {}",
+          identifier,
+          catalog.getClass().getCanonicalName());
+    }
+    return fallback;
+  }
+
+  /**
+   * Unity Catalog managed tables have no location available at the time the create command is
+   * built, and the session catalog cannot resolve a default path for a Unity Catalog namespace. In
+   * that case the table is identified by its {@code catalog.schema.table} name, which is the same
+   * name attached as a symlink when the location is known, so both forms refer to the same table.
+   */
+  private Optional<DatasetIdentifier> unityCatalogIdentifier(
+      TableCatalog catalog, Identifier identifier) {
+    boolean unityCatalogEnabled =
+        context
+            .getSparkContext()
+            .map(SparkContext::getConf)
+            .map(DatabricksUtils::isDatabricksUnityCatalogEnabled)
+            .orElse(false);
+
+    if (!unityCatalogEnabled) {
+      return Optional.empty();
+    }
+
+    String name = DatabricksUtils.qualifiedUnityCatalogTableName(catalog, identifier);
+    log.warn(
+        "Could not resolve the location of Unity Catalog table {}, falling back to its qualified name",
+        name);
+    return Optional.of(
+        new DatasetIdentifier(name, DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE));
   }
 
   @Override
@@ -184,17 +182,6 @@ public class CreateReplaceOutputDatasetBuilder
       return Optional.empty();
     }
 
-    Identifier identifier = null;
-    if (plan instanceof CreateTableAsSelect) {
-      identifier = ((CreateTableAsSelect) plan).tableName();
-    } else if (plan instanceof ReplaceTable) {
-      identifier = ((ReplaceTable) plan).tableName();
-    } else if (plan instanceof ReplaceTableAsSelect) {
-      identifier = ((ReplaceTableAsSelect) plan).tableName();
-    } else if (plan instanceof CreateTable) {
-      identifier = ((CreateTable) plan).tableName();
-    }
-
-    return Optional.of(identToSuffix(identifier));
+    return V2CreateTablePlanUtils.identifier(plan).map(this::identToSuffix);
   }
 }

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -53,6 +53,8 @@ import scala.collection.immutable.Map;
 class CreateReplaceDatasetBuilderTest {
 
   private static final String TABLE = "table";
+  private static final String SOME_KEY = "some-key";
+  private static final String SOME_VALUE = "some-value";
   SparkContext sparkContext = mock(SparkContext.class);
   OpenLineageContext openLineageContext =
       OpenLineageContext.builder()
@@ -103,7 +105,7 @@ class CreateReplaceDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.writeOptions())
         .thenReturn(
-            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
     verifyApply(
         (LogicalPlan) logicalPlan,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
@@ -130,7 +132,7 @@ class CreateReplaceDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.writeOptions())
         .thenReturn(
-            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
     verifyApply(
         (LogicalPlan) logicalPlan,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
@@ -247,7 +249,7 @@ class CreateReplaceDatasetBuilderTest {
       when(logicalPlan.tableSchema()).thenReturn(schema);
       when(logicalPlan.writeOptions())
           .thenReturn(
-              ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+              ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
 
       when(PlanUtils3.getDatasetIdentifier(
               openLineageContext,
@@ -271,7 +273,7 @@ class CreateReplaceDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.writeOptions())
         .thenReturn(
-            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
 
     verifyApply(
         (LogicalPlan) logicalPlan,

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -20,6 +20,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
@@ -27,6 +28,7 @@ import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
@@ -51,10 +53,11 @@ import scala.collection.immutable.Map;
 class CreateReplaceDatasetBuilderTest {
 
   private static final String TABLE = "table";
+  SparkContext sparkContext = mock(SparkContext.class);
   OpenLineageContext openLineageContext =
       OpenLineageContext.builder()
           .sparkSession(mock(SparkSession.class))
-          .sparkContext(mock(SparkContext.class))
+          .sparkContext(sparkContext)
           .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
           .meterRegistry(new SimpleMeterRegistry())
           .openLineageConfig(new SparkOpenLineageConfig())
@@ -257,6 +260,95 @@ class CreateReplaceDatasetBuilderTest {
           builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
       assertEquals(0, outputDatasets.size());
     }
+  }
+
+  @Test
+  void testApplyWhenTableSpecIsNotAvailable() {
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenThrow(new NoSuchMethodError("tableSpec"));
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    when(logicalPlan.writeOptions())
+        .thenReturn(
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+  }
+
+  @Test
+  void testApplyFallsBackToQuerySchema() {
+    StructType querySchema = new StructType().add("id", "int");
+    LogicalPlan query = mock(LogicalPlan.class);
+    when(query.schema()).thenReturn(querySchema);
+
+    CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenThrow(new NoSuchMethodError("tableSchema"));
+    when(logicalPlan.query()).thenReturn(query);
+    when(logicalPlan.writeOptions()).thenReturn(new HashMap<>());
+
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              eq(openLineageContext), eq(catalog), eq(tableName), anyMap()))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals(
+          "id", outputDatasets.get(0).getFacets().getSchema().getFields().get(0).getName());
+    }
+  }
+
+  @Test
+  void testApplyFallsBackToUnityCatalogName() {
+    SparkConf sparkConf = new SparkConf();
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    when(logicalPlan.writeOptions()).thenReturn(new HashMap<>());
+
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic<DatabricksUtils> databricks = mockStatic(DatabricksUtils.class)) {
+        databricks
+            .when(() -> DatabricksUtils.isDatabricksUnityCatalogEnabled(sparkConf))
+            .thenReturn(true);
+        databricks
+            .when(() -> DatabricksUtils.qualifiedUnityCatalogTableName(catalog, tableName))
+            .thenReturn("catalog.db.table");
+        when(PlanUtils3.getDatasetIdentifier(
+                eq(openLineageContext), eq(catalog), eq(tableName), anyMap()))
+            .thenThrow(new IllegalStateException("no default path for a unity catalog namespace"));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals("catalog.db.table", outputDatasets.get(0).getName());
+        assertEquals("unity-catalog", outputDatasets.get(0).getNamespace());
+      }
+    }
+  }
+
+  @Test
+  void testApplyWhenCatalogCannotBeResolved() {
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(mock(LogicalPlan.class));
+    when(logicalPlan.tableName()).thenReturn(tableName);
+
+    assertThat(builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan))
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
-->

closes: #4807

### One-line summary for changelog:
Fix missing Databricks Spark lineage for CTAS outputs, COPY INTO (including Spark 4.0 `CopyIntoCommandEdge` with storage-backed Unity Catalog identity), DELETE/UPDATE (output and subquery inputs), and LOAD DATA source paths on Unity Catalog.


### Meaningful description

On Databricks Runtime with Unity Catalog, several DDL/DML statements produced incomplete or empty OpenLineage events:

| Statement | Before |
|-----------|--------|
| `CREATE [OR REPLACE] TABLE … AS SELECT` | Source tables in `inputs`, **empty `outputs`** |
| `COPY INTO` | empty inputs and outputs |
| `DELETE FROM` / `UPDATE` | **Empty event** on tahoe `DeleteCommandEdge` / `UpdateCommandEdge` |
| `DELETE` / `UPDATE` with subquery | Subquery tables missing from `inputs` |
| `LOAD DATA` | Target in `outputs` only; source path absent from `inputs` |

**Root causes:** Databricks resolves SQL to proprietary tahoe plan nodes not on the compile classpath; catalyst signature drift caused `NoSuchMethodError` in CTAS output builders (swallowed by `safeApply`); COPY INTO `CopyIntoCommandEdge` renames command members between runtimes so hard-coded accessor lists miss; resolving the target via `session.table()` in the SparkListener thread re-analyzes Unity Catalog without credential scope; DELETE/UPDATE tables in WHERE/SET live in expressions rather than plan children; LOAD DATA never emitted `command.path()` as an input; Unity Catalog managed tables sometimes lack a resolvable storage location without V2 catalog fallback.

**Solution:**

- **CTAS:** Read V2 create-table plan members reflectively (`V2CreateTablePlanUtils`); Unity Catalog qualified-name fallback when storage location is unavailable (`CreateReplaceOutputDatasetBuilder`).
- **COPY INTO:** Register `CopyIntoCommandInputDatasetBuilder` / `CopyIntoCommandOutputDatasetBuilder`; match `CopyIntoCommand` and `CopyIntoCommandEdge`; scan command fields for catalog-backed target and location-shaped source (not hard-coded names); parse SQL text as fallback (`CopyIntoSqlUtils`); resolve output through V2 catalog (`UnityCatalogTableDatasetUtils`) — **never** `session.table()`; build file inputs with `PathUtils.fromPath`. Validated on DBR: output matches DELETE (`s3://…` namespace, `storage` / `schema` / `catalog` / `symlinks` facets).
- **DELETE / UPDATE output:** Add `DeleteUpdateCommandOutputDatasetBuilder` + `DeleteUpdateCommandUtils` for tahoe delete/update commands.
- **DELETE / UPDATE inputs:** Extend `TableContentChangeInputDatasetBuilder` to call `subqueries()` on catalyst and tahoe delete/update nodes.
- **LOAD DATA:** Add `LoadDataCommandInputVisitor` for the source path.
- **UC dataset identity:** Extend `DataSourceV2RelationDatasetExtractor` with qualified-name fallback used for CTAS.

Plain `DELETE`/`UPDATE` remain **output-only** by design (target = modified dataset, not also an input).



**Tests:** Unit tests for all new builders/utils including tahoe `CopyIntoCommandEdge` fixture with non-standard member names; `CopyIntoSqlUtilsTest`; `UnityCatalogTableDatasetUtilsTest`; existing Spark module regression suites. Manual Databricks validation: CTAS, COPY INTO (`/Volumes/...` → UC table with storage-backed output), DELETE/UPDATE, LOAD DATA.

### Validation artifacts
Databricks validation notebook and captured OpenLineage events:

- Validation notebook: https://gist.github.com/mishrasangeeta87/3e16e755b7d16ec38c57959abaeda6df
- Before/After OpenLineage events inputs and outputs: https://gist.github.com/mishrasangeeta87/069530bae87a5964e179035ddcbcbbe2


### Checklist
- [x] AI was used in creating this PR
-  ⚠️ **AI Disclosure** — This pull request was generated with AI assistance (Cursor). All proposed changes were reviewed and validated by verifying the expected input and output lineage for the affected scenarios as specified under , Validation artifacts section.