### PR TITLE
ci: resolve spec schema refs from the in-repo mirror in jv hooks

### DIFF
--- a/.pre_commit/json-schema/check-spec.sh
+++ b/.pre_commit/json-schema/check-spec.sh
@@ -7,8 +7,14 @@
 
 set -e
 
+# The facet schemas $ref the root schema by its absolute openlineage.io URL, which
+# jv would otherwise fetch over the network. Map that prefix onto the in-repo
+# published mirror so the hook is hermetic and validates the refs against the
+# working tree rather than against the last release.
+SPEC_MIRROR="https://openlineage.io/spec/=website/static/spec/"
+
 while [ "$1" ]; do
   echo "Checking $1 schema"
-  jv "$1"
+  jv --map "$SPEC_MIRROR" "$1"
   shift
 done

--- a/.pre_commit/json-schema/test-facets.sh
+++ b/.pre_commit/json-schema/test-facets.sh
@@ -7,6 +7,10 @@
 
 set -e
 
+# See check-spec.sh: resolve the absolute openlineage.io $refs from the in-repo
+# published mirror instead of over the network.
+SPEC_MIRROR="https://openlineage.io/spec/=website/static/spec/"
+
 while [ "$1" ]; do
   event_type=$(basename "$1" .json)
   shopt -s nullglob
@@ -14,7 +18,7 @@ while [ "$1" ]; do
   if [ ${#test_events[@]} -gt 0 ]; then
     for event in "${test_events[@]}"; do
       echo "Validating ${event} against $1"
-      jv "$1" "${event}" --assert-format
+      jv --map "$SPEC_MIRROR" "$1" "${event}" --assert-format
     done
   fi
   shift


### PR DESCRIPTION
Closes #4841.

`jv` resolved the facet schemas' absolute `$ref`s over the network, so `check_schemas` and `test_events` both needed openlineage.io reachable; `--map` points them at the in-repo published mirror instead. It also changes which root schema the refs resolve to — the working tree rather than the last release — so a facet that disagrees with the root now fails at commit time instead of after publication.

Verified: `HTTPS_PROXY=http://127.0.0.1:1 ./.pre_commit/json-schema/check-spec.sh spec/OpenLineage.json spec/facets/*.json spec/registry/*/registry.json` → 45/45 schemas load (39 fail without this change); `test-facets.sh` → 39/39 facet/event pairs pass.
