### PR TITLE
clients: support dependentRequired in generators

### DIFF
--- a/client/go/pkg/facets/facets.gen.go
+++ b/client/go/pkg/facets/facets.gen.go
@@ -1198,6 +1198,37 @@ type LineageJobEntry struct {
 	Type LineageJobEntryType `json:"type"`
 }
 
+// Validate checks the dependentRequired constraints for LineageJobEntry.
+func (v LineageJobEntry) Validate() error {
+	if v.Name != nil && v.Namespace == nil {
+		return fmt.Errorf("property \"namespace\" is required when \"name\" is set")
+	}
+	if v.Namespace != nil && v.Name == nil {
+		return fmt.Errorf("property \"name\" is required when \"namespace\" is set")
+	}
+	return nil
+}
+
+// MarshalJSON validates LineageJobEntry before serialization.
+func (v LineageJobEntry) MarshalJSON() ([]byte, error) {
+	if err := v.Validate(); err != nil {
+		return nil, err
+	}
+	type plain LineageJobEntry
+	return json.Marshal(plain(v))
+}
+
+// UnmarshalJSON validates LineageJobEntry after deserialization.
+func (v *LineageJobEntry) UnmarshalJSON(data []byte) error {
+	type plain LineageJobEntry
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*v = LineageJobEntry(decoded)
+	return v.Validate()
+}
+
 // LineageJobInput — A source job that feeds data into a lineage target. Without namespace and name, the source is the event's own job.
 type LineageJobInput struct {
 	// The name of the source job. Omit together with namespace to refer to the event's own job.
@@ -1210,6 +1241,37 @@ type LineageJobInput struct {
 	Transformations []LineageTransformation `json:"transformations,omitempty"`
 	// The source entity type. Must be JOB.
 	Type LineageJobInputType `json:"type"`
+}
+
+// Validate checks the dependentRequired constraints for LineageJobInput.
+func (v LineageJobInput) Validate() error {
+	if v.Name != nil && v.Namespace == nil {
+		return fmt.Errorf("property \"namespace\" is required when \"name\" is set")
+	}
+	if v.Namespace != nil && v.Name == nil {
+		return fmt.Errorf("property \"name\" is required when \"namespace\" is set")
+	}
+	return nil
+}
+
+// MarshalJSON validates LineageJobInput before serialization.
+func (v LineageJobInput) MarshalJSON() ([]byte, error) {
+	if err := v.Validate(); err != nil {
+		return nil, err
+	}
+	type plain LineageJobInput
+	return json.Marshal(plain(v))
+}
+
+// UnmarshalJSON validates LineageJobInput after deserialization.
+func (v *LineageJobInput) UnmarshalJSON(data []byte) error {
+	type plain LineageJobInput
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*v = LineageJobInput(decoded)
+	return v.Validate()
 }
 
 // LineageTransformation — A transformation applied to source data in a lineage relationship.

--- a/client/go/pkg/facets/lineage_test.go
+++ b/client/go/pkg/facets/lineage_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018-2026 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package facets
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestLineageJobIdentityFieldsMustBePaired(t *testing.T) {
+	name := "partial"
+	namespace := "jobs"
+
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{
+			name: "entry missing name",
+			value: LineageJobEntry{
+				Namespace: &namespace,
+				Type:      LineageJobEntryTypeJob,
+			},
+		},
+		{
+			name: "input missing namespace",
+			value: LineageJobInput{
+				Name: &name,
+				Type: LineageJobInputTypeJob,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := json.Marshal(tt.value)
+			if err == nil || !strings.Contains(err.Error(), "is required when") {
+				t.Fatalf("json.Marshal() error = %v, want dependentRequired error", err)
+			}
+		})
+	}
+}
+
+func TestLineageJobIdentityFieldsAcceptBothOrNeither(t *testing.T) {
+	name := "job"
+	namespace := "jobs"
+
+	values := []interface{}{
+		NewLineageJobEntry(),
+		LineageJobEntry{
+			Name:      &name,
+			Namespace: &namespace,
+			Type:      LineageJobEntryTypeJob,
+		},
+		NewLineageJobInput(),
+		LineageJobInput{
+			Name:      &name,
+			Namespace: &namespace,
+			Type:      LineageJobInputTypeJob,
+		},
+	}
+
+	for _, value := range values {
+		if _, err := json.Marshal(value); err != nil {
+			t.Fatalf("json.Marshal(%T) unexpected error: %v", value, err)
+		}
+	}
+}
+
+func TestLineageJobIdentityFieldsAreValidatedOnUnmarshal(t *testing.T) {
+	var input LineageJobInput
+	err := json.Unmarshal([]byte(`{"type":"JOB","name":"partial"}`), &input)
+	if err == nil || !strings.Contains(err.Error(), "namespace") {
+		t.Fatalf("json.Unmarshal() error = %v, want missing namespace error", err)
+	}
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -299,7 +299,29 @@ public class JavaPoetGenerator {
     if (type.hasAdditionalProperties()) {
       constructor.addCode(CodeBlock.builder().addStatement("this.$N = new $T<>()", "additionalProperties", LinkedHashMap.class).build());
     }
+    addDependentRequiredValidation(type, constructor);
     return constructor.build();
+  }
+
+  private void addDependentRequiredValidation(
+      ObjectResolvedType type, MethodSpec.Builder constructor) {
+    type.getDependentRequired()
+        .forEach(
+            (property, dependencies) ->
+                dependencies.forEach(
+                    dependency ->
+                        constructor
+                            .beginControlFlow(
+                                "if (this.$N != null && this.$N == null)", property, dependency)
+                            .addStatement(
+                                "throw new $T($S)",
+                                IllegalArgumentException.class,
+                                "property \""
+                                    + dependency
+                                    + "\" is required when \""
+                                    + property
+                                    + "\" is set")
+                            .endControlFlow()));
   }
 
   private TypeSpec modelClass(ObjectResolvedType type) {
@@ -707,6 +729,7 @@ public class JavaPoetGenerator {
       if (type.hasAdditionalProperties()) {
         addAdditionalProperties(type, classBuilder, constructor);
       }
+      addDependentRequiredValidation(type, constructor);
       classBuilder.addMethod(constructor.build());
       containerTypeBuilder.addType(classBuilder.build());
 

--- a/client/java/generator/src/main/java/io/openlineage/client/SchemaParser.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/SchemaParser.java
@@ -8,7 +8,9 @@ package io.openlineage.client;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,6 +52,7 @@ public class SchemaParser {
           return new PrimitiveType(typeName, typeJson.has("format") ? typeJson.get("format").asText() : null);
         } else if (typeName.equals("object") && (typeJson.has("properties") || typeJson.has("additionalProperties") || typeJson.has("patternProperties"))) {
           List<Field> fields = new ArrayList<Field>();
+          Map<String, List<String>> dependentRequired = new LinkedHashMap<>();
           boolean hasAdditionalProperties = false;
           Type additionalPropertiesType = null;
           if (typeJson.has("properties")) {
@@ -65,6 +68,19 @@ public class SchemaParser {
               } else {
                 fields.add(new Field(field.getKey(), fieldType, description));
               }
+            }
+          }
+          if (typeJson.has("dependentRequired")) {
+            for (Iterator<Entry<String, JsonNode>> dependenciesJson =
+                    typeJson.get("dependentRequired").fields();
+                dependenciesJson.hasNext(); ) {
+              Entry<String, JsonNode> dependency = dependenciesJson.next();
+              List<String> requiredProperties = new ArrayList<>();
+              dependency
+                  .getValue()
+                  .elements()
+                  .forEachRemaining(property -> requiredProperties.add(property.asText()));
+              dependentRequired.put(dependency.getKey(), requiredProperties);
             }
           }
           if (typeJson.has("additionalProperties")) {
@@ -85,7 +101,8 @@ public class SchemaParser {
               additionalPropertiesType = parse(patternField.getValue());
             }
           }
-          return new ObjectType(fields, hasAdditionalProperties, additionalPropertiesType);
+          return new ObjectType(
+              fields, hasAdditionalProperties, additionalPropertiesType, dependentRequired);
         } else if (typeName.equals("array")) {
           Type itemsType = parse(typeJson.get("items"));
           return new ArrayType(itemsType);
@@ -423,12 +440,18 @@ public class SchemaParser {
     private final List<Field> properties;
     private final boolean additionalProperties;
     private final Type additionalPropertiesType;
+    private final Map<String, List<String>> dependentRequired;
 
-    public ObjectType(List<Field> properties, boolean additionalProperties, Type additionalPropertiesType) {
+    public ObjectType(
+        List<Field> properties,
+        boolean additionalProperties,
+        Type additionalPropertiesType,
+        Map<String, List<String>> dependentRequired) {
       super();
       this.properties = properties;
       this.additionalProperties = additionalProperties;
       this.additionalPropertiesType = additionalPropertiesType;
+      this.dependentRequired = dependentRequired;
     }
 
     public boolean isObject() { return true; };
@@ -448,6 +471,10 @@ public class SchemaParser {
 
     public Type getAdditionalPropertiesType() {
       return additionalPropertiesType;
+    }
+
+    public Map<String, List<String>> getDependentRequired() {
+      return dependentRequired;
     }
 
     @Override

--- a/client/java/generator/src/main/java/io/openlineage/client/TypeResolver.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/TypeResolver.java
@@ -559,6 +559,23 @@ public class TypeResolver {
       return additionalPropertiesType;
     }
 
+    public Map<String, List<String>> getDependentRequired() {
+      Map<String, List<String>> combined = new LinkedHashMap<>();
+      for (ObjectType objectType : objectTypes) {
+        objectType
+            .getDependentRequired()
+            .forEach(
+                (property, dependencies) -> {
+                  List<String> combinedDependencies =
+                      combined.computeIfAbsent(property, ignored -> new ArrayList<>());
+                  dependencies.stream()
+                      .filter(dependency -> !combinedDependencies.contains(dependency))
+                      .forEach(combinedDependencies::add);
+                });
+      }
+      return combined;
+    }
+
     public void setAdditionalProperties(boolean additionalProperties) {
       this.additionalProperties = additionalProperties;
     }

--- a/client/java/generator/src/test/java/io/openlineage/client/GeneratorTest.java
+++ b/client/java/generator/src/test/java/io/openlineage/client/GeneratorTest.java
@@ -8,6 +8,7 @@ package io.openlineage.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,6 +67,17 @@ class GeneratorTest {
   }
 
   @Test
+  void generatesDependentRequiredValidation() throws Exception {
+    String source = generate();
+
+    assertTrue(source.contains("if (this.namespace != null && this.name == null)"));
+    assertTrue(
+        source.contains(
+            "property \\\"name\\\" is required when \\\"namespace\\\" is set"));
+    assertTrue(source.contains("if (this.name != null && this.namespace == null)"));
+  }
+
+  @Test
   void generatedUnionDeserializesToItsConcreteVariant() throws Exception {
     generate();
     Path generatedSource = outputDirectory.resolve("OpenLineage.java");
@@ -97,6 +109,14 @@ class GeneratorTest {
               .readValue("{\"type\":\"DATASET\",\"namespace\":\"warehouse\"}", unionType);
 
       assertEquals("LineageDatasetEntry", value.getClass().getSimpleName());
+
+      Class<?> inputUnionType =
+          classLoader.loadClass("io.openlineage.client.OpenLineage$LineageInput");
+      assertThrows(
+          com.fasterxml.jackson.core.JsonProcessingException.class,
+          () ->
+              new ObjectMapper()
+                  .readValue("{\"type\":\"JOB\",\"name\":\"partial\"}", inputUnionType));
     }
   }
 

--- a/client/java/generator/src/test/resources/discriminated-union/SharedFacet.json
+++ b/client/java/generator/src/test/resources/discriminated-union/SharedFacet.json
@@ -75,7 +75,14 @@
         },
         "namespace": {
           "type": "string"
+        },
+        "name": {
+          "type": "string"
         }
+      },
+      "dependentRequired": {
+        "namespace": ["name"],
+        "name": ["namespace"]
       }
     },
     "LineageInput": {
@@ -113,7 +120,14 @@
         },
         "name": {
           "type": "string"
+        },
+        "namespace": {
+          "type": "string"
         }
+      },
+      "dependentRequired": {
+        "namespace": ["name"],
+        "name": ["namespace"]
       }
     },
     "LegacyChoice": {

--- a/client/java/src/test/java/io/openlineage/client/LineageFacetTest.java
+++ b/client/java/src/test/java/io/openlineage/client/LineageFacetTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -157,5 +158,25 @@ class LineageFacetTest {
                 .getInputs()
                 .get(0))
         .isInstanceOf(LineageJobInput.class);
+  }
+
+  @Test
+  void jobIdentityRequiresNamespaceAndNameTogether() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            openLineage
+                .newLineageJobEntryBuilder()
+                .namespace("https://example.com/jobs")
+                .type(LineageJobEntry.Type.JOB)
+                .build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            openLineage
+                .newLineageJobInputBuilder()
+                .name("upstream_job")
+                .type(LineageJobInput.Type.JOB)
+                .build());
   }
 }

--- a/client/python/src/openlineage/client/generated/lineage.py
+++ b/client/python/src/openlineage/client/generated/lineage.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal, Union
+from typing import Any, ClassVar, Literal, Union
 
 import attr
 from openlineage.client.generated.base import DatasetFacet, JobFacet
@@ -143,6 +143,24 @@ class LineageJobEntry(RedactMixin):
 
         UUID(value)
 
+    @name.validator
+    def name_dependent_required_check(self, attribute: Any, value: Any) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        missing = [name for name in ["namespace"] if getattr(self, name) is None]
+        if missing:
+            msg = f"{', '.join(missing)} required when name is set"
+            raise ValueError(msg)
+
+    @namespace.validator
+    def namespace_dependent_required_check(self, attribute: Any, value: Any) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        missing = [name for name in ["name"] if getattr(self, name) is None]
+        if missing:
+            msg = f"{', '.join(missing)} required when namespace is set"
+            raise ValueError(msg)
+
 
 @attr.define
 class LineageJobFacet(JobFacet):
@@ -194,6 +212,24 @@ class LineageJobInput(RedactMixin):
         from uuid import UUID
 
         UUID(value)
+
+    @name.validator
+    def name_dependent_required_check(self, attribute: Any, value: Any) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        missing = [name for name in ["namespace"] if getattr(self, name) is None]
+        if missing:
+            msg = f"{', '.join(missing)} required when name is set"
+            raise ValueError(msg)
+
+    @namespace.validator
+    def namespace_dependent_required_check(self, attribute: Any, value: Any) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        missing = [name for name in ["name"] if getattr(self, name) is None]
+        if missing:
+            msg = f"{', '.join(missing)} required when namespace is set"
+            raise ValueError(msg)
 
 
 @attr.define

--- a/client/python/src/openlineage/client/generator/base.py
+++ b/client/python/src/openlineage/client/generator/base.py
@@ -55,6 +55,7 @@ TEMPLATES_LOCATION = FILE_LOCATION / "templates"
 # Contains schema URLs and base IDs parsed from specification files
 SCHEMA_URLS: dict[str, str] = {}
 BASE_IDS: dict[str, str] = {}
+DEPENDENT_REQUIRED: dict[str, dict[str, list[str]]] = {}
 
 
 def deep_merge_dicts(dict1: dict[str, Any], dict2: dict[str, Any]) -> dict[str, Any]:
@@ -76,6 +77,19 @@ def deep_merge_dicts(dict1: dict[str, Any], dict2: dict[str, Any]) -> dict[str, 
     return merged
 
 
+def collect_dependent_required(schema: dict[str, Any]) -> dict[str, list[str]]:
+    """Collect dependentRequired constraints from an object and its inline allOf schemas."""
+    combined: dict[str, list[str]] = {}
+    schemas = [schema, *(item for item in schema.get("allOf", []) if isinstance(item, dict))]
+    for object_schema in schemas:
+        for property_name, dependencies in object_schema.get("dependentRequired", {}).items():
+            combined_dependencies = combined.setdefault(property_name, [])
+            combined_dependencies.extend(
+                dependency for dependency in dependencies if dependency not in combined_dependencies
+            )
+    return combined
+
+
 def parse_additional_data(spec: dict[str, Any], file_name: str) -> None:
     """Parse additional data from spec files.
 
@@ -83,13 +97,18 @@ def parse_additional_data(spec: dict[str, Any], file_name: str) -> None:
         * schema URLs
         * base IDs
 
-    Updates the module-level SCHEMA_URLS and BASE_IDS dictionaries
+    Updates the module-level SCHEMA_URLS, BASE_IDS, and DEPENDENT_REQUIRED dictionaries
     that can be imported by other modules.
     """
     base_id = spec["$id"]
-    for name, _ in spec["$defs"].items():
+    for name, definition in spec["$defs"].items():
         SCHEMA_URLS[name] = f"{base_id}#/$defs/{name}"
         BASE_IDS[file_name] = spec["$id"]
+        dependent_required = collect_dependent_required(definition)
+        if dependent_required:
+            DEPENDENT_REQUIRED[name] = dependent_required
+        else:
+            DEPENDENT_REQUIRED.pop(name, None)
 
 
 def load_specs(base_spec_location: pathlib.Path, facets_spec_location: pathlib.Path) -> list[pathlib.Path]:
@@ -117,6 +136,15 @@ def parse_and_generate(
 ) -> dict[str, Any]:
     """Parse and generate data models from a given specification."""
     temporary_locations = []
+
+    dependent_required_template_data = {
+        class_name: {"dependent_required": dependencies}
+        for class_name, dependencies in DEPENDENT_REQUIRED.items()
+    }
+    extra_template_data = deep_merge_dicts(
+        extra_template_data or {},
+        dependent_required_template_data,
+    )
 
     current_dir = pathlib.Path.cwd()
     with tempfile.TemporaryDirectory() as tmp:

--- a/client/python/src/openlineage/client/generator/templates/dataclass.jinja2
+++ b/client/python/src/openlineage/client/generator/templates/dataclass.jinja2
@@ -198,4 +198,17 @@ class {{ class_name }}:
 {%- for field in fields -%}
     {{ validators.validator(field.name, field.type_hint, field.required) }}
 {%- endfor -%}
+{#- add object-level dependentRequired validators -#}
+{%- for property, dependencies in (dependent_required | default({}) | dictsort) %}
+    @{{ property }}.validator
+    def {{ property | lower }}_dependent_required_check(
+        self, attribute: Any, value: Any
+    ) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        missing = [name for name in {{ dependencies }} if getattr(self, name) is None]
+        if missing:
+            msg = f"{', '.join(missing)} required when {{ property }} is set"
+            raise ValueError(msg)
+{%- endfor -%}
 {%- endif -%}

--- a/client/python/tests/generator/test_base.py
+++ b/client/python/tests/generator/test_base.py
@@ -10,8 +10,10 @@ from unittest import mock
 import pytest
 from openlineage.client.generator.base import (
     BASE_IDS,
+    DEPENDENT_REQUIRED,
     SCHEMA_URLS,
     camel_to_snake,
+    collect_dependent_required,
     deep_merge_dicts,
     load_specs,
     parse_additional_data,
@@ -45,10 +47,17 @@ def test_parse_additional_data() -> None:
     # Reset global dictionaries
     SCHEMA_URLS.clear()
     BASE_IDS.clear()
+    DEPENDENT_REQUIRED.clear()
 
     spec = {
         "$id": "https://openlineage.io/spec/facets/1-0-0/TestFacet.json",
-        "$defs": {"TestFacet": {"type": "object"}, "AnotherFacet": {"type": "object"}},
+        "$defs": {
+            "TestFacet": {
+                "type": "object",
+                "dependentRequired": {"namespace": ["name"]},
+            },
+            "AnotherFacet": {"type": "object"},
+        },
     }
 
     parse_additional_data(spec, "TestFacet.json")
@@ -61,6 +70,22 @@ def test_parse_additional_data() -> None:
         == "https://openlineage.io/spec/facets/1-0-0/TestFacet.json#/$defs/AnotherFacet"
     )
     assert BASE_IDS["TestFacet.json"] == "https://openlineage.io/spec/facets/1-0-0/TestFacet.json"
+    assert DEPENDENT_REQUIRED == {"TestFacet": {"namespace": ["name"]}}
+
+
+def test_collect_dependent_required_merges_inline_all_of() -> None:
+    schema = {
+        "dependentRequired": {"namespace": ["name"]},
+        "allOf": [
+            {"$ref": "#/$defs/Base"},
+            {"dependentRequired": {"namespace": ["runId"], "name": ["namespace"]}},
+        ],
+    }
+
+    assert collect_dependent_required(schema) == {
+        "namespace": ["name", "runId"],
+        "name": ["namespace"],
+    }
 
 
 @pytest.fixture

--- a/client/python/tests/test_lineage_facet.py
+++ b/client/python/tests/test_lineage_facet.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Literal, get_type_hints
 
+import pytest
 from openlineage.client.facet_v2 import lineage
 from openlineage.client.serde import Serde
 
@@ -109,3 +111,17 @@ def test_lineage_dataset_inputs_are_omitted_when_unspecified() -> None:
     assert "inputs" not in serialized_facet
     assert "inputs" not in serialized_entries[0]
     assert serialized_entries[1]["inputs"] == []
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: lineage.LineageJobEntry(type="JOB", namespace="jobs"),
+        lambda: lineage.LineageJobEntry(type="JOB", name="job"),
+        lambda: lineage.LineageJobInput(type="JOB", namespace="jobs"),
+        lambda: lineage.LineageJobInput(type="JOB", name="job"),
+    ],
+)
+def test_lineage_job_identity_fields_must_be_paired(factory: Callable[[], object]) -> None:
+    with pytest.raises(ValueError, match="required when"):
+        factory()

--- a/generator/go/ir/build.go
+++ b/generator/go/ir/build.go
@@ -62,8 +62,9 @@ func buildObject(
 
 	if t == nil {
 		return &ObjectDef{
-			TypeName: suggestedName,
-			Required: map[string]bool{},
+			TypeName:          suggestedName,
+			Required:          map[string]bool{},
+			DependentRequired: map[string][]string{},
 		}
 	}
 
@@ -79,10 +80,11 @@ func buildObject(
 	}
 
 	obj := &ObjectDef{
-		TypeName:    typeName,
-		Description: t.Description,
-		Fields:      nil,
-		Required:    map[string]bool{},
+		TypeName:          typeName,
+		Description:       t.Description,
+		Fields:            nil,
+		Required:          map[string]bool{},
+		DependentRequired: map[string][]string{},
 	}
 
 	// ✅ Register early to break cycles
@@ -98,6 +100,7 @@ func buildObject(
 		for _, name := range o.Required {
 			obj.Required[name] = true
 		}
+		mergeDependentRequired(obj.DependentRequired, o.DependentRequired)
 	}
 
 	// 2) Properties — from all schemas (required + optional), first definition wins
@@ -143,6 +146,33 @@ func buildObject(
 	})
 
 	return obj
+}
+
+func mergeDependentRequired(target, source map[string][]string) {
+	properties := make([]string, 0, len(source))
+	for property := range source {
+		properties = append(properties, property)
+	}
+	sort.Strings(properties)
+
+	for _, property := range properties {
+		dependencies := append([]string(nil), source[property]...)
+		sort.Strings(dependencies)
+		for _, dependency := range dependencies {
+			if !contains(target[property], dependency) {
+				target[property] = append(target[property], dependency)
+			}
+		}
+	}
+}
+
+func contains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/generator/go/ir/build_test.go
+++ b/generator/go/ir/build_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/atombender/go-jsonschema/pkg/schemas"
 
+	"github.com/OpenLineage/openlineage/generator/go/discover"
 	"github.com/OpenLineage/openlineage/generator/go/resolve"
 )
 
@@ -35,5 +36,33 @@ func TestDetectDiscriminatorFieldSupportsSingletonEnums(t *testing.T) {
 	want := []string{"DATASET", "JOB"}
 	if !reflect.DeepEqual(values, want) {
 		t.Fatalf("detectDiscriminatorField() values = %v, want %v", values, want)
+	}
+}
+
+func TestBuildFacetPreservesDependentRequired(t *testing.T) {
+	schema := &schemas.Type{
+		Type: schemas.TypeList{"object"},
+		Properties: map[string]*schemas.Type{
+			"namespace": {Type: schemas.TypeList{"string"}},
+			"name":      {Type: schemas.TypeList{"string"}},
+		},
+		DependentRequired: map[string][]string{
+			"namespace": {"name"},
+			"name":      {"namespace"},
+		},
+	}
+
+	facet := BuildFacet(
+		discover.Facet{Name: "TestFacet", Schema: schema},
+		resolve.New(nil),
+		false,
+	)
+
+	want := map[string][]string{
+		"name":      {"namespace"},
+		"namespace": {"name"},
+	}
+	if !reflect.DeepEqual(facet.Root.DependentRequired, want) {
+		t.Fatalf("DependentRequired = %v, want %v", facet.Root.DependentRequired, want)
 	}
 }

--- a/generator/go/ir/facet.go
+++ b/generator/go/ir/facet.go
@@ -18,10 +18,11 @@ type Facet struct {
 
 // ObjectDef represents an object type in the IR.
 type ObjectDef struct {
-	TypeName    string // Go struct name (from $defs or derived from context)
-	Description string
-	Fields      []Field
-	Required    map[string]bool
+	TypeName          string // Go struct name (from $defs or derived from context)
+	Description       string
+	Fields            []Field
+	Required          map[string]bool
+	DependentRequired map[string][]string
 }
 
 // UnionDef represents a oneOf discriminated union.

--- a/generator/go/render/client/facets.go
+++ b/generator/go/render/client/facets.go
@@ -48,10 +48,17 @@ func RenderStructs(facets []ir.Facet) string {
 	unions := collectUnionTypes(sorted)
 	enums := collectEnumTypes(sorted)
 	nested := collectNestedTypes(sorted)
+	hasDependentRequired := false
+	for _, f := range sorted {
+		hasDependentRequired = hasDependentRequired || len(f.Root.DependentRequired) > 0
+	}
+	for _, obj := range nested {
+		hasDependentRequired = hasDependentRequired || len(obj.DependentRequired) > 0
+	}
 
 	// Choose imports based on what types are actually used.
 	imports := "\t\"time\"\n"
-	if len(unions) > 0 {
+	if len(unions) > 0 || hasDependentRequired {
 		imports = "\t\"encoding/json\"\n\t\"fmt\"\n\t\"time\"\n"
 	}
 
@@ -160,6 +167,7 @@ func emitFacetStruct(b *strings.Builder, f ir.Facet) {
 	}
 
 	b.WriteString("}\n\n")
+	emitDependentRequiredMethods(b, f.Root)
 }
 
 // ── Nested struct ─────────────────────────────────────────────────────────────
@@ -179,6 +187,84 @@ func emitNestedStruct(b *strings.Builder, obj *ir.ObjectDef) {
 		emitStructFieldDecl(b, &obj.Fields[i])
 	}
 	b.WriteString("}\n\n")
+	emitDependentRequiredMethods(b, obj)
+}
+
+func emitDependentRequiredMethods(b *strings.Builder, obj *ir.ObjectDef) {
+	if len(obj.DependentRequired) == 0 {
+		return
+	}
+
+	properties := make([]string, 0, len(obj.DependentRequired))
+	for property := range obj.DependentRequired {
+		properties = append(properties, property)
+	}
+	sort.Strings(properties)
+
+	fmt.Fprintf(b, "// Validate checks the dependentRequired constraints for %s.\n", obj.TypeName)
+	fmt.Fprintf(b, "func (v %s) Validate() error {\n", obj.TypeName)
+	for _, property := range properties {
+		propertyField := objectFieldByJSONName(obj, property)
+		dependencies := append([]string(nil), obj.DependentRequired[property]...)
+		sort.Strings(dependencies)
+		for _, dependency := range dependencies {
+			dependencyField := objectFieldByJSONName(obj, dependency)
+			fmt.Fprintf(
+				b,
+				"\tif %s && %s {\n\t\treturn fmt.Errorf(%q)\n\t}\n",
+				fieldPresentExpr("v", propertyField),
+				fieldAbsentExpr("v", dependencyField),
+				fmt.Sprintf("property %q is required when %q is set", dependency, property),
+			)
+		}
+	}
+	b.WriteString("\treturn nil\n}\n\n")
+
+	fmt.Fprintf(b, "// MarshalJSON validates %s before serialization.\n", obj.TypeName)
+	fmt.Fprintf(b, "func (v %s) MarshalJSON() ([]byte, error) {\n", obj.TypeName)
+	b.WriteString("\tif err := v.Validate(); err != nil {\n\t\treturn nil, err\n\t}\n")
+	fmt.Fprintf(b, "\ttype plain %s\n", obj.TypeName)
+	b.WriteString("\treturn json.Marshal(plain(v))\n}\n\n")
+
+	fmt.Fprintf(b, "// UnmarshalJSON validates %s after deserialization.\n", obj.TypeName)
+	fmt.Fprintf(b, "func (v *%s) UnmarshalJSON(data []byte) error {\n", obj.TypeName)
+	fmt.Fprintf(b, "\ttype plain %s\n", obj.TypeName)
+	b.WriteString("\tvar decoded plain\n")
+	b.WriteString("\tif err := json.Unmarshal(data, &decoded); err != nil {\n\t\treturn err\n\t}\n")
+	fmt.Fprintf(b, "\t*v = %s(decoded)\n", obj.TypeName)
+	b.WriteString("\treturn v.Validate()\n}\n\n")
+}
+
+func objectFieldByJSONName(obj *ir.ObjectDef, jsonName string) *ir.Field {
+	for i := range obj.Fields {
+		if obj.Fields[i].JSONName == jsonName {
+			return &obj.Fields[i]
+		}
+	}
+	log.Fatalf("dependentRequired on %s references unknown property %q", obj.TypeName, jsonName)
+	return nil
+}
+
+func fieldPresentExpr(receiver string, field *ir.Field) string {
+	if field.Required {
+		return "true"
+	}
+	goName := genutil.FormatGoFieldName(field.GoName)
+	if _, ok := field.Type.(ir.Union); ok {
+		return fmt.Sprintf("%s.%s.V != nil", receiver, goName)
+	}
+	return fmt.Sprintf("%s.%s != nil", receiver, goName)
+}
+
+func fieldAbsentExpr(receiver string, field *ir.Field) string {
+	if field.Required {
+		return "false"
+	}
+	goName := genutil.FormatGoFieldName(field.GoName)
+	if _, ok := field.Type.(ir.Union); ok {
+		return fmt.Sprintf("%s.%s.V == nil", receiver, goName)
+	}
+	return fmt.Sprintf("%s.%s == nil", receiver, goName)
 }
 
 // emitStructFieldDecl emits a single struct field declaration with a JSON tag.
@@ -571,6 +657,24 @@ func sameObjectShape(a, b *ir.ObjectDef) bool {
 	for i := range a.Fields {
 		if a.Fields[i].JSONName != b.Fields[i].JSONName {
 			return false
+		}
+	}
+	return sameDependentRequired(a.DependentRequired, b.DependentRequired)
+}
+
+func sameDependentRequired(a, b map[string][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for property, dependencies := range a {
+		other, ok := b[property]
+		if !ok || len(dependencies) != len(other) {
+			return false
+		}
+		for i := range dependencies {
+			if dependencies[i] != other[i] {
+				return false
+			}
 		}
 	}
 	return true


### PR DESCRIPTION
## Summary

Add `dependentRequired` support to the Java, Python, and Go client generators.

## Motivation

The lineage facet can identify another job by `namespace` and `name`, or omit both fields to refer to the event's own job. A partial identity is invalid because it cannot identify either case:

```json
{
  "type": "JOB",
  "namespace": "https://example.com/jobs"
}
```

The schema uses symmetric `dependentRequired` constraints to require `name` whenever `namespace` is present and vice versa. Before this change, all three generators ignored that keyword, so generated clients could construct and serialize payloads that the OpenLineage schema rejects.

## Changes

- Java parses and merges `dependentRequired` constraints, then emits constructor validation used by builders and Jackson deserialization.
- Python extracts the constraints into template metadata and emits attrs field validators.
- Go carries the constraints through its IR and emits `Validate`, `MarshalJSON`, and `UnmarshalJSON` methods, preserving existing constructor signatures.
- Regenerate the Python and Go lineage models and add generator- and client-level coverage for valid and invalid field combinations.
