### PR TITLE
fixed bug in the Python clients's async HTTP transport

### DIFF
--- a/client/python/src/openlineage/client/transport/async_http.py
+++ b/client/python/src/openlineage/client/transport/async_http.py
@@ -597,7 +597,6 @@ class AsyncHttpTransport(Transport):
             bool: True if all events were processed, False if some events were not processed.
         """
         log.debug("Waiting for events completion for %.3f seconds", timeout)
-        self.may_exit.set()
         start_time = time.time()
         while timeout < 0 or time.time() - start_time < timeout:
             if self._all_processed():
@@ -611,6 +610,8 @@ class AsyncHttpTransport(Transport):
 
     def close(self, timeout: float = -1.0) -> bool:
         log.debug("Closing Async HTTP transport with timeout %.3f seconds", timeout)
+        # Allow the worker to exit once the queue drains, now that the transport is shutting down.
+        self.may_exit.set()
         result = self.wait_for_completion(timeout)
         self.should_exit.set()
         self.events = {}

--- a/client/python/tests/test_async_http.py
+++ b/client/python/tests/test_async_http.py
@@ -967,6 +967,28 @@ class TestAsyncHttpTransportErrorHandling:
                 assert result
                 assert call_count > 2
 
+    def test_wait_for_completion_keeps_worker_alive_for_later_events(self):
+        """wait_for_completion() should only wait, not shut down the worker.
+
+        Regression test for https://github.com/OpenLineage/OpenLineage/issues/4823:
+        the worker used to exit permanently once the queue drained (may_exit was set
+        by wait_for_completion), so events emitted afterwards were never processed.
+        """
+        config = AsyncHttpConfig(url="http://example.com")
+        transport = AsyncHttpTransport(config)
+
+        with closing_immediately(transport) as transport:
+            assert transport.wait_for_completion(timeout=1)
+            assert not transport.may_exit.is_set()
+
+            # Give the worker a chance to observe the exit signal, if one was (wrongly) set.
+            time.sleep(0.2)
+            assert transport.worker_thread.is_alive()
+
+        # close() is the one lifecycle method that should allow the worker to exit.
+        assert transport.may_exit.is_set()
+        assert not transport.worker_thread.is_alive()
+
     def test_task_exception_handling_in_event_loop(self, mock_async_http_client_class):
         """Test exception handling when tasks raise exceptions in event loop"""
         config = AsyncHttpConfig(url="http://example.com", max_concurrent_requests=1)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->


### Checklist
- [ ] AI was used in creating this PR
