### PR TITLE
spark: fix Databricks UPDATE output and subquery input lineage

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -37,6 +37,8 @@ import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.column.JdbcColumnLineageVisitor;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.column.MergeIntoDelta11ColumnLineageVisitor;
@@ -68,6 +70,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new SubqueryAliasInputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
+            .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new ViewInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
@@ -91,6 +94,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new DeleteCommandOutputDatasetBuilder(context))
+            .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -20,6 +20,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1InputDatasetBu
 import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
@@ -44,6 +45,7 @@ public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new DeleteCommandOutputDatasetBuilder(context))
+            .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -35,6 +35,8 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
@@ -67,6 +69,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new SubqueryAliasInputDatasetBuilder(context))
             .add(new CreateReplaceInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
+            .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new ViewInputDatasetBuilder(context))
@@ -92,6 +95,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new DeleteCommandOutputDatasetBuilder(context))
+            .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new DropTableDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -34,6 +34,8 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
@@ -65,6 +67,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new SubqueryAliasInputDatasetBuilder(context))
             .add(new CreateReplaceInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
+            .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
@@ -89,6 +92,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new DeleteCommandOutputDatasetBuilder(context))
+            .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -34,6 +34,8 @@ import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.column.JdbcColumnLineageVisitor;
 import io.openlineage.spark31.agent.lifecycle.plan.AlterTableDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.column.MergeIntoDelta11ColumnLineageVisitor;
@@ -61,6 +63,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
+            .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new SubqueryAliasInputDatasetBuilder(context));
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {
@@ -82,6 +85,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new DeleteCommandOutputDatasetBuilder(context))
+            .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -35,6 +35,8 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
@@ -68,6 +70,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new SubqueryAliasInputDatasetBuilder(context))
             .add(new CreateReplaceInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
+            .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
             .add(new StreamingDataSourceV2ScanRelationDatasetBuilder(context))
@@ -93,6 +96,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new DeleteCommandOutputDatasetBuilder(context))
+            .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandInputDatasetBuilder.java
@@ -1,0 +1,69 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.UpdateCommandUtils;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+
+/**
+ * Extracts input datasets from the subqueries of an {@link UpdateTable} or of the Databricks Delta
+ * command the same statement is resolved to.
+ *
+ * <p>Tables referenced from a WHERE clause or from an UPDATE assignment live inside expressions,
+ * not inside the children of the plan node:
+ *
+ * <pre>
+ * UpdateTable
+ * +- table: DataSourceV2Relation           (visited, emitted as output)
+ * +- condition: InSubquery(id, ListQuery)  (not a child, never visited)
+ *                +- plan: the subquery reading another table
+ * </pre>
+ *
+ * The regular traversal only walks children, so those tables were missing from the event. {@code
+ * subqueries()} is available on the Databricks commands as well, because the condition is one of
+ * their expressions.
+ */
+public class UpdateCommandInputDatasetBuilder
+    extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
+
+  public UpdateCommandInputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof UpdateTable) || UpdateCommandUtils.isUpdateCommand(x);
+  }
+
+  @Override
+  public List<InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    // subqueries() returns the plans held by the expressions of this node only, so the children of
+    // the node are left to the regular traversal
+    return ScalaConversionUtils.<LogicalPlan>fromSeq(x.subqueries()).stream()
+        .flatMap(subquery -> collectInputs(subquery, event).stream())
+        .collect(Collectors.toList());
+  }
+
+  private List<InputDataset> collectInputs(LogicalPlan subquery, SparkListenerEvent event) {
+    return ScalaConversionUtils.fromSeq(
+            subquery.collect(
+                delegate(
+                    context.getInputDatasetQueryPlanVisitors(),
+                    context.getInputDatasetBuilders(),
+                    event)))
+        .stream()
+        .flatMap(datasets -> datasets.stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandOutputDatasetBuilder.java
@@ -1,0 +1,61 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.UpdateCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Extracts the modified table of a Databricks {@code UPDATE} as an output dataset.
+ *
+ * <p>{@link TableContentChangeDatasetBuilder} covers the catalyst {@code UpdateTable} node, which
+ * Databricks never produces - the runtime resolves the statement to a Delta command instead.
+ * Without this builder those statements emit an event with no datasets at all: nothing matches the
+ * plan, so the target is missing from {@code outputs} and the job name carries no table suffix
+ * either.
+ */
+@Slf4j
+public class UpdateCommandOutputDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public UpdateCommandOutputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return UpdateCommandUtils.isUpdateCommand(x);
+  }
+
+  @Override
+  protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    return UpdateCommandUtils.target(x)
+        .map(target -> delegate(target, event))
+        .orElse(Collections.emptyList());
+  }
+
+  @Override
+  public Optional<String> jobNameSuffix(LogicalPlan plan) {
+    return UpdateCommandUtils.target(plan)
+        .flatMap(
+            target ->
+                context.getOutputDatasetBuilders().stream()
+                    .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
+                    .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
+                    .map(b -> b.jobNameSuffixFromLogicalPlan(target))
+                    .filter(Optional::isPresent)
+                    .map(o -> (String) o.get())
+                    .findFirst());
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UpdateCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UpdateCommandUtils.java
@@ -1,0 +1,67 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+
+/**
+ * Recognises the Databricks Delta commands that an {@code UPDATE} statement is turned into, and
+ * reads their target relation.
+ *
+ * <p>On Databricks the catalyst node {@code UpdateTable} never reaches the dataset builders: the
+ * runtime resolves the statement straight to a command under {@code
+ * com.databricks.sql.transaction.tahoe.commands}, so neither the optimized nor the analyzed plan
+ * holds the catalyst node. Those commands are not on the compile classpath, hence the match by
+ * class name and the reflective member access, the same approach {@code MergeIntoCommandEdge} and
+ * {@code CopyIntoCommand} already use.
+ */
+@Slf4j
+public class UpdateCommandUtils {
+
+  private static final List<String> COMMAND_CLASS_NAMES =
+      Arrays.asList(
+          "sql.transaction.tahoe.commands.UpdateCommand",
+          "sql.transaction.tahoe.commands.UpdateCommandEdge");
+
+  private UpdateCommandUtils() {}
+
+  public static boolean isUpdateCommand(LogicalPlan plan) {
+    return matchesCommandClassName(plan.getClass().getCanonicalName());
+  }
+
+  /** Package-visible for tests; Databricks command classes are not on the classpath. */
+  static boolean matchesCommandClassName(String canonicalName) {
+    return canonicalName != null && COMMAND_CLASS_NAMES.stream().anyMatch(canonicalName::endsWith);
+  }
+
+  /**
+   * Reads the modified relation from {@code target()}, unwrapping the {@link SubqueryAlias} the
+   * command keeps when the statement uses a table alias.
+   */
+  public static Optional<LogicalPlan> target(LogicalPlan plan) {
+    Object target;
+    try {
+      target = MethodUtils.invokeExactMethod(plan, "target", new Object[] {});
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.warn("Cannot extract target from Databricks command {}", plan.getClass(), e);
+      return Optional.empty();
+    }
+
+    if (target instanceof SubqueryAlias) {
+      return Optional.of(((SubqueryAlias) target).child());
+    } else if (target instanceof LogicalPlan) {
+      return Optional.of((LogicalPlan) target);
+    }
+    return Optional.empty();
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandInputDatasetBuilderTest.java
@@ -1,0 +1,99 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
+
+class UpdateCommandInputDatasetBuilderTest {
+
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  UpdateCommandInputDatasetBuilder builder = new UpdateCommandInputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+
+  @Test
+  void testIsDefinedAtLogicalPlan() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(UpdateTable.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(DeleteFromTable.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyCollectsInputsFromSubqueries() {
+    givenSubqueryVisitorReturning("subquery_table", "subquery_namespace");
+
+    UpdateTable plan = mock(UpdateTable.class);
+    when(plan.subqueries())
+        .thenReturn(
+            ScalaConversionUtils.fromList(
+                Collections.<LogicalPlan>singletonList(new OneRowRelation())));
+
+    List<InputDataset> inputs = builder.apply(event, plan);
+
+    assertThat(inputs)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "subquery_table")
+        .hasFieldOrPropertyWithValue("namespace", "subquery_namespace");
+  }
+
+  @Test
+  void testApplyWithoutSubqueries() {
+    givenSubqueryVisitorReturning("subquery_table", "subquery_namespace");
+
+    UpdateTable plan = mock(UpdateTable.class);
+    when(plan.subqueries()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
+
+    assertThat(builder.apply(event, plan)).isEmpty();
+  }
+
+  /**
+   * Registers a visitor that turns the subquery plan node into a known dataset, standing in for the
+   * relation builders that resolve a real table.
+   */
+  private void givenSubqueryVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<InputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<InputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return x instanceof OneRowRelation;
+          }
+
+          @Override
+          public List<InputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newInputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getInputDatasetQueryPlanVisitors()).thenReturn(Collections.singletonList(visitor));
+    when(context.getInputDatasetBuilders()).thenReturn(Collections.emptyList());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/UpdateCommandOutputDatasetBuilderTest.java
@@ -1,0 +1,97 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.UpdateCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
+
+class UpdateCommandOutputDatasetBuilderTest {
+
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  UpdateCommandOutputDatasetBuilder builder = new UpdateCommandOutputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+
+  @Test
+  void testIsNotDefinedAtOtherPlans() {
+    assertFalse(builder.isDefinedAtLogicalPlan(new OneRowRelation()));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(UpdateTable.class)));
+  }
+
+  @Test
+  void testApplyEmitsTargetAsOutput() {
+    givenTargetVisitorReturning("update_table", "unity-catalog");
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<UpdateCommandUtils> utils = mockStatic(UpdateCommandUtils.class)) {
+      utils
+          .when(() -> UpdateCommandUtils.target(command))
+          .thenReturn(Optional.of(new OneRowRelation()));
+
+      List<OutputDataset> outputs = builder.apply(event, command);
+
+      assertThat(outputs)
+          .singleElement()
+          .hasFieldOrPropertyWithValue("name", "update_table")
+          .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  @Test
+  void testApplyWhenTargetIsMissing() {
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<UpdateCommandUtils> utils = mockStatic(UpdateCommandUtils.class)) {
+      utils.when(() -> UpdateCommandUtils.target(command)).thenReturn(Optional.empty());
+
+      assertThat(builder.apply(event, command)).isEmpty();
+    }
+  }
+
+  private void givenTargetVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<OutputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<OutputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return x instanceof OneRowRelation;
+          }
+
+          @Override
+          public List<OutputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newOutputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getOutputDatasetQueryPlanVisitors())
+        .thenReturn(Collections.singletonList(visitor));
+    when(context.getOutputDatasetBuilders()).thenReturn(Collections.emptyList());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/UpdateCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/UpdateCommandUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.junit.jupiter.api.Test;
+
+class UpdateCommandUtilsTest {
+
+  @Test
+  void testMatchesCommandClassName() {
+    assertThat(
+            UpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.UpdateCommandEdge"))
+        .isTrue();
+    assertThat(
+            UpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.UpdateCommand"))
+        .isTrue();
+    assertThat(
+            UpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.DeleteCommandEdge"))
+        .isFalse();
+    assertThat(
+            UpdateCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.DeleteCommand"))
+        .isFalse();
+    assertThat(UpdateCommandUtils.matchesCommandClassName("UpdateTable")).isFalse();
+    assertThat(UpdateCommandUtils.matchesCommandClassName(null)).isFalse();
+  }
+
+  @Test
+  void testTargetWhenCommandHasNoSuchMember() {
+    assertThat(UpdateCommandUtils.target(new OneRowRelation())).isEmpty();
+  }
+}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->
related: https://github.com/OpenLineage/OpenLineage/issues/4807

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Fix missing Databricks Spark lineage for UPDATE statements (tahoe output and subquery inputs) on Unity Catalog.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
On Databricks Runtime with Unity Catalog, `UPDATE` statements produced incomplete or empty OpenLineage events. DELETE was fixed separately in #4815; this PR adds the parallel UPDATE support.

**Root cause:** Databricks resolves `UPDATE` to proprietary tahoe plan nodes (`UpdateCommand` / `UpdateCommandEdge`), not catalyst `UpdateTable`. The existing `TableContentChangeDatasetBuilder` covers catalyst nodes on OSS but never matches on Databricks. Tables referenced in SET/WHERE subqueries live inside expressions, not plan children, so tree traversal never visited them.

**Solution:**

- **UPDATE output:** Add `UpdateCommandOutputDatasetBuilder` + `UpdateCommandUtils` with reflective `target()` on tahoe update commands (same pattern as `DeleteCommandOutputDatasetBuilder` / `DeleteCommandUtils` from #4815).
- **UPDATE inputs:** Add `UpdateCommandInputDatasetBuilder` calling `subqueries()` on catalyst `UpdateTable` and tahoe update commands.
- **Factory registration:** Register both builders in all `Spark3*DatasetBuilderFactory` classes.
Plain `UPDATE` remains **output-only** by design (target = modified dataset, not also an input). Catalyst `UpdateTable` output on OSS continues to be handled by `TableContentChangeDatasetBuilder`.

**Tests:** `UpdateCommandUtilsTest`, `UpdateCommandOutputDatasetBuilderTest`, `UpdateCommandInputDatasetBuilderTest`.

**Validation artifacts**

Validation notebook:

https://gist.github.com/mishrasangeeta87/3e16e755b7d16ec38c57959abaeda6df

OpenLineage events:

| Scenario | Before | After |
|-----------|--------|-------|
| UPDATE inputs | []| [{"name":"unity-catalog/7474644317745272/sangeeta/__unitystorage/catalogs/3d92ab1b-c9c7-41e7-9b7b-77c689e76698/tables/a446b585-4716-4ef2-ba8c-be60a429a7b7","namespace":"s3://databricks-workspace-stack-93947-bucket","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"s3://databricks-workspace-stack-93947-bucket","uri":"s3://databricks-workspace-stack-93947-bucket"},"storage":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/StorageDatasetFacet.json#/$defs/StorageDatasetFacet","storageLayer":"unity","fileFormat":"parquet"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"catalog":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-1-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet","framework":"delta","type":"unity","name":"sangeeta_catalog","source":"spark"},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"unity-catalog","name":"sangeeta_catalog.openlineage_dml.source_table","type":"TABLE"}]}},"inputFacets":{"inputStatistics":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-0/InputStatisticsInputDatasetFacet.json#/$defs/InputStatisticsInputDatasetFacet","size":1275}},"outputFacets":{}}]|
| UPDATE outputs | []| [{"name":"unity-catalog/7474644317745272/sangeeta/__unitystorage/catalogs/3d92ab1b-c9c7-41e7-9b7b-77c689e76698/tables/dd6364ac-16a0-4287-9401-c68d8d43609b","namespace":"s3://databricks-workspace-stack-93947-bucket","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"s3://databricks-workspace-stack-93947-bucket","uri":"s3://databricks-workspace-stack-93947-bucket"},"storage":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/StorageDatasetFacet.json#/$defs/StorageDatasetFacet","storageLayer":"unity","fileFormat":"parquet"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"catalog":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-1-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet","framework":"delta","type":"unity","name":"sangeeta_catalog","source":"spark"},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"unity-catalog","name":"sangeeta_catalog.openlineage_dml.update_table","type":"TABLE"}]}},"inputFacets":{},"outputFacets":{"outputStatistics":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-2/OutputStatisticsOutputDatasetFacet.json#/$defs/OutputStatisticsOutputDatasetFacet","rowCount":2,"size":2284,"fileCount":1}}}]|


### Checklist
- [x] AI was used in creating this PR
> ⚠️ **AI Disclosure** — This pull request was generated with AI assistance (Cursor). All proposed changes were reviewed and validated by verifying the expected input and output lineage for the affected scenarios as specified under , Validation artifacts section.
