### PR TITLE
Skip CI approval for PR authors and project committers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,14 @@ jobs:
               echo "Not a pull request build. Removing approval steps."
               python dev/filter_approvals.py
             else
+              # --- Token diagnostic (temporary): verify collaborator endpoint access ---
+              echo "Token scopes: $(gh auth status 2>&1 | grep -i 'token scopes' | sed 's/^[[:space:]]*-[[:space:]]*//' || echo '<none>')"
+              if gh api "repos/OpenLineage/OpenLineage/collaborators/mobuchowski" >/dev/null 2>&1; then
+                echo "Collaborator endpoint: functional (known maintainer detected)"
+              else
+                echo "Collaborator endpoint: NOT functional (token lacks push access and/or read:org scope)"
+              fi
+              # --- End token diagnostic ---
               PR_AUTHOR=$(gh pr view "$CIRCLE_PULL_REQUEST" --repo OpenLineage/OpenLineage --json author -q .author.login 2>/dev/null)
               COMMITTER="${CIRCLE_USERNAME:-}"
               COMMITTER_LOWER=$(echo "$COMMITTER" | tr '[:upper:]' '[:lower:]')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,14 +74,6 @@ jobs:
               echo "Not a pull request build. Removing approval steps."
               python dev/filter_approvals.py
             else
-              # --- Token diagnostic (temporary): verify collaborator endpoint access ---
-              echo "Token scopes: $(gh auth status 2>&1 | grep -i 'token scopes' | sed 's/^[[:space:]]*-[[:space:]]*//' || echo '<none>')"
-              if gh api "repos/OpenLineage/OpenLineage/collaborators/mobuchowski" >/dev/null 2>&1; then
-                echo "Collaborator endpoint: functional (known maintainer detected)"
-              else
-                echo "Collaborator endpoint: NOT functional (token lacks push access and/or read:org scope)"
-              fi
-              # --- End token diagnostic ---
               PR_AUTHOR=$(gh pr view "$CIRCLE_PULL_REQUEST" --repo OpenLineage/OpenLineage --json author -q .author.login 2>/dev/null)
               COMMITTER="${CIRCLE_USERNAME:-}"
               COMMITTER_LOWER=$(echo "$COMMITTER" | tr '[:upper:]' '[:lower:]')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,17 +65,27 @@ jobs:
           environment:
             NIGHTLY_RUN: << pipeline.parameters.nightly-run >>
             INTEGRATION_TYPE: << pipeline.parameters.integration-type >>
-      - unless:
-          condition:
-            matches:
-              pattern: '^pull\/[0-9]+$'
-              value: << pipeline.git.branch >>
-          steps:
-            - run:
-                name: Remove approval steps if not pull from forks.
-                command: |
-                  pip install pyyaml==6.0.1
-                  python dev/filter_approvals.py
+      - run:
+          name: Remove approval steps if committer is the PR author.
+          command: |
+            pip install pyyaml==6.0.1
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              # Not a pull request build (e.g. main branch or tag) - no approval needed.
+              echo "Not a pull request build. Removing approval steps."
+              python dev/filter_approvals.py
+            else
+              PR_AUTHOR=$(gh pr view "$CIRCLE_PULL_REQUEST" --repo OpenLineage/OpenLineage --json author -q .author.login 2>/dev/null)
+              COMMITTER=$(echo "${CIRCLE_USERNAME:-}" | tr '[:upper:]' '[:lower:]')
+              AUTHOR=$(echo "${PR_AUTHOR:-}" | tr '[:upper:]' '[:lower:]')
+              echo "Committer: ${CIRCLE_USERNAME:-<unset>}"
+              echo "PR author: ${PR_AUTHOR:-<unknown>}"
+              if [ -n "$COMMITTER" ] && [ -n "$AUTHOR" ] && [ "$COMMITTER" == "$AUTHOR" ]; then
+                echo "Committer is the PR author. Removing approval steps."
+                python dev/filter_approvals.py
+              else
+                echo "Committer is not the PR author. Keeping approval steps."
+              fi
+            fi
       - run: |
           export PR_NUM=$(echo $CIRCLE_PULL_REQUEST | cut -d'/' -f7)
           export HAS_FULL_TESTS_LABEL=$(gh pr view $CIRCLE_PULL_REQUEST --repo OpenLineage/OpenLineage --json labels | jq 'any(.labels[]; .name == "full-tests")')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             NIGHTLY_RUN: << pipeline.parameters.nightly-run >>
             INTEGRATION_TYPE: << pipeline.parameters.integration-type >>
       - run:
-          name: Remove approval steps if committer is the PR author.
+          name: Remove approval steps if committer is the PR author or a project committer.
           command: |
             pip install pyyaml==6.0.1
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
@@ -75,15 +75,21 @@ jobs:
               python dev/filter_approvals.py
             else
               PR_AUTHOR=$(gh pr view "$CIRCLE_PULL_REQUEST" --repo OpenLineage/OpenLineage --json author -q .author.login 2>/dev/null)
-              COMMITTER=$(echo "${CIRCLE_USERNAME:-}" | tr '[:upper:]' '[:lower:]')
-              AUTHOR=$(echo "${PR_AUTHOR:-}" | tr '[:upper:]' '[:lower:]')
-              echo "Committer: ${CIRCLE_USERNAME:-<unset>}"
+              COMMITTER="${CIRCLE_USERNAME:-}"
+              COMMITTER_LOWER=$(echo "$COMMITTER" | tr '[:upper:]' '[:lower:]')
+              AUTHOR_LOWER=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+              echo "Committer: ${COMMITTER:-<unset>}"
               echo "PR author: ${PR_AUTHOR:-<unknown>}"
-              if [ -n "$COMMITTER" ] && [ -n "$AUTHOR" ] && [ "$COMMITTER" == "$AUTHOR" ]; then
+              if [ -n "$COMMITTER_LOWER" ] && [ -n "$AUTHOR_LOWER" ] && [ "$COMMITTER_LOWER" == "$AUTHOR_LOWER" ]; then
                 echo "Committer is the PR author. Removing approval steps."
                 python dev/filter_approvals.py
+              elif [ -n "$COMMITTER" ] && gh api "repos/OpenLineage/OpenLineage/collaborators/$COMMITTER" >/dev/null 2>&1; then
+                # Covers committers who push to their own fork: they are trusted
+                # collaborators of the repo even though the PR comes from a fork.
+                echo "Committer is a project committer. Removing approval steps."
+                python dev/filter_approvals.py
               else
-                echo "Committer is not the PR author. Keeping approval steps."
+                echo "Committer is not the PR author and not a project committer. Keeping approval steps."
               fi
             fi
       - run: |


### PR DESCRIPTION
## What this does

Fork pull requests need a manual approval before the Spark integration tests run. This happens even when a project committer pushes the code from their own fork.

This change skips the approval when the committer is the PR author or a project committer. We compare the committer with the PR author, then check the repository collaborators list. If we cannot identify the committer, we keep the approval.
