### PR TITLE
website: broaden Foundational producer description on the Ecosystem page

### DIFF
--- a/website/static/ecosystem/producers.tsx
+++ b/website/static/ecosystem/producers.tsx
@@ -182,7 +182,7 @@ export const Producers: Array<Partner> = [
     org: "Foundational",
     full_name: "Foundational",
     description:
-      "Foundational exports code-time lineage as OpenLineage events, derived from static analysis of pipeline code across dbt, Airflow, Spark, Snowflake, BigQuery and more, for consumption by any OpenLineage-compatible catalog.",
+      "Foundational exports code-time lineage as OpenLineage events, derived from static analysis of pipeline code across any type of programming language such as Python, Java, COBOL, Scala and more, for consumption by any OpenLineage-compatible catalog.",
     docs_url: "https://docs.foundational.io/en/articles/10304496-openlineage-support-in-foundational",
     org_url: "https://www.foundational.io/",
   },


### PR DESCRIPTION
### One-line summary for changelog:

Broadened the Foundational producer description on the Ecosystem page to describe language coverage rather than specific platforms.

### Meaningful description

Follow-up to #4832, which added Foundational to the Ecosystem page.

The producer entry described the export in terms of specific platforms (dbt, Airflow, Spark, Snowflake, BigQuery). Foundational's static analysis is language-oriented rather than platform-oriented, so this describes it that way instead — the lineage is derived from the pipeline source code itself, whatever language it happens to be written in.

Before:

> Foundational exports code-time lineage as OpenLineage events, derived from static analysis of pipeline code across dbt, Airflow, Spark, Snowflake, BigQuery and more, for consumption by any OpenLineage-compatible catalog.

After:

> Foundational exports code-time lineage as OpenLineage events, derived from static analysis of pipeline code across any type of programming language such as Python, Java, COBOL, Scala and more, for consumption by any OpenLineage-compatible catalog.

One line changed in `website/static/ecosystem/producers.tsx`. The consumer entry and the logo are untouched. Verified with `yarn start` that the card renders the updated text.

### Checklist
- [x] AI was used in creating this PR
