### PR TITLE
client/java: make ReducedDataset facet comparison null-safe

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/dataset/partition/ReducedDataset.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/partition/ReducedDataset.java
@@ -86,7 +86,7 @@ class ReducedDataset {
   }
 
   private boolean hasSameFacets(ReducedDataset other) {
-    if (!dataset.getFacets().equals(other.dataset.getFacets())) {
+    if (!Objects.equals(dataset.getFacets(), other.dataset.getFacets())) {
       return false;
     }
 

--- a/client/java/src/test/java/io/openlineage/client/dataset/partition/ReducedDatasetTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/partition/ReducedDatasetTest.java
@@ -9,7 +9,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage.Dataset;
+import io.openlineage.client.OpenLineage.DatasetFacets;
+import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.dataset.DatasetConfig;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ReducedDatasetTest {
@@ -28,6 +31,38 @@ class ReducedDatasetTest {
     verifyTrimDatasetName("/a/b/c", "/a/b/c");
     verifyTrimDatasetName("/a/b/2025-01-01/2025-01-01/c", "/a/b/2025-01-01/2025-01-01/c");
     verifyTrimDatasetName("/a/b/2025T01T01", "/a/b/2025T01T01");
+  }
+
+  @Test
+  void testReduceDatasetsWithNullFacets() {
+    InputDataset d1 = mock(InputDataset.class);
+    InputDataset d2 = mock(InputDataset.class);
+    when(d1.getName()).thenReturn("/a/b/2025-01-01");
+    when(d2.getName()).thenReturn("/a/b/2025-01-02");
+
+    Optional<ReducedDataset> reduced =
+        ReducedDataset.of(config, d1).reduce(ReducedDataset.of(config, d2));
+
+    assertThat(reduced).isPresent();
+    assertThat(reduced.get().getTrimmedDatasetName()).isEqualTo("/a/b");
+    assertThat(reduced.get().getNonTrimmedNames())
+        .containsExactly("/a/b/2025-01-01", "/a/b/2025-01-02");
+  }
+
+  @Test
+  void testReduceDatasetWithNullFacetsAndDatasetWithNonNullFacets() {
+    InputDataset withNullFacets = mock(InputDataset.class);
+    InputDataset withFacets = mock(InputDataset.class);
+    when(withNullFacets.getName()).thenReturn("/a/b/2025-01-01");
+    when(withFacets.getName()).thenReturn("/a/b/2025-01-02");
+    when(withFacets.getFacets()).thenReturn(mock(DatasetFacets.class));
+
+    assertThat(
+            ReducedDataset.of(config, withNullFacets).reduce(ReducedDataset.of(config, withFacets)))
+        .isEmpty();
+    assertThat(
+            ReducedDataset.of(config, withFacets).reduce(ReducedDataset.of(config, withNullFacets)))
+        .isEmpty();
   }
 
   private void verifyTrimDatasetName(String expected, String input) {


### PR DESCRIPTION
Closes #4836

### One-line summary for changelog:
Prevent dataset reduction failures when dataset facets are null.

### Meaningful description
ReducedDataset.hasSameFacets previously called equals directly on Dataset.getFacets(). Generated or mocked datasets can have null facets, causing a NullPointerException during partition-aware dataset reduction and aborting reduction for the event.

Use Objects.equals for the dataset-facet comparison, consistent with the existing null-safe input and output facet comparisons. Regression tests cover both null/null facets, which should reduce successfully, and null/non-null facets in both orders, which should remain distinct.

### Validation
- git diff --check
- Focused Gradle test and Spotless check could not run locally because JDK 17 is unavailable in the current environment; GitHub CI will run the project checks.

### Checklist
- [x] AI was used in creating this PR