### PR TITLE
client: add OL name escaping

### DIFF
--- a/client/go/pkg/openlineage/naming.go
+++ b/client/go/pkg/openlineage/naming.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2026 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package openlineage
+
+import (
+	"os"
+	"strings"
+)
+
+const nameEscapingEnvVar = "OPENLINEAGE__NAME__ESCAPING"
+
+// IsNameEscapingEnabled reports whether dot-escaping of name segments is
+// enabled.
+//
+// Escaping is on by default and can be disabled by setting the environment
+// variable OPENLINEAGE__NAME__ESCAPING=false (case-insensitive).
+func IsNameEscapingEnabled() bool {
+	raw := os.Getenv(nameEscapingEnvVar)
+	if raw == "" {
+		return true
+	}
+	return !strings.EqualFold(strings.TrimSpace(raw), "false")
+}
+
+// EscapeNameSegment escapes dots in a single OpenLineage name segment.
+//
+// OpenLineage names are structured as dot-separated segments, e.g.
+// "{database}.{schema}.{table}". When a segment itself contains a literal dot
+// (e.g. an Oracle service name "mydb.example.com"), the dot must be escaped so
+// that consumers can unambiguously split the name into its constituent parts.
+//
+// The escaping rule (from the naming specification) is: a literal "." inside a
+// segment is written as "\\.".
+//
+// The transformation is applied only when [IsNameEscapingEnabled] returns true;
+// otherwise the segment is returned unchanged.
+func EscapeNameSegment(segment string) string {
+	if !IsNameEscapingEnabled() {
+		return segment
+	}
+	return strings.ReplaceAll(segment, ".", "\\.")
+}

--- a/client/go/pkg/openlineage/naming.go
+++ b/client/go/pkg/openlineage/naming.go
@@ -15,14 +15,10 @@ const nameEscapingEnvVar = "OPENLINEAGE__NAME__ESCAPING"
 // IsNameEscapingEnabled reports whether dot-escaping of name segments is
 // enabled.
 //
-// Escaping is on by default and can be disabled by setting the environment
-// variable OPENLINEAGE__NAME__ESCAPING=false (case-insensitive).
+// Escaping is off by default and can be enabled by setting the environment
+// variable OPENLINEAGE__NAME__ESCAPING=true (case-insensitive).
 func IsNameEscapingEnabled() bool {
-	raw := os.Getenv(nameEscapingEnvVar)
-	if raw == "" {
-		return true
-	}
-	return !strings.EqualFold(strings.TrimSpace(raw), "false")
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(nameEscapingEnvVar)), "true")
 }
 
 // EscapeNameSegment escapes dots in a single OpenLineage name segment.

--- a/client/go/pkg/openlineage/naming_test.go
+++ b/client/go/pkg/openlineage/naming_test.go
@@ -34,41 +34,41 @@ func TestEscapeNameSegment_EscapingEnabled(t *testing.T) {
 	}
 }
 
-func TestEscapeNameSegment_EscapingDisabled(t *testing.T) {
-	t.Setenv("OPENLINEAGE__NAME__ESCAPING", "false")
+func TestEscapeNameSegment_EscapingDisabledByDefault(t *testing.T) {
+	t.Setenv("OPENLINEAGE__NAME__ESCAPING", "")
 
 	input := "mydb.example.com"
 	got := ol.EscapeNameSegment(input)
 	if got != input {
-		t.Errorf("EscapeNameSegment(%q) with escaping disabled = %q, want %q", input, got, input)
+		t.Errorf("EscapeNameSegment(%q) with escaping disabled by default = %q, want %q", input, got, input)
 	}
 }
 
-func TestIsNameEscapingEnabled_DefaultTrue(t *testing.T) {
+func TestIsNameEscapingEnabled_DefaultFalse(t *testing.T) {
 	t.Setenv("OPENLINEAGE__NAME__ESCAPING", "")
 
-	if !ol.IsNameEscapingEnabled() {
-		t.Error("expected escaping to be enabled by default")
+	if ol.IsNameEscapingEnabled() {
+		t.Error("expected escaping to be disabled by default")
 	}
 }
 
-func TestIsNameEscapingEnabled_FalseVariants(t *testing.T) {
-	for _, v := range []string{"false", "FALSE", "False", " false "} {
+func TestIsNameEscapingEnabled_TrueVariants(t *testing.T) {
+	for _, v := range []string{"true", "TRUE", "True", " true "} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv("OPENLINEAGE__NAME__ESCAPING", v)
-			if ol.IsNameEscapingEnabled() {
-				t.Errorf("expected escaping to be disabled for env value %q", v)
+			if !ol.IsNameEscapingEnabled() {
+				t.Errorf("expected escaping to be enabled for env value %q", v)
 			}
 		})
 	}
 }
 
-func TestIsNameEscapingEnabled_NonFalseValues(t *testing.T) {
-	for _, v := range []string{"true", "TRUE", "1", "yes", "on"} {
+func TestIsNameEscapingEnabled_NonTrueValues(t *testing.T) {
+	for _, v := range []string{"false", "FALSE", "1", "yes", "on"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv("OPENLINEAGE__NAME__ESCAPING", v)
-			if !ol.IsNameEscapingEnabled() {
-				t.Errorf("expected escaping to be enabled for env value %q", v)
+			if ol.IsNameEscapingEnabled() {
+				t.Errorf("expected escaping to be disabled for env value %q", v)
 			}
 		})
 	}

--- a/client/go/pkg/openlineage/naming_test.go
+++ b/client/go/pkg/openlineage/naming_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2026 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package openlineage_test
+
+import (
+	"testing"
+
+	ol "github.com/OpenLineage/openlineage/client/go/pkg/openlineage"
+)
+
+func TestEscapeNameSegment_EscapingEnabled(t *testing.T) {
+	t.Setenv("OPENLINEAGE__NAME__ESCAPING", "true")
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"plain", "plain"},
+		{"mydb.example.com", `mydb\.example\.com`},
+		{"one.two.three", `one\.two\.three`},
+		{"no_dots_here", "no_dots_here"},
+		{"leading.", `leading\.`},
+		{".leading", `\.leading`},
+	}
+
+	for _, tc := range cases {
+		got := ol.EscapeNameSegment(tc.input)
+		if got != tc.want {
+			t.Errorf("EscapeNameSegment(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestEscapeNameSegment_EscapingDisabled(t *testing.T) {
+	t.Setenv("OPENLINEAGE__NAME__ESCAPING", "false")
+
+	input := "mydb.example.com"
+	got := ol.EscapeNameSegment(input)
+	if got != input {
+		t.Errorf("EscapeNameSegment(%q) with escaping disabled = %q, want %q", input, got, input)
+	}
+}
+
+func TestIsNameEscapingEnabled_DefaultTrue(t *testing.T) {
+	t.Setenv("OPENLINEAGE__NAME__ESCAPING", "")
+
+	if !ol.IsNameEscapingEnabled() {
+		t.Error("expected escaping to be enabled by default")
+	}
+}
+
+func TestIsNameEscapingEnabled_FalseVariants(t *testing.T) {
+	for _, v := range []string{"false", "FALSE", "False", " false "} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("OPENLINEAGE__NAME__ESCAPING", v)
+			if ol.IsNameEscapingEnabled() {
+				t.Errorf("expected escaping to be disabled for env value %q", v)
+			}
+		})
+	}
+}
+
+func TestIsNameEscapingEnabled_NonFalseValues(t *testing.T) {
+	for _, v := range []string{"true", "TRUE", "1", "yes", "on"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("OPENLINEAGE__NAME__ESCAPING", v)
+			if !ol.IsNameEscapingEnabled() {
+				t.Errorf("expected escaping to be enabled for env value %q", v)
+			}
+		})
+	}
+}

--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -71,6 +71,9 @@ public final class Clients {
     Optional.ofNullable(openLineageConfig.getMetricsConfig())
         .map(MicrometerProvider::addMeterRegistryFromConfig)
         .ifPresent(f -> builder.meterRegistry((MeterRegistry) f)); // Java 8 requires cast here :(
+
+    Optional.ofNullable(openLineageConfig.getNameConfig()).ifPresent(builder::nameConfig);
+
     return builder.transport(transport).build();
   }
 

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -11,6 +11,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.openlineage.client.circuitBreaker.CircuitBreaker;
 import io.openlineage.client.metrics.MicrometerProvider;
+import io.openlineage.client.naming.NameConfig;
 import io.openlineage.client.transports.ConsoleTransport;
 import io.openlineage.client.transports.Transport;
 import java.time.Duration;
@@ -29,6 +30,7 @@ public final class OpenLineageClient implements AutoCloseable {
   final Optional<CircuitBreaker> circuitBreaker;
   final MeterRegistry meterRegistry;
   final String[] disabledFacets;
+  final NameConfig nameConfig;
 
   Counter emitStart;
   Counter emitComplete;
@@ -53,9 +55,19 @@ public final class OpenLineageClient implements AutoCloseable {
       CircuitBreaker circuitBreaker,
       MeterRegistry meterRegistry,
       String... disabledFacets) {
+    this(transport, circuitBreaker, meterRegistry, null, disabledFacets);
+  }
+
+  public OpenLineageClient(
+      @NonNull final Transport transport,
+      CircuitBreaker circuitBreaker,
+      MeterRegistry meterRegistry,
+      NameConfig nameConfig,
+      String... disabledFacets) {
     this.transport = transport;
     this.disabledFacets = Arrays.copyOf(disabledFacets, disabledFacets.length);
     this.circuitBreaker = Optional.ofNullable(circuitBreaker);
+    this.nameConfig = nameConfig;
     if (meterRegistry == null) {
       this.meterRegistry = MicrometerProvider.getMeterRegistry();
     } else {
@@ -210,6 +222,7 @@ public final class OpenLineageClient implements AutoCloseable {
     private String[] disabledFacets;
     private CircuitBreaker circuitBreaker;
     private MeterRegistry meterRegistry;
+    private NameConfig nameConfig;
 
     private Builder() {
       this.transport = DEFAULT_TRANSPORT;
@@ -236,12 +249,18 @@ public final class OpenLineageClient implements AutoCloseable {
       return this;
     }
 
+    public Builder nameConfig(NameConfig nameConfig) {
+      this.nameConfig = nameConfig;
+      return this;
+    }
+
     /**
      * @return an {@link OpenLineageClient} object with the properties of this {@link
      *     OpenLineageClient.Builder}.
      */
     public OpenLineageClient build() {
-      return new OpenLineageClient(transport, circuitBreaker, meterRegistry, disabledFacets);
+      return new OpenLineageClient(
+          transport, circuitBreaker, meterRegistry, nameConfig, disabledFacets);
     }
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -359,7 +359,7 @@ public final class OpenLineageClientUtils {
   public static ExecutorService getOrCreateExecutor() {
     return EXECUTOR.updateAndGet(
         existing -> {
-          if (existing == null) {
+          if (existing == null || existing.isShutdown()) {
             return Executors.newFixedThreadPool(
                 DEFAULT_THREAD_POOL_SIZE, new ExecutorThreadFactory("openlineage-executor"));
           }
@@ -370,7 +370,7 @@ public final class OpenLineageClientUtils {
   public static ExecutorService getOrCreateExecutor(ThreadFactory threadFactory) {
     return EXECUTOR.updateAndGet(
         existing -> {
-          if (existing == null) {
+          if (existing == null || existing.isShutdown()) {
             return Executors.newFixedThreadPool(DEFAULT_THREAD_POOL_SIZE, threadFactory);
           }
           return existing;

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.job.JobConfig;
+import io.openlineage.client.naming.NameConfig;
 import io.openlineage.client.run.RunConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
@@ -53,6 +54,9 @@ public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConf
   @JsonProperty("job")
   protected JobConfig jobConfig;
 
+  @JsonProperty("name")
+  protected NameConfig nameConfig;
+
   /**
    * Overwrites existing object with properties of other config entries whenever they're present.
    *
@@ -68,6 +72,7 @@ public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConf
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
         mergePropertyWith(metricsConfig, other.metricsConfig),
         mergePropertyWith(runConfig, other.runConfig),
-        mergePropertyWith(jobConfig, other.jobConfig));
+        mergePropertyWith(jobConfig, other.jobConfig),
+        mergePropertyWith(nameConfig, other.nameConfig));
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/dataset/Naming.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/Naming.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.dataset;
 
+import io.openlineage.client.naming.NameEscaping;
 import lombok.Builder;
 
 /**
@@ -40,7 +41,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return catalog + "." + database + "." + table;
+      return NameEscaping.escapeSegment(catalog)
+          + "."
+          + NameEscaping.escapeSegment(database)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -140,7 +145,7 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return schema + "." + table;
+      return NameEscaping.escapeSegment(schema) + "." + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -175,7 +180,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return String.format("%s.%s.%s", projectId, datasetName, tableName);
+      return NameEscaping.escapeSegment(projectId)
+          + "."
+          + NameEscaping.escapeSegment(datasetName)
+          + "."
+          + NameEscaping.escapeSegment(tableName);
     }
   }
 
@@ -201,7 +210,7 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return keyspace + "." + table;
+      return NameEscaping.escapeSegment(keyspace) + "." + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -266,7 +275,7 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + table;
+      return NameEscaping.escapeSegment(database) + "." + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -294,7 +303,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(database)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -322,7 +335,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(database)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -348,7 +365,7 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + table;
+      return NameEscaping.escapeSegment(database) + "." + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -376,7 +393,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return serviceName + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(serviceName)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -404,7 +425,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(database)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -430,7 +455,7 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + table;
+      return NameEscaping.escapeSegment(database) + "." + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -466,7 +491,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(database)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -499,7 +528,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return database + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(database)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 
@@ -527,7 +560,11 @@ public final class Naming {
 
     @Override
     public String getName() {
-      return catalog + "." + schema + "." + table;
+      return NameEscaping.escapeSegment(catalog)
+          + "."
+          + NameEscaping.escapeSegment(schema)
+          + "."
+          + NameEscaping.escapeSegment(table);
     }
   }
 

--- a/client/java/src/main/java/io/openlineage/client/job/Naming.java
+++ b/client/java/src/main/java/io/openlineage/client/job/Naming.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.job;
 
+import io.openlineage.client.naming.NameEscaping;
 import javax.annotation.Nullable;
 import lombok.Builder;
 
@@ -64,7 +65,9 @@ public class Naming {
      */
     @Override
     public String getName() {
-      return appName + (command != null ? "." + command : "") + (table != null ? "." + table : "");
+      return NameEscaping.escapeSegment(appName)
+          + (command != null ? "." + NameEscaping.escapeSegment(command) : "")
+          + (table != null ? "." + NameEscaping.escapeSegment(table) : "");
     }
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/naming/NameConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/naming/NameConfig.java
@@ -20,13 +20,13 @@ import lombok.ToString;
  *
  * <pre>{@code
  * name:
- *   escaping: false   # disable automatic dot-escaping of name segments
+ *   escaping: true   # enable automatic dot-escaping of name segments (off by default)
  * }</pre>
  *
  * <p>The same setting can also be applied through the dynamic environment variable convention:
  *
  * <pre>{@code
- * OPENLINEAGE__NAME__ESCAPING=false
+ * OPENLINEAGE__NAME__ESCAPING=true
  * }</pre>
  *
  * <p>When the environment variable is set it takes precedence because {@link NameEscaping} reads
@@ -41,8 +41,8 @@ import lombok.ToString;
 public class NameConfig implements MergeConfig<NameConfig> {
 
   /**
-   * When {@code false}, automatic dot-escaping of name segments is disabled. Defaults to {@code
-   * null}, which is treated as {@code true} (escaping enabled) by {@link NameEscaping}.
+   * When {@code true}, automatic dot-escaping of name segments is enabled. Defaults to {@code
+   * null}, which is treated as {@code false} (escaping disabled) by {@link NameEscaping}.
    */
   @JsonProperty("escaping")
   private Boolean escaping;

--- a/client/java/src/main/java/io/openlineage/client/naming/NameConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/naming/NameConfig.java
@@ -1,0 +1,56 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.naming;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.MergeConfig;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Configuration for OpenLineage name-related behaviour.
+ *
+ * <p>This class is bound to the {@code name} key in the top-level OpenLineage configuration:
+ *
+ * <pre>{@code
+ * name:
+ *   escaping: false   # disable automatic dot-escaping of name segments
+ * }</pre>
+ *
+ * <p>The same setting can also be applied through the dynamic environment variable convention:
+ *
+ * <pre>{@code
+ * OPENLINEAGE__NAME__ESCAPING=false
+ * }</pre>
+ *
+ * <p>When the environment variable is set it takes precedence because {@link NameEscaping} reads
+ * {@code System.getenv("OPENLINEAGE__NAME__ESCAPING")} at call time, independently of whether the
+ * YAML configuration has been loaded.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NameConfig implements MergeConfig<NameConfig> {
+
+  /**
+   * When {@code false}, automatic dot-escaping of name segments is disabled. Defaults to {@code
+   * null}, which is treated as {@code true} (escaping enabled) by {@link NameEscaping}.
+   */
+  @JsonProperty("escaping")
+  private Boolean escaping;
+
+  @Override
+  public NameConfig mergeWithNonNull(NameConfig other) {
+    NameConfig merged = new NameConfig();
+    merged.escaping = mergePropertyWith(this.escaping, other.escaping);
+    return merged;
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/naming/NameEscaping.java
+++ b/client/java/src/main/java/io/openlineage/client/naming/NameEscaping.java
@@ -1,0 +1,66 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.naming;
+
+import org.apache.commons.lang3.Strings;
+
+/**
+ * Utility class for escaping dots in OpenLineage name segments.
+ *
+ * <p>OpenLineage names are structured as dot-separated segments, e.g. {@code
+ * {database}.{schema}.{table}}. When a segment itself contains a literal dot (e.g. an Oracle
+ * service name {@code mydb.example.com}), the dot must be escaped so that consumers can
+ * unambiguously split the name into its constituent parts.
+ *
+ * <p>The escaping rule (from the naming specification) is: a literal {@code .} inside a segment is
+ * written as {@code \\.}.
+ *
+ * <p>Escaping is <em>enabled by default</em> and can be disabled by setting the environment
+ * variable {@code OPENLINEAGE__NAME__ESCAPING} to {@code false} (case-insensitive). This is
+ * intended as an escape hatch for producers that emit names that are already pre-escaped or that
+ * target consumers which do not yet support the escaping convention.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * // "mydb\\.example\\.com.mySchema.myTable"
+ * NameEscaping.escapeSegment("mydb.example.com") + "." + "mySchema" + "." + "myTable"
+ * }</pre>
+ */
+public final class NameEscaping {
+
+  private static final String ENV_VAR = "OPENLINEAGE__NAME__ESCAPING";
+
+  private NameEscaping() {}
+
+  /**
+   * Returns {@code true} if dot-escaping is enabled (the default).
+   *
+   * <p>Escaping can be disabled by setting the environment variable {@code
+   * OPENLINEAGE__NAME__ESCAPING=false} (case-insensitive).
+   *
+   * @return {@code true} when escaping is active
+   */
+  public static boolean isEscapingEnabled() {
+    return !Strings.CI.equals("false", System.getenv(ENV_VAR));
+  }
+
+  /**
+   * Escapes dots in a single name segment when escaping is enabled.
+   *
+   * <p>A literal {@code .} is replaced with {@code \\.} so that consumers can tell structural dots
+   * (separating segments) from literal dots that are part of a segment value.
+   *
+   * <p>The transformation is applied only when {@link #isEscapingEnabled()} returns {@code true};
+   * otherwise the segment is returned unchanged.
+   *
+   * @param segment a single name component (e.g. database, schema, table)
+   * @return the segment with literal dots escaped, or unchanged when escaping is disabled
+   */
+  public static String escapeSegment(String segment) {
+    return isEscapingEnabled() ? segment.replace(".", "\\.") : segment;
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/naming/NameEscaping.java
+++ b/client/java/src/main/java/io/openlineage/client/naming/NameEscaping.java
@@ -20,6 +20,12 @@ package io.openlineage.client.naming;
  * variable {@code OPENLINEAGE__NAME__ESCAPING} to {@code true} (case-insensitive), or by setting
  * {@code name.escaping: true} in the YAML configuration.
  *
+ * <p>When a {@link NameConfig} is available (e.g. loaded from YAML), prefer the overloads that
+ * accept it — {@link #isEscapingEnabled(NameConfig)} and {@link #escapeSegment(String, NameConfig)}
+ * — so that the YAML setting takes precedence over the environment variable. The zero-argument
+ * overloads consult only the environment variable and are intended for call sites that do not have
+ * access to a {@link NameConfig} instance.
+ *
  * <p>Example:
  *
  * <pre>{@code
@@ -34,10 +40,11 @@ public final class NameEscaping {
   private NameEscaping() {}
 
   /**
-   * Returns {@code true} if dot-escaping is enabled.
+   * Returns {@code true} if dot-escaping is enabled, consulting only the environment variable
+   * {@code OPENLINEAGE__NAME__ESCAPING}.
    *
-   * <p>Escaping is <em>disabled by default</em>. It can be enabled by setting the environment
-   * variable {@code OPENLINEAGE__NAME__ESCAPING=true} (case-insensitive).
+   * <p>Use {@link #isEscapingEnabled(NameConfig)} when a {@link NameConfig} is available so that
+   * the YAML setting takes precedence.
    *
    * @return {@code true} when escaping is active
    */
@@ -46,18 +53,51 @@ public final class NameEscaping {
   }
 
   /**
-   * Escapes dots in a single name segment when escaping is enabled.
+   * Returns {@code true} if dot-escaping is enabled, with the following resolution order:
    *
-   * <p>A literal {@code .} is replaced with {@code \\.} so that consumers can tell structural dots
-   * (separating segments) from literal dots that are part of a segment value.
+   * <ol>
+   *   <li>If {@code nameConfig} is non-{@code null} and its {@code escaping} field is non-{@code
+   *       null}, that value is returned.
+   *   <li>Otherwise the environment variable {@code OPENLINEAGE__NAME__ESCAPING} is consulted.
+   * </ol>
    *
-   * <p>The transformation is applied only when {@link #isEscapingEnabled()} returns {@code true};
-   * otherwise the segment is returned unchanged.
+   * @param nameConfig the parsed name configuration, may be {@code null}
+   * @return {@code true} when escaping is active
+   */
+  public static boolean isEscapingEnabled(NameConfig nameConfig) {
+    if (nameConfig != null && nameConfig.getEscaping() != null) {
+      return nameConfig.getEscaping();
+    }
+    return isEscapingEnabled();
+  }
+
+  /**
+   * Escapes dots in a single name segment when escaping is enabled, consulting only the environment
+   * variable.
+   *
+   * <p>Use {@link #escapeSegment(String, NameConfig)} when a {@link NameConfig} is available.
    *
    * @param segment a single name component (e.g. database, schema, table)
    * @return the segment with literal dots escaped, or unchanged when escaping is disabled
    */
   public static String escapeSegment(String segment) {
     return isEscapingEnabled() ? segment.replace(".", "\\.") : segment;
+  }
+
+  /**
+   * Escapes dots in a single name segment when escaping is enabled.
+   *
+   * <p>A literal {@code .} is replaced with {@code \\.} so that consumers can tell structural dots
+   * (separating segments) from literal dots that are part of a segment value.
+   *
+   * <p>The transformation is applied only when {@link #isEscapingEnabled(NameConfig)} returns
+   * {@code true}; otherwise the segment is returned unchanged.
+   *
+   * @param segment a single name component (e.g. database, schema, table)
+   * @param nameConfig the parsed name configuration, may be {@code null}
+   * @return the segment with literal dots escaped, or unchanged when escaping is disabled
+   */
+  public static String escapeSegment(String segment, NameConfig nameConfig) {
+    return isEscapingEnabled(nameConfig) ? segment.replace(".", "\\.") : segment;
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/naming/NameEscaping.java
+++ b/client/java/src/main/java/io/openlineage/client/naming/NameEscaping.java
@@ -5,8 +5,6 @@
 
 package io.openlineage.client.naming;
 
-import org.apache.commons.lang3.Strings;
-
 /**
  * Utility class for escaping dots in OpenLineage name segments.
  *
@@ -18,10 +16,9 @@ import org.apache.commons.lang3.Strings;
  * <p>The escaping rule (from the naming specification) is: a literal {@code .} inside a segment is
  * written as {@code \\.}.
  *
- * <p>Escaping is <em>enabled by default</em> and can be disabled by setting the environment
- * variable {@code OPENLINEAGE__NAME__ESCAPING} to {@code false} (case-insensitive). This is
- * intended as an escape hatch for producers that emit names that are already pre-escaped or that
- * target consumers which do not yet support the escaping convention.
+ * <p>Escaping is <em>disabled by default</em> and can be enabled by setting the environment
+ * variable {@code OPENLINEAGE__NAME__ESCAPING} to {@code true} (case-insensitive), or by setting
+ * {@code name.escaping: true} in the YAML configuration.
  *
  * <p>Example:
  *
@@ -37,15 +34,15 @@ public final class NameEscaping {
   private NameEscaping() {}
 
   /**
-   * Returns {@code true} if dot-escaping is enabled (the default).
+   * Returns {@code true} if dot-escaping is enabled.
    *
-   * <p>Escaping can be disabled by setting the environment variable {@code
-   * OPENLINEAGE__NAME__ESCAPING=false} (case-insensitive).
+   * <p>Escaping is <em>disabled by default</em>. It can be enabled by setting the environment
+   * variable {@code OPENLINEAGE__NAME__ESCAPING=true} (case-insensitive).
    *
    * @return {@code true} when escaping is active
    */
   public static boolean isEscapingEnabled() {
-    return !Strings.CI.equals("false", System.getenv(ENV_VAR));
+    return Boolean.valueOf(System.getenv(ENV_VAR));
   }
 
   /**

--- a/client/java/src/test/java/io/openlineage/client/dataset/NamingTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/NamingTest.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.dataset;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
@@ -327,5 +328,24 @@ class NamingTest {
     assertThrowsExactly(
         IllegalArgumentException.class,
         () -> Naming.Athena.builder().catalog("some-catalog").build());
+  }
+
+  // -----------------------------------------------------------------------
+  // Escaping tests via Naming helpers (env-var default: escaping enabled)
+  // Full env-var toggle tests live in NameEscapingTest.
+  // -----------------------------------------------------------------------
+
+  @Test
+  void oracleNamingWithPlainSegmentsProducesExpectedName() {
+    Naming.Oracle naming =
+        Naming.Oracle.builder()
+            .host("localhost")
+            .port("1521")
+            .serviceName("ORCLCDB")
+            .schema("myschema")
+            .table("my_table")
+            .build();
+    // No dots in any segment — output is the same regardless of escaping.
+    assertThat(naming.getName()).isEqualTo("ORCLCDB.myschema.my_table");
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/job/NamingTest.java
+++ b/client/java/src/test/java/io/openlineage/client/job/NamingTest.java
@@ -5,34 +5,132 @@
 
 package io.openlineage.client.job;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class NamingTest {
 
+  private static final String ENV_VAR = "OPENLINEAGE__NAME__ESCAPING";
+
+  @SuppressWarnings({"unchecked", "PMD"})
+  private void setEnv(Map<String, String> vars) throws Exception {
+    Class<?> cls = System.getenv().getClass();
+    Field f = cls.getDeclaredField("m");
+    f.setAccessible(true);
+    Map<String, String> writable = (Map<String, String>) f.get(System.getenv());
+    writable.putAll(vars);
+  }
+
+  @SuppressWarnings({"unchecked", "PMD"})
+  private void clearEnv(Set<String> keys) throws Exception {
+    Class<?> cls = System.getenv().getClass();
+    Field f = cls.getDeclaredField("m");
+    f.setAccessible(true);
+    Map<String, String> writable = (Map<String, String>) f.get(System.getenv());
+    keys.forEach(writable::remove);
+  }
+
+  @AfterEach
+  void restoreEnv() throws Exception {
+    clearEnv(Set.of(ENV_VAR));
+  }
+
+  // -----------------------------------------------------------------------
+  // Escaping disabled (default)
+  // -----------------------------------------------------------------------
+
   @Test
-  void testSparkJobName() {
+  void sparkNameAllSegments_noEscaping() throws Exception {
+    clearEnv(Set.of(ENV_VAR));
     Naming.Spark spark =
         Naming.Spark.builder()
-            .appName("my_awesome_app")
-            .command("execute_insert_into_hive_table")
-            .table("mydb_mytable")
+            .appName("my.app")
+            .command("execute_insert")
+            .table("mydb.myschema.mytable")
             .build();
 
-    assertEquals("my_awesome_app.execute_insert_into_hive_table.mydb_mytable", spark.getName());
+    assertThat(spark.getName()).isEqualTo("my.app.execute_insert.mydb.myschema.mytable");
   }
 
   @Test
-  void testSparkEmptyFieldsThrowException() {
-    assertThrows(IllegalArgumentException.class, () -> new Naming.Spark("", "cmd", "table"));
+  void sparkNameNullCommandAndTable_noEscaping() throws Exception {
+    clearEnv(Set.of(ENV_VAR));
+    Naming.Spark spark = Naming.Spark.builder().appName("my.app").build();
+
+    assertThat(spark.getName()).isEqualTo("my.app");
   }
 
   @Test
-  void testSparkNullFieldsThrowException() {
-    assertThrows(
-        NullPointerException.class,
-        () -> Naming.Spark.builder().appName(null).command("cmd").table("table").build());
+  void sparkNameNullTable_noEscaping() throws Exception {
+    clearEnv(Set.of(ENV_VAR));
+    Naming.Spark spark = Naming.Spark.builder().appName("my.app").command("execute_insert").build();
+
+    assertThat(spark.getName()).isEqualTo("my.app.execute_insert");
+  }
+
+  // -----------------------------------------------------------------------
+  // Escaping enabled via environment variable
+  // -----------------------------------------------------------------------
+
+  @Test
+  void sparkNameAllSegments_escapingEnabled() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnv(env);
+
+    try {
+      Naming.Spark spark =
+          Naming.Spark.builder()
+              .appName("my.app")
+              .command("execute_insert")
+              .table("mydb.myschema.mytable")
+              .build();
+
+      // Each segment's internal dots are escaped; structural dots between segments are not.
+      assertThat(spark.getName()).isEqualTo("my\\.app.execute_insert.mydb\\.myschema\\.mytable");
+    } finally {
+      clearEnv(env.keySet());
+    }
+  }
+
+  @Test
+  void sparkNameNullCommandAndTable_escapingEnabled() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnv(env);
+
+    try {
+      Naming.Spark spark = Naming.Spark.builder().appName("my.app").build();
+
+      assertThat(spark.getName()).isEqualTo("my\\.app");
+    } finally {
+      clearEnv(env.keySet());
+    }
+  }
+
+  @Test
+  void sparkNamePlainSegments_escapingEnabled_unchanged() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnv(env);
+
+    try {
+      Naming.Spark spark =
+          Naming.Spark.builder()
+              .appName("myapp")
+              .command("execute_insert")
+              .table("mytable")
+              .build();
+
+      assertThat(spark.getName()).isEqualTo("myapp.execute_insert.mytable");
+    } finally {
+      clearEnv(env.keySet());
+    }
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/naming/NameEscapingTest.java
+++ b/client/java/src/test/java/io/openlineage/client/naming/NameEscapingTest.java
@@ -1,0 +1,271 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.naming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.client.OpenLineageConfig;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class NameEscapingTest {
+
+  private static final String ENV_VAR = "OPENLINEAGE__NAME__ESCAPING";
+
+  // -----------------------------------------------------------------------
+  // Helpers — identical pattern to JwtTokenProviderTest
+  // -----------------------------------------------------------------------
+
+  @SuppressWarnings({"unchecked", "PMD"})
+  private void setEnvironmentVariables(Map<String, String> newEnv) throws Exception {
+    Class<?> classOfMap = System.getenv().getClass();
+    Field field = classOfMap.getDeclaredField("m");
+    field.setAccessible(true);
+    Map<String, String> writeable = (Map<String, String>) field.get(System.getenv());
+    writeable.putAll(newEnv);
+  }
+
+  @SuppressWarnings({"unchecked", "PMD"})
+  private void clearEnvironmentVariables(Set<String> keys) throws Exception {
+    Class<?> classOfMap = System.getenv().getClass();
+    Field field = classOfMap.getDeclaredField("m");
+    field.setAccessible(true);
+    Map<String, String> writeable = (Map<String, String>) field.get(System.getenv());
+    keys.forEach(writeable::remove);
+  }
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    // Always restore so subsequent tests start with escaping enabled (the default).
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+  }
+
+  // -----------------------------------------------------------------------
+  // isEscapingEnabled — env-var behaviour
+  // -----------------------------------------------------------------------
+
+  @Test
+  void escapingIsEnabledByDefault() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    assertThat(NameEscaping.isEscapingEnabled()).isTrue();
+  }
+
+  @Test
+  void escapingIsDisabledWhenEnvVarIsFalse() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "false");
+    setEnvironmentVariables(env);
+
+    try {
+      assertThat(NameEscaping.isEscapingEnabled()).isFalse();
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
+  }
+
+  @Test
+  void escapingIsDisabledCaseInsensitive() throws Exception {
+    for (String value : new String[] {"false", "FALSE", "False"}) {
+      Map<String, String> env = new HashMap<>();
+      env.put(ENV_VAR, value);
+      setEnvironmentVariables(env);
+
+      try {
+        assertThat(NameEscaping.isEscapingEnabled())
+            .as("isEscapingEnabled() should be false for env value %s", value)
+            .isFalse();
+      } finally {
+        clearEnvironmentVariables(env.keySet());
+      }
+    }
+  }
+
+  @Test
+  void escapingRemainsEnabledForNonFalseValues() throws Exception {
+    for (String value : new String[] {"true", "TRUE", "1", "yes", "on"}) {
+      Map<String, String> env = new HashMap<>();
+      env.put(ENV_VAR, value);
+      setEnvironmentVariables(env);
+
+      try {
+        assertThat(NameEscaping.isEscapingEnabled())
+            .as("isEscapingEnabled() should be true for env value %s", value)
+            .isTrue();
+      } finally {
+        clearEnvironmentVariables(env.keySet());
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // escapeSegment — transformation behaviour
+  // -----------------------------------------------------------------------
+
+  @Test
+  void escapeSegmentEscapesDotsWhenEnabled() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    assertThat(NameEscaping.escapeSegment("mydb.example.com")).isEqualTo("mydb\\.example\\.com");
+  }
+
+  @Test
+  void escapeSegmentEscapesMultipleDots() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    assertThat(NameEscaping.escapeSegment("a.b.c")).isEqualTo("a\\.b\\.c");
+  }
+
+  @Test
+  void escapeSegmentLeavesNonDotCharsUnchanged() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    assertThat(NameEscaping.escapeSegment("my_schema")).isEqualTo("my_schema");
+    assertThat(NameEscaping.escapeSegment("myTable")).isEqualTo("myTable");
+    assertThat(NameEscaping.escapeSegment("plain")).isEqualTo("plain");
+  }
+
+  @Test
+  void escapeSegmentReturnsInputUnchangedWhenDisabled() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "false");
+    setEnvironmentVariables(env);
+
+    try {
+      assertThat(NameEscaping.escapeSegment("mydb.example.com")).isEqualTo("mydb.example.com");
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // OpenLineageConfig — name.escaping is parsed correctly from env vars
+  // -----------------------------------------------------------------------
+
+  @Test
+  void nameConfigEscapingIsTrueWhenEnvVarIsTrue() throws Exception {
+    Map<String, String> envVars = new HashMap<>();
+    envVars.put("OPENLINEAGE__TRANSPORT__TYPE", "console");
+    envVars.put(ENV_VAR, "true");
+    setEnvironmentVariables(envVars);
+
+    try {
+      OpenLineageConfig<?> config =
+          OpenLineageClientUtils.loadOpenLineageConfigFromEnvVars(
+              new TypeReference<OpenLineageConfig<OpenLineageConfig<?>>>() {});
+
+      assertThat(config.getNameConfig()).isNotNull();
+      assertThat(config.getNameConfig().getEscaping()).isTrue();
+    } finally {
+      clearEnvironmentVariables(envVars.keySet());
+    }
+  }
+
+  @Test
+  void nameConfigEscapingIsFalseWhenEnvVarIsFalse() throws Exception {
+    Map<String, String> envVars = new HashMap<>();
+    envVars.put("OPENLINEAGE__TRANSPORT__TYPE", "console");
+    envVars.put(ENV_VAR, "false");
+    setEnvironmentVariables(envVars);
+
+    try {
+      OpenLineageConfig<?> config =
+          OpenLineageClientUtils.loadOpenLineageConfigFromEnvVars(
+              new TypeReference<OpenLineageConfig<OpenLineageConfig<?>>>() {});
+
+      assertThat(config.getNameConfig()).isNotNull();
+      assertThat(config.getNameConfig().getEscaping()).isFalse();
+    } finally {
+      clearEnvironmentVariables(envVars.keySet());
+    }
+  }
+
+  @Test
+  void nameConfigIsNullWhenEnvVarIsAbsent() throws Exception {
+    Map<String, String> envVars = new HashMap<>();
+    envVars.put("OPENLINEAGE__TRANSPORT__TYPE", "console");
+    // ENV_VAR intentionally not set
+    setEnvironmentVariables(envVars);
+
+    try {
+      OpenLineageConfig<?> config =
+          OpenLineageClientUtils.loadOpenLineageConfigFromEnvVars(
+              new TypeReference<OpenLineageConfig<OpenLineageConfig<?>>>() {});
+
+      // nameConfig may be null when the env var was never set; null means "use default" (enabled)
+      if (config.getNameConfig() != null) {
+        assertThat(config.getNameConfig().getEscaping()).isNull();
+      }
+    } finally {
+      clearEnvironmentVariables(envVars.keySet());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Integration — Naming helpers respect the env var end-to-end
+  // -----------------------------------------------------------------------
+
+  @Test
+  void oracleNamingEscapesServiceNameWithDotsByDefault() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    io.openlineage.client.dataset.Naming.Oracle oracle =
+        io.openlineage.client.dataset.Naming.Oracle.builder()
+            .host("localhost")
+            .port("1521")
+            .serviceName("mydb.example.com")
+            .schema("mySchema")
+            .table("myTable")
+            .build();
+
+    // Spec example: "mydb\.example\.com.mySchema.myTable"
+    assertThat(oracle.getName()).isEqualTo("mydb\\.example\\.com.mySchema.myTable");
+  }
+
+  @Test
+  void oracleNamingDoesNotEscapeWhenDisabled() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "false");
+    setEnvironmentVariables(env);
+
+    try {
+      io.openlineage.client.dataset.Naming.Oracle oracle =
+          io.openlineage.client.dataset.Naming.Oracle.builder()
+              .host("localhost")
+              .port("1521")
+              .serviceName("mydb.example.com")
+              .schema("mySchema")
+              .table("myTable")
+              .build();
+
+      assertThat(oracle.getName()).isEqualTo("mydb.example.com.mySchema.myTable");
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
+  }
+
+  @Test
+  void plainSegmentsAreUnchangedRegardlessOfEscapingSetting() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    io.openlineage.client.dataset.Naming.Postgres pg =
+        io.openlineage.client.dataset.Naming.Postgres.builder()
+            .host("localhost")
+            .port("5432")
+            .database("mydb")
+            .schema("myschema")
+            .table("mytable")
+            .build();
+
+    assertThat(pg.getName()).isEqualTo("mydb.myschema.mytable");
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/naming/NameEscapingTest.java
+++ b/client/java/src/test/java/io/openlineage/client/naming/NameEscapingTest.java
@@ -45,7 +45,7 @@ class NameEscapingTest {
 
   @AfterEach
   void cleanUp() throws Exception {
-    // Always restore so subsequent tests start with escaping enabled (the default).
+    // Always restore so subsequent tests start with escaping disabled (the default).
     clearEnvironmentVariables(Set.of(ENV_VAR));
   }
 
@@ -54,45 +54,28 @@ class NameEscapingTest {
   // -----------------------------------------------------------------------
 
   @Test
-  void escapingIsEnabledByDefault() throws Exception {
+  void escapingIsDisabledByDefault() throws Exception {
     clearEnvironmentVariables(Set.of(ENV_VAR));
 
-    assertThat(NameEscaping.isEscapingEnabled()).isTrue();
+    assertThat(NameEscaping.isEscapingEnabled()).isFalse();
   }
 
   @Test
-  void escapingIsDisabledWhenEnvVarIsFalse() throws Exception {
+  void escapingIsEnabledWhenEnvVarIsTrue() throws Exception {
     Map<String, String> env = new HashMap<>();
-    env.put(ENV_VAR, "false");
+    env.put(ENV_VAR, "true");
     setEnvironmentVariables(env);
 
     try {
-      assertThat(NameEscaping.isEscapingEnabled()).isFalse();
+      assertThat(NameEscaping.isEscapingEnabled()).isTrue();
     } finally {
       clearEnvironmentVariables(env.keySet());
     }
   }
 
   @Test
-  void escapingIsDisabledCaseInsensitive() throws Exception {
-    for (String value : new String[] {"false", "FALSE", "False"}) {
-      Map<String, String> env = new HashMap<>();
-      env.put(ENV_VAR, value);
-      setEnvironmentVariables(env);
-
-      try {
-        assertThat(NameEscaping.isEscapingEnabled())
-            .as("isEscapingEnabled() should be false for env value %s", value)
-            .isFalse();
-      } finally {
-        clearEnvironmentVariables(env.keySet());
-      }
-    }
-  }
-
-  @Test
-  void escapingRemainsEnabledForNonFalseValues() throws Exception {
-    for (String value : new String[] {"true", "TRUE", "1", "yes", "on"}) {
+  void escapingIsEnabledCaseInsensitive() throws Exception {
+    for (String value : new String[] {"true", "TRUE", "True"}) {
       Map<String, String> env = new HashMap<>();
       env.put(ENV_VAR, value);
       setEnvironmentVariables(env);
@@ -107,22 +90,58 @@ class NameEscapingTest {
     }
   }
 
+  @Test
+  void escapingRemainsDisabledForNonTrueValues() throws Exception {
+    for (String value : new String[] {"false", "FALSE", "1", "yes", "on"}) {
+      Map<String, String> env = new HashMap<>();
+      env.put(ENV_VAR, value);
+      setEnvironmentVariables(env);
+
+      try {
+        assertThat(NameEscaping.isEscapingEnabled())
+            .as("isEscapingEnabled() should be false for env value %s", value)
+            .isFalse();
+      } finally {
+        clearEnvironmentVariables(env.keySet());
+      }
+    }
+  }
+
   // -----------------------------------------------------------------------
   // escapeSegment — transformation behaviour
   // -----------------------------------------------------------------------
 
   @Test
-  void escapeSegmentEscapesDotsWhenEnabled() throws Exception {
+  void escapeSegmentReturnsInputUnchangedByDefault() throws Exception {
     clearEnvironmentVariables(Set.of(ENV_VAR));
 
-    assertThat(NameEscaping.escapeSegment("mydb.example.com")).isEqualTo("mydb\\.example\\.com");
+    assertThat(NameEscaping.escapeSegment("mydb.example.com")).isEqualTo("mydb.example.com");
+  }
+
+  @Test
+  void escapeSegmentEscapesDotsWhenEnabled() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnvironmentVariables(env);
+
+    try {
+      assertThat(NameEscaping.escapeSegment("mydb.example.com")).isEqualTo("mydb\\.example\\.com");
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
   }
 
   @Test
   void escapeSegmentEscapesMultipleDots() throws Exception {
-    clearEnvironmentVariables(Set.of(ENV_VAR));
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnvironmentVariables(env);
 
-    assertThat(NameEscaping.escapeSegment("a.b.c")).isEqualTo("a\\.b\\.c");
+    try {
+      assertThat(NameEscaping.escapeSegment("a.b.c")).isEqualTo("a\\.b\\.c");
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
   }
 
   @Test
@@ -132,19 +151,6 @@ class NameEscapingTest {
     assertThat(NameEscaping.escapeSegment("my_schema")).isEqualTo("my_schema");
     assertThat(NameEscaping.escapeSegment("myTable")).isEqualTo("myTable");
     assertThat(NameEscaping.escapeSegment("plain")).isEqualTo("plain");
-  }
-
-  @Test
-  void escapeSegmentReturnsInputUnchangedWhenDisabled() throws Exception {
-    Map<String, String> env = new HashMap<>();
-    env.put(ENV_VAR, "false");
-    setEnvironmentVariables(env);
-
-    try {
-      assertThat(NameEscaping.escapeSegment("mydb.example.com")).isEqualTo("mydb.example.com");
-    } finally {
-      clearEnvironmentVariables(env.keySet());
-    }
   }
 
   // -----------------------------------------------------------------------
@@ -215,7 +221,7 @@ class NameEscapingTest {
   // -----------------------------------------------------------------------
 
   @Test
-  void oracleNamingEscapesServiceNameWithDotsByDefault() throws Exception {
+  void oracleNamingDoesNotEscapeByDefault() throws Exception {
     clearEnvironmentVariables(Set.of(ENV_VAR));
 
     io.openlineage.client.dataset.Naming.Oracle oracle =
@@ -227,14 +233,13 @@ class NameEscapingTest {
             .table("myTable")
             .build();
 
-    // Spec example: "mydb\.example\.com.mySchema.myTable"
-    assertThat(oracle.getName()).isEqualTo("mydb\\.example\\.com.mySchema.myTable");
+    assertThat(oracle.getName()).isEqualTo("mydb.example.com.mySchema.myTable");
   }
 
   @Test
-  void oracleNamingDoesNotEscapeWhenDisabled() throws Exception {
+  void oracleNamingEscapesServiceNameWithDotsWhenEnabled() throws Exception {
     Map<String, String> env = new HashMap<>();
-    env.put(ENV_VAR, "false");
+    env.put(ENV_VAR, "true");
     setEnvironmentVariables(env);
 
     try {
@@ -247,7 +252,8 @@ class NameEscapingTest {
               .table("myTable")
               .build();
 
-      assertThat(oracle.getName()).isEqualTo("mydb.example.com.mySchema.myTable");
+      // Spec example: "mydb\.example\.com.mySchema.myTable"
+      assertThat(oracle.getName()).isEqualTo("mydb\\.example\\.com.mySchema.myTable");
     } finally {
       clearEnvironmentVariables(env.keySet());
     }

--- a/client/java/src/test/java/io/openlineage/client/naming/NameEscapingTest.java
+++ b/client/java/src/test/java/io/openlineage/client/naming/NameEscapingTest.java
@@ -8,6 +8,7 @@ package io.openlineage.client.naming;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.OpenLineageConfig;
 import java.lang.reflect.Field;
@@ -50,7 +51,7 @@ class NameEscapingTest {
   }
 
   // -----------------------------------------------------------------------
-  // isEscapingEnabled — env-var behaviour
+  // isEscapingEnabled() — env-var behaviour (zero-arg overload)
   // -----------------------------------------------------------------------
 
   @Test
@@ -108,7 +109,7 @@ class NameEscapingTest {
   }
 
   // -----------------------------------------------------------------------
-  // escapeSegment — transformation behaviour
+  // escapeSegment(String) — transformation behaviour (env-var overload)
   // -----------------------------------------------------------------------
 
   @Test
@@ -207,12 +208,135 @@ class NameEscapingTest {
           OpenLineageClientUtils.loadOpenLineageConfigFromEnvVars(
               new TypeReference<OpenLineageConfig<OpenLineageConfig<?>>>() {});
 
-      // nameConfig may be null when the env var was never set; null means "use default" (enabled)
+      // nameConfig may be null when the env var was never set; null means "use default" (disabled)
       if (config.getNameConfig() != null) {
         assertThat(config.getNameConfig().getEscaping()).isNull();
       }
     } finally {
       clearEnvironmentVariables(envVars.keySet());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // isEscapingEnabled(NameConfig) — NameConfig overload behaviour
+  // -----------------------------------------------------------------------
+
+  @Test
+  void escapingEnabledViaNameConfig() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(true);
+
+    assertThat(NameEscaping.isEscapingEnabled(cfg)).isTrue();
+  }
+
+  @Test
+  void escapingDisabledViaNameConfig() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(false);
+
+    assertThat(NameEscaping.isEscapingEnabled(cfg)).isFalse();
+  }
+
+  @Test
+  void nameConfigTakesPrecedenceOverEnvVar() throws Exception {
+    // Env var says "true" but NameConfig says "false" → NameConfig wins.
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnvironmentVariables(env);
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(false);
+
+    try {
+      assertThat(NameEscaping.isEscapingEnabled(cfg)).isFalse();
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
+  }
+
+  @Test
+  void nullNameConfigFallsBackToEnvVar() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnvironmentVariables(env);
+
+    try {
+      assertThat(NameEscaping.isEscapingEnabled((NameConfig) null)).isTrue();
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
+  }
+
+  @Test
+  void nameConfigWithNullEscapingFallsBackToEnvVar() throws Exception {
+    // A NameConfig whose escaping field is null should not override the env var.
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnvironmentVariables(env);
+
+    try {
+      assertThat(NameEscaping.isEscapingEnabled(new NameConfig())).isTrue();
+    } finally {
+      clearEnvironmentVariables(env.keySet());
+    }
+  }
+
+  @Test
+  void escapeSegmentEscapesWhenEnabledViaNameConfig() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(true);
+
+    assertThat(NameEscaping.escapeSegment("mydb.example.com", cfg))
+        .isEqualTo("mydb\\.example\\.com");
+  }
+
+  @Test
+  void escapeSegmentUnchangedWhenDisabledViaNameConfig() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(false);
+
+    assertThat(NameEscaping.escapeSegment("mydb.example.com", cfg)).isEqualTo("mydb.example.com");
+  }
+
+  // -----------------------------------------------------------------------
+  // Builder integration — nameConfig field is stored on the client instance
+  // -----------------------------------------------------------------------
+
+  @Test
+  void builderNameConfigEscapingEnabled() throws Exception {
+    clearEnvironmentVariables(Set.of(ENV_VAR));
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(true);
+
+    // Build the client to confirm the config is accepted; verify escaping through the same config.
+    OpenLineageClient.builder().nameConfig(cfg).build().close();
+    assertThat(NameEscaping.escapeSegment("a.b", cfg)).isEqualTo("a\\.b");
+  }
+
+  @Test
+  void builderNameConfigEscapingDisabled() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put(ENV_VAR, "true");
+    setEnvironmentVariables(env);
+
+    NameConfig cfg = new NameConfig();
+    cfg.setEscaping(false);
+
+    // Even with env var true, the config says false → escaping off.
+    OpenLineageClient.builder().nameConfig(cfg).build().close();
+    try {
+      assertThat(NameEscaping.escapeSegment("a.b", cfg)).isEqualTo("a.b");
+    } finally {
+      clearEnvironmentVariables(env.keySet());
     }
   }
 

--- a/client/python/src/openlineage/client/client.py
+++ b/client/python/src/openlineage/client/client.py
@@ -29,6 +29,7 @@ from openlineage.client.git import (
     get_git_tag,
     get_git_version,
 )
+from openlineage.client.naming.escape import configure as configure_escaping
 from openlineage.client.serde import Serde
 from openlineage.client.tags import TagsConfig
 from openlineage.client.transport import (
@@ -63,11 +64,25 @@ class OpenLineageClientOptions:
 
 
 @attr.define
+class NameConfig:
+    """Configuration for OpenLineage name-related behaviour.
+
+    Corresponds to the ``name`` key in the top-level OpenLineage configuration::
+
+        name:
+          escaping: true   # enable automatic dot-escaping of name segments (off by default)
+    """
+
+    escaping: bool | None = attr.field(default=None)
+
+
+@attr.define
 class OpenLineageConfig:
     transport: dict[str, Any] | None = attr.field(factory=dict)
     facets: FacetsConfig = attr.field(factory=FacetsConfig)
     filters: list[FilterConfig] = attr.field(factory=list)
     tags: TagsConfig = attr.field(factory=TagsConfig)
+    name: NameConfig = attr.field(factory=NameConfig)
     dataset: DatasetConfig = attr.field(factory=DatasetConfig)
 
     @classmethod
@@ -91,6 +106,8 @@ class OpenLineageConfig:
                 job=params["tags"].get("job", {}),
                 run=params["tags"].get("run", {}),
             )
+        if "name" in params:
+            config.name = NameConfig(escaping=params["name"].get("escaping"))
         if "dataset" in params:
             ds = dict(params["dataset"])
             ds["disabled_trimmers"] = split_into_list(ds.get("disabled_trimmers", []))
@@ -142,6 +159,10 @@ class OpenLineageClient:
             url=url, options=options, session=session, transport=transport, factory=factory
         )
         log.info("OpenLineageClient will use `%s` transport", self.transport.kind)
+
+        # Apply the name config so that `name.escaping: true` in YAML is honoured.
+        # self.config is already populated at this point (accessed inside _resolve_transport).
+        configure_escaping(self.config.name.escaping)
 
         self._filters: list[Filter] = []
         for conf in self.config.filters:

--- a/client/python/src/openlineage/client/naming/dataset.py
+++ b/client/python/src/openlineage/client/naming/dataset.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import Protocol
 
 import attr
+from openlineage.client.naming.escape import escape
 
 
 def _check_not_empty(instance: object, attribute: attr.Attribute[str], value: str) -> str:  # noqa: ARG001
@@ -71,7 +72,7 @@ class Athena(DatasetNaming):
         return f"awsathena://athena.{self.region_name}.amazonaws.com"
 
     def get_name(self) -> str:
-        return f"{self.catalog}.{self.database}.{self.table}"
+        return f"{escape(self.catalog)}.{escape(self.database)}.{escape(self.table)}"
 
 
 @attr.define
@@ -117,6 +118,7 @@ class AzureDataExplorer(DatasetNaming):
         return f"azurekusto://{self.host}.kusto.windows.net"
 
     def get_name(self) -> str:
+        # AzureDataExplorer uses `/` as separator, not `.`, so no dot-escaping needed here
         return f"{self.database}/{self.table}"
 
 
@@ -133,7 +135,7 @@ class AzureSynapse(DatasetNaming):
         return f"sqlserver://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.schema}.{self.table}"
+        return f"{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -152,7 +154,7 @@ class BigQuery(DatasetNaming):
         return "bigquery"
 
     def get_name(self) -> str:
-        return f"{self.project_id}.{self.dataset_name}.{self.table_name}"
+        return f"{escape(self.project_id)}.{escape(self.dataset_name)}.{escape(self.table_name)}"
 
 
 @attr.define
@@ -168,7 +170,7 @@ class Cassandra(DatasetNaming):
         return f"cassandra://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.keyspace}.{self.table}"
+        return f"{escape(self.keyspace)}.{escape(self.table)}"
 
 
 @attr.define
@@ -184,7 +186,7 @@ class MySQL(DatasetNaming):
         return f"mysql://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.table)}"
 
 
 @attr.define
@@ -201,7 +203,7 @@ class CrateDB(DatasetNaming):
         return f"crate://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.schema}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -218,7 +220,7 @@ class DB2(DatasetNaming):
         return f"db2://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.schema}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -234,7 +236,7 @@ class OceanBase(DatasetNaming):
         return f"oceanbase://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.table)}"
 
 
 @attr.define
@@ -251,7 +253,7 @@ class Oracle(DatasetNaming):
         return f"oracle://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.service_name}.{self.schema}.{self.table}"
+        return f"{escape(self.service_name)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -268,7 +270,7 @@ class Postgres(DatasetNaming):
         return f"postgres://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.schema}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -284,7 +286,7 @@ class Teradata(DatasetNaming):
         return f"teradata://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.table)}"
 
 
 @attr.define
@@ -302,7 +304,7 @@ class Redshift(DatasetNaming):
         return f"redshift://{self.cluster_identifier}.{self.region}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.schema}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -319,7 +321,7 @@ class Snowflake(DatasetNaming):
         return f"snowflake://{self.organization_name}-{self.account_name}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.schema}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -336,7 +338,7 @@ class Trino(DatasetNaming):
         return f"trino://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.catalog}.{self.schema}.{self.table}"
+        return f"{escape(self.catalog)}.{escape(self.schema)}.{escape(self.table)}"
 
 
 @attr.define
@@ -410,7 +412,7 @@ class Hive(DatasetNaming):
         return f"hive://{self.host}:{self.port}"
 
     def get_name(self) -> str:
-        return f"{self.database}.{self.table}"
+        return f"{escape(self.database)}.{escape(self.table)}"
 
 
 @attr.define

--- a/client/python/src/openlineage/client/naming/escape.py
+++ b/client/python/src/openlineage/client/naming/escape.py
@@ -1,0 +1,68 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Dot-escaping utilities for OpenLineage name segments.
+
+OpenLineage names are structured as dot-separated segments, e.g.
+``{database}.{schema}.{table}``.  When a segment itself contains a literal
+dot (e.g. an Oracle service name ``mydb.example.com``), the dot must be
+escaped so that consumers can unambiguously split the name into its
+constituent parts.
+
+The escaping rule (from the naming specification) is:
+
+    A literal ``.`` inside a segment is written as ``\\.``
+
+Escaping is **enabled by default** and can be disabled by setting the
+environment variable ``OPENLINEAGE__NAME__ESCAPING`` to ``false`` (case-
+insensitive).  This is intended as an escape hatch for producers that emit
+names that are already pre-escaped or that target consumers which do not yet
+support the escaping convention.
+
+Example::
+
+    >>> from openlineage.client.naming.escape import escape, is_escaping_enabled
+    >>> escape("mydb.example.com")
+    'mydb\\\\.example\\\\.com'
+    >>> escape("my_schema")
+    'my_schema'
+"""
+
+from __future__ import annotations
+
+import os
+
+_ENV_VAR = "OPENLINEAGE__NAME__ESCAPING"
+
+
+def is_escaping_enabled() -> bool:
+    """Return ``True`` if dot-escaping is enabled (the default).
+
+    Escaping can be disabled by setting the environment variable
+    ``OPENLINEAGE__NAME__ESCAPING=false`` (case-insensitive).
+    """
+    raw = os.environ.get(_ENV_VAR, "true")
+    return raw.strip().lower() != "false"
+
+
+def escape(segment: str) -> str:
+    """Escape dots in a single name segment when escaping is enabled.
+
+    A literal ``.`` is replaced with ``\\.`` so that consumers can tell
+    structural dots (separating segments) from literal dots that are part
+    of a segment value.
+
+    The transformation is **only** applied when :func:`is_escaping_enabled`
+    returns ``True``; otherwise the segment is returned unchanged.
+
+    Args:
+        segment: A single name component (e.g. database, schema, table).
+
+    Returns:
+        The segment with literal dots escaped (or unchanged if escaping is
+        disabled).
+    """
+    if not is_escaping_enabled():
+        return segment
+    return segment.replace(".", "\\.")

--- a/client/python/src/openlineage/client/naming/escape.py
+++ b/client/python/src/openlineage/client/naming/escape.py
@@ -14,19 +14,17 @@ The escaping rule (from the naming specification) is:
 
     A literal ``.`` inside a segment is written as ``\\.``
 
-Escaping is **enabled by default** and can be disabled by setting the
-environment variable ``OPENLINEAGE__NAME__ESCAPING`` to ``false`` (case-
-insensitive).  This is intended as an escape hatch for producers that emit
-names that are already pre-escaped or that target consumers which do not yet
-support the escaping convention.
+Escaping is **disabled by default** and can be enabled by setting the
+environment variable ``OPENLINEAGE__NAME__ESCAPING`` to ``true`` (case-
+insensitive), or by setting ``name.escaping: true`` in the YAML configuration.
 
 Example::
 
     >>> from openlineage.client.naming.escape import escape, is_escaping_enabled
+    >>> is_escaping_enabled()
+    False
     >>> escape("mydb.example.com")
-    'mydb\\\\.example\\\\.com'
-    >>> escape("my_schema")
-    'my_schema'
+    'mydb.example.com'
 """
 
 from __future__ import annotations
@@ -37,13 +35,13 @@ _ENV_VAR = "OPENLINEAGE__NAME__ESCAPING"
 
 
 def is_escaping_enabled() -> bool:
-    """Return ``True`` if dot-escaping is enabled (the default).
+    """Return ``True`` if dot-escaping is enabled.
 
-    Escaping can be disabled by setting the environment variable
-    ``OPENLINEAGE__NAME__ESCAPING=false`` (case-insensitive).
+    Escaping is **disabled by default**. It can be enabled by setting the
+    environment variable ``OPENLINEAGE__NAME__ESCAPING=true`` (case-insensitive).
     """
-    raw = os.environ.get(_ENV_VAR, "true")
-    return raw.strip().lower() != "false"
+    raw = os.environ.get(_ENV_VAR, "false")
+    return raw.strip().lower() == "true"
 
 
 def escape(segment: str) -> str:

--- a/client/python/src/openlineage/client/naming/escape.py
+++ b/client/python/src/openlineage/client/naming/escape.py
@@ -14,9 +14,15 @@ The escaping rule (from the naming specification) is:
 
     A literal ``.`` inside a segment is written as ``\\.``
 
-Escaping is **disabled by default** and can be enabled by setting the
-environment variable ``OPENLINEAGE__NAME__ESCAPING`` to ``true`` (case-
-insensitive), or by setting ``name.escaping: true`` in the YAML configuration.
+Escaping is **disabled by default** and can be enabled by:
+
+1. Setting the environment variable ``OPENLINEAGE__NAME__ESCAPING`` to
+   ``true`` (case-insensitive), or
+2. Setting ``name.escaping: true`` in the YAML configuration and calling
+   :func:`configure` with the loaded value.
+
+When both are provided the value passed to :func:`configure` takes
+precedence over the environment variable.
 
 Example::
 
@@ -30,16 +36,43 @@ Example::
 from __future__ import annotations
 
 import os
+from typing import Optional
 
 _ENV_VAR = "OPENLINEAGE__NAME__ESCAPING"
+
+# Config-derived override.  ``None`` means "no YAML config was loaded; fall
+# back to the environment variable".  A non-``None`` value was set by
+# :func:`configure` and takes precedence.
+_config_override: Optional[bool] = None
+
+
+def configure(escaping: Optional[bool]) -> None:
+    """Apply the ``name.escaping`` value loaded from a YAML/dict config.
+
+    Call this after the OpenLineage configuration has been parsed so that
+    the ``name.escaping`` YAML field is honoured.  Pass ``None`` to clear the
+    override and fall back to the environment variable.
+
+    Args:
+        escaping: ``True`` to enable escaping, ``False`` to disable it
+            explicitly, or ``None`` to reset to env-var lookup.
+    """
+    global _config_override  # noqa: PLW0603
+    _config_override = escaping
 
 
 def is_escaping_enabled() -> bool:
     """Return ``True`` if dot-escaping is enabled.
 
-    Escaping is **disabled by default**. It can be enabled by setting the
-    environment variable ``OPENLINEAGE__NAME__ESCAPING=true`` (case-insensitive).
+    Resolution order:
+
+    1. If :func:`configure` was called with a non-``None`` value, that value
+       is returned.
+    2. Otherwise the environment variable ``OPENLINEAGE__NAME__ESCAPING`` is
+       consulted.
     """
+    if _config_override is not None:
+        return _config_override
     raw = os.environ.get(_ENV_VAR, "false")
     return raw.strip().lower() == "true"
 

--- a/client/python/tests/test_escape.py
+++ b/client/python/tests/test_escape.py
@@ -7,23 +7,23 @@ from openlineage.client.naming.escape import escape, is_escaping_enabled
 
 
 class TestIsEscapingEnabled:
-    def test_enabled_by_default(self, monkeypatch):
+    def test_disabled_by_default(self, monkeypatch):
         monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
-        assert is_escaping_enabled() is True
-
-    def test_disabled_when_false(self, monkeypatch):
-        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "false")
         assert is_escaping_enabled() is False
 
-    def test_disabled_case_insensitive(self, monkeypatch):
-        for value in ("false", "FALSE", "False", " false "):
-            monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", value)
-            assert is_escaping_enabled() is False, f"should be disabled for {value!r}"
+    def test_enabled_when_true(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
+        assert is_escaping_enabled() is True
 
-    def test_enabled_for_true_values(self, monkeypatch):
-        for value in ("true", "TRUE", "1", "yes", "on"):
+    def test_enabled_case_insensitive(self, monkeypatch):
+        for value in ("true", "TRUE", "True", " true "):
             monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", value)
             assert is_escaping_enabled() is True, f"should be enabled for {value!r}"
+
+    def test_disabled_for_non_true_values(self, monkeypatch):
+        for value in ("false", "FALSE", "1", "yes", "on"):
+            monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", value)
+            assert is_escaping_enabled() is False, f"should be disabled for {value!r}"
 
 
 class TestEscape:
@@ -32,21 +32,21 @@ class TestEscape:
         assert escape("plain") == "plain"
         assert escape("my_schema") == "my_schema"
 
-    def test_single_dot_escaped(self, monkeypatch):
+    def test_segment_unchanged_by_default(self, monkeypatch):
         monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        assert escape("mydb.example.com") == "mydb.example.com"
+
+    def test_single_dot_escaped_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
         assert escape("a.b") == r"a\.b"
 
-    def test_multiple_dots_escaped(self, monkeypatch):
-        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+    def test_multiple_dots_escaped_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
         assert escape("mydb.example.com") == r"mydb\.example\.com"
         assert escape("a.b.c") == r"a\.b\.c"
 
-    def test_segment_unchanged_when_escaping_disabled(self, monkeypatch):
-        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "false")
-        assert escape("mydb.example.com") == "mydb.example.com"
-
-    def test_leading_trailing_dot(self, monkeypatch):
-        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+    def test_leading_trailing_dot_escaped_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
         assert escape(".leading") == r"\.leading"
         assert escape("trailing.") == r"trailing\."
 
@@ -54,24 +54,24 @@ class TestEscape:
 class TestEscapingIntegrationWithNaming:
     """Verify that escaping flows through the Naming helpers end-to-end."""
 
-    def test_oracle_service_name_with_dots_escaped(self, monkeypatch):
+    def test_oracle_service_name_with_dots_unescaped_by_default(self, monkeypatch):
         from openlineage.client.naming.dataset import Oracle
 
         monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
-        oracle = Oracle("localhost", "1521", "mydb.example.com", "mySchema", "myTable")
-        assert oracle.get_name() == r"mydb\.example\.com.mySchema.myTable"
-
-    def test_oracle_service_name_with_dots_unescaped_when_disabled(self, monkeypatch):
-        from openlineage.client.naming.dataset import Oracle
-
-        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "false")
         oracle = Oracle("localhost", "1521", "mydb.example.com", "mySchema", "myTable")
         assert oracle.get_name() == "mydb.example.com.mySchema.myTable"
 
-    def test_bigquery_project_id_with_dots_escaped(self, monkeypatch):
+    def test_oracle_service_name_with_dots_escaped_when_enabled(self, monkeypatch):
+        from openlineage.client.naming.dataset import Oracle
+
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
+        oracle = Oracle("localhost", "1521", "mydb.example.com", "mySchema", "myTable")
+        assert oracle.get_name() == r"mydb\.example\.com.mySchema.myTable"
+
+    def test_bigquery_project_id_with_dots_escaped_when_enabled(self, monkeypatch):
         from openlineage.client.naming.dataset import BigQuery
 
-        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
         bq = BigQuery("my.project.id", "dataset", "table")
         assert bq.get_name() == r"my\.project\.id.dataset.table"
 

--- a/client/python/tests/test_escape.py
+++ b/client/python/tests/test_escape.py
@@ -1,0 +1,83 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the dot-escaping utilities."""
+
+from openlineage.client.naming.escape import escape, is_escaping_enabled
+
+
+class TestIsEscapingEnabled:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        assert is_escaping_enabled() is True
+
+    def test_disabled_when_false(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "false")
+        assert is_escaping_enabled() is False
+
+    def test_disabled_case_insensitive(self, monkeypatch):
+        for value in ("false", "FALSE", "False", " false "):
+            monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", value)
+            assert is_escaping_enabled() is False, f"should be disabled for {value!r}"
+
+    def test_enabled_for_true_values(self, monkeypatch):
+        for value in ("true", "TRUE", "1", "yes", "on"):
+            monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", value)
+            assert is_escaping_enabled() is True, f"should be enabled for {value!r}"
+
+
+class TestEscape:
+    def test_plain_segment_unchanged(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        assert escape("plain") == "plain"
+        assert escape("my_schema") == "my_schema"
+
+    def test_single_dot_escaped(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        assert escape("a.b") == r"a\.b"
+
+    def test_multiple_dots_escaped(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        assert escape("mydb.example.com") == r"mydb\.example\.com"
+        assert escape("a.b.c") == r"a\.b\.c"
+
+    def test_segment_unchanged_when_escaping_disabled(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "false")
+        assert escape("mydb.example.com") == "mydb.example.com"
+
+    def test_leading_trailing_dot(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        assert escape(".leading") == r"\.leading"
+        assert escape("trailing.") == r"trailing\."
+
+
+class TestEscapingIntegrationWithNaming:
+    """Verify that escaping flows through the Naming helpers end-to-end."""
+
+    def test_oracle_service_name_with_dots_escaped(self, monkeypatch):
+        from openlineage.client.naming.dataset import Oracle
+
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        oracle = Oracle("localhost", "1521", "mydb.example.com", "mySchema", "myTable")
+        assert oracle.get_name() == r"mydb\.example\.com.mySchema.myTable"
+
+    def test_oracle_service_name_with_dots_unescaped_when_disabled(self, monkeypatch):
+        from openlineage.client.naming.dataset import Oracle
+
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "false")
+        oracle = Oracle("localhost", "1521", "mydb.example.com", "mySchema", "myTable")
+        assert oracle.get_name() == "mydb.example.com.mySchema.myTable"
+
+    def test_bigquery_project_id_with_dots_escaped(self, monkeypatch):
+        from openlineage.client.naming.dataset import BigQuery
+
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        bq = BigQuery("my.project.id", "dataset", "table")
+        assert bq.get_name() == r"my\.project\.id.dataset.table"
+
+    def test_postgres_plain_segments_unchanged(self, monkeypatch):
+        from openlineage.client.naming.dataset import Postgres
+
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        pg = Postgres("localhost", "5432", "mydb", "myschema", "mytable")
+        assert pg.get_name() == "mydb.myschema.mytable"

--- a/client/python/tests/test_escape.py
+++ b/client/python/tests/test_escape.py
@@ -3,7 +3,8 @@
 
 """Tests for the dot-escaping utilities."""
 
-from openlineage.client.naming.escape import escape, is_escaping_enabled
+import pytest
+from openlineage.client.naming.escape import configure, escape, is_escaping_enabled
 
 
 class TestIsEscapingEnabled:
@@ -81,3 +82,77 @@ class TestEscapingIntegrationWithNaming:
         monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
         pg = Postgres("localhost", "5432", "mydb", "myschema", "mytable")
         assert pg.get_name() == "mydb.myschema.mytable"
+
+
+class TestConfigure:
+    """Tests for the configure() override that wires YAML config through."""
+
+    @pytest.fixture(autouse=True)
+    def reset_override(self):
+        """Always reset the module-level override after each test."""
+        yield
+        configure(None)
+
+    def test_configure_enables_escaping(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        configure(True)
+        assert is_escaping_enabled() is True
+
+    def test_configure_disables_escaping(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        configure(False)
+        assert is_escaping_enabled() is False
+
+    def test_configure_none_resets_to_env_var_true(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
+        configure(None)
+        assert is_escaping_enabled() is True
+
+    def test_configure_none_resets_to_env_var_false(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        configure(None)
+        assert is_escaping_enabled() is False
+
+    def test_configure_takes_precedence_over_env_var(self, monkeypatch):
+        # Env var says "true" but configure says False → configure wins.
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
+        configure(False)
+        assert is_escaping_enabled() is False
+
+    def test_configure_false_takes_precedence_over_env_var_true(self, monkeypatch):
+        monkeypatch.setenv("OPENLINEAGE__NAME__ESCAPING", "true")
+        configure(False)
+        assert escape("a.b") == "a.b"
+
+    def test_configure_true_escapes_segment(self, monkeypatch):
+        monkeypatch.delenv("OPENLINEAGE__NAME__ESCAPING", raising=False)
+        configure(True)
+        assert escape("mydb.example.com") == r"mydb\.example\.com"
+
+
+class TestOpenLineageConfigNameParsing:
+    """Verify that from_dict correctly parses the ``name`` section."""
+
+    def test_name_escaping_true_parsed(self):
+        from openlineage.client.client import OpenLineageConfig
+
+        cfg = OpenLineageConfig.from_dict({"name": {"escaping": True}})
+        assert cfg.name.escaping is True
+
+    def test_name_escaping_false_parsed(self):
+        from openlineage.client.client import OpenLineageConfig
+
+        cfg = OpenLineageConfig.from_dict({"name": {"escaping": False}})
+        assert cfg.name.escaping is False
+
+    def test_name_absent_defaults_to_none(self):
+        from openlineage.client.client import OpenLineageConfig
+
+        cfg = OpenLineageConfig.from_dict({})
+        assert cfg.name.escaping is None
+
+    def test_name_escaping_absent_defaults_to_none(self):
+        from openlineage.client.client import OpenLineageConfig
+
+        cfg = OpenLineageConfig.from_dict({"name": {}})
+        assert cfg.name.escaping is None

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.job.JobConfig;
+import io.openlineage.client.naming.NameConfig;
 import io.openlineage.client.run.RunConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
@@ -62,7 +63,8 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
       Integer trackingIntervalInSeconds,
       Integer detachedStartEventEmitTimeoutInSeconds,
       Boolean enableDetachedJobTracking,
-      Boolean disableCheckpointTracking) {
+      Boolean disableCheckpointTracking,
+      NameConfig nameConfig) {
     super(
         transportConfig,
         facetsConfig,
@@ -70,7 +72,8 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
         circuitBreaker,
         metricsConfig,
         runConfig,
-        jobConfig);
+        jobConfig,
+        nameConfig);
     this.datasetConfig = datasetConfig;
     this.trackingIntervalInSeconds = trackingIntervalInSeconds;
     this.detachedStartEventEmitTimeoutInSeconds = detachedStartEventEmitTimeoutInSeconds;
@@ -92,7 +95,8 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
         mergePropertyWith(
             detachedStartEventEmitTimeoutInSeconds, other.detachedStartEventEmitTimeoutInSeconds),
         mergePropertyWith(enableDetachedJobTracking, other.enableDetachedJobTracking),
-        mergePropertyWith(disableCheckpointTracking, other.disableCheckpointTracking));
+        mergePropertyWith(disableCheckpointTracking, other.disableCheckpointTracking),
+        mergePropertyWith(nameConfig, other.nameConfig));
   }
 
   public Integer getTrackingIntervalInSeconds() {

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfig.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfig.java
@@ -8,6 +8,7 @@ import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.job.JobConfig;
+import io.openlineage.client.naming.NameConfig;
 import io.openlineage.client.run.RunConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
@@ -35,7 +36,8 @@ public class HiveOpenLineageConfig extends OpenLineageConfig<HiveOpenLineageConf
       CircuitBreakerConfig circuitBreaker,
       Map metricsConfig,
       RunConfig runConfig,
-      JobConfig jobConfig) {
+      JobConfig jobConfig,
+      NameConfig nameConfig) {
     super(
         transportConfig,
         facetsConfig,
@@ -43,7 +45,8 @@ public class HiveOpenLineageConfig extends OpenLineageConfig<HiveOpenLineageConf
         circuitBreaker,
         metricsConfig,
         runConfig,
-        jobConfig);
+        jobConfig,
+        nameConfig);
   }
 
   @Override
@@ -58,6 +61,7 @@ public class HiveOpenLineageConfig extends OpenLineageConfig<HiveOpenLineageConf
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
         mergePropertyWith(metricsConfig, other.metricsConfig),
         mergePropertyWith(runConfig, other.runConfig),
-        mergePropertyWith(jobConfig, other.jobConfig));
+        mergePropertyWith(jobConfig, other.jobConfig),
+        mergePropertyWith(nameConfig, other.nameConfig));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -13,6 +13,7 @@ import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.job.JobConfig;
+import io.openlineage.client.naming.NameConfig;
 import io.openlineage.client.run.RunConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
@@ -93,8 +94,17 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       ColumnLineageConfig columnLineageConfig,
       VendorsConfig vendors,
       FilterConfig filterConfig,
-      RunConfig run) {
-    super(transportConfig, facetsConfig, datasetConfig, circuitBreaker, metricsConfig, run, job);
+      RunConfig run,
+      NameConfig nameConfig) {
+    super(
+        transportConfig,
+        facetsConfig,
+        datasetConfig,
+        circuitBreaker,
+        metricsConfig,
+        run,
+        job,
+        nameConfig);
     this.namespace = namespace;
     this.parentJobName = parentJobName;
     this.parentJobNamespace = parentJobNamespace;
@@ -211,6 +221,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
         mergePropertyWith(columnLineageConfig, other.columnLineageConfig),
         mergePropertyWith(vendors, other.vendors),
         mergePropertyWith(filterConfig, other.filterConfig),
-        mergePropertyWith(runConfig, other.runConfig));
+        mergePropertyWith(runConfig, other.runConfig),
+        mergePropertyWith(nameConfig, other.nameConfig));
   }
 }

--- a/website/docs/client/java/configuration.md
+++ b/website/docs/client/java/configuration.md
@@ -18,10 +18,11 @@ You can make this file available to the client in three ways (the list also pres
 
 The following environment variables are available:
 
-| Name                 | Description                                                                 | Since |
-|----------------------|-----------------------------------------------------------------------------|-------|
-| OPENLINEAGE_CONFIG   | The path to the YAML configuration file. Example: `path/to/openlineage.yml` |       |
-| OPENLINEAGE_DISABLED | When `true`, OpenLineage will not emit events.                              | 0.9.0 |
+| Name                          | Description                                                                                                                                 | Since |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------|
+| OPENLINEAGE_CONFIG            | The path to the YAML configuration file. Example: `path/to/openlineage.yml`                                                                |       |
+| OPENLINEAGE_DISABLED          | When `true`, OpenLineage will not emit events.                                                                                              | 0.9.0 |
+| OPENLINEAGE__NAME__ESCAPING   | Controls automatic dot-escaping in name segments produced by the naming helpers. Set to `false` to disable. Defaults to enabled (escaping on). See [Naming — Escaping](../../spec/naming.md#automatic-escaping-in-openlineage-clients). | |
 
 You can also configure the client with dynamic environment variables.
 

--- a/website/docs/client/python/configuration.md
+++ b/website/docs/client/python/configuration.md
@@ -186,11 +186,12 @@ transport:
 ### Meta variables
 There are few variables that do not follow the above pattern (mostly due to legacy reasons): 
 
-| Name                       | Description                                                       | Example                 | Since  |
-|----------------------------|-------------------------------------------------------------------|-------------------------|--------|
-| OPENLINEAGE_CONFIG         | The path to the YAML configuration file                           | path/to/openlineage.yml |        |
-| OPENLINEAGE_CLIENT_LOGGING | Logging level of OpenLineage client and its child modules         | DEBUG                   |        |
-| OPENLINEAGE_DISABLED       | When `true`, OpenLineage will not emit events (default: false)    | false                   | 0.9.0  |
+| Name                         | Description                                                                                                                                     | Example                 | Since  |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|--------|
+| OPENLINEAGE_CONFIG           | The path to the YAML configuration file                                                                                                         | path/to/openlineage.yml |        |
+| OPENLINEAGE_CLIENT_LOGGING   | Logging level of OpenLineage client and its child modules                                                                                       | DEBUG                   |        |
+| OPENLINEAGE_DISABLED         | When `true`, OpenLineage will not emit events (default: false)                                                                                  | false                   | 0.9.0  |
+| OPENLINEAGE__NAME__ESCAPING  | Controls automatic dot-escaping in name segments produced by the naming helpers. Set to `false` to disable. Defaults to enabled (escaping on). See [Naming — Escaping](../../spec/naming.md#automatic-escaping-in-openlineage-clients). | true | |
 
 
 ### Legacy syntax

--- a/website/docs/spec/naming.md
+++ b/website/docs/spec/naming.md
@@ -123,8 +123,8 @@ OPENLINEAGE__NAME__ESCAPING=false
 
 | Value | Behaviour |
 |-------|-----------|
-| _(unset or any other value)_ | Escaping **enabled** (default) |
-| `false` | Escaping **disabled** |
+| _(unset or any other value)_ | Escaping **disabled** (default) |
+| `true` | Escaping **enabled** |
 
 ## Additional Resources
 

--- a/website/docs/spec/naming.md
+++ b/website/docs/spec/naming.md
@@ -92,9 +92,39 @@ run = Run(str(generate_new_uuid()))
 ## Why Naming Matters
 
 Naming enables focused insight into data flows, even when datasets and workflows are distributed across an organization.
-This focus enabled by naming is key to the production of useful lineage.
+This focus enabled by naming is key to the production of useful lineage, as consistent naming conventions are one of the mechanisms that OpenLineage consumers can use to reconcile entities captured by different OpenLineage producers. 
+
+While it is also recommended for OpenLineage producers and consumers to support [Hierarchy Dataset facet](https://openlineage.io/docs/spec/facets/dataset-facets/hierarchy) to make the reconciliation process more reliable, the facet is optional and compliance with defined naming conventions is still essential. 
 
 ![image](./naming-correlations.svg)
+
+## Escaping
+
+As OpenLineage Dataset and Job names follow the patterns defined in the naming conventions described above, it is necessary to allow for escaping of special characters - specifically it is necessary to escape dots (`.`) in OpenLineage name segments. The escaping sequence applied should be `\\`. OpenLineage producers should automatically apply the escaping sequence and OpenLineage consumers should reflect it in case they are processing the OpenLineage names and are deducing hierarchy levels from it (e.g. `database.schema.table`).
+
+Example:
+
+Oracle table with following coordinates is referenced as a DataSet in OpenLineage event
+- Service Name = `mydb.example.com`
+- Schema Name = `mySchema`
+- Table Name = `myTable`
+
+The escaped OpenLineage name of the dataset should be `mydb\\.example\\.com.mySchema.myTable`.
+
+Without the escaping mechanims in place, consumers would have no way how to correctly segment the OpenLineage name based on the pattern defined in the naming conventions.
+
+The Java, Python, and Go OpenLineage clients **automatically escape dots** in all name segments produced by their built-in naming helpers (e.g. `Naming.Oracle`, `Oracle(...)`, etc.). Escaping is **enabled by default**.
+
+To disable automatic escaping, set the following environment variable before the process starts:
+
+```sh
+OPENLINEAGE__NAME__ESCAPING=false
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| _(unset or any other value)_ | Escaping **enabled** (default) |
+| `false` | Escaping **disabled** |
 
 ## Additional Resources
 


### PR DESCRIPTION
### One-line summary for changelog:
Documenting how OL names should be escaped, and adding automated configurable escaping to OL clients 

### Meaningful description
Non-escaped dots in OL names break reconciliation of datasets and jobs. This PR documents how to escape the dots and adds automation to the client libraries that escapes them automatically. 

Slack discussion https://openlineage.slack.com/archives/C065PQ4TL8K/p1783674560023109

### Checklist
- [x] AI was used in creating this PR
