### PR TITLE
great_expectations: emit a valid producer URI and a tz-aware eventTime

### DIFF
--- a/integration/common/src/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/src/openlineage/common/provider/great_expectations/action.py
@@ -5,7 +5,7 @@ import copy
 import logging
 import os
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -21,6 +21,7 @@ from openlineage.client.facet_v2 import (
 )
 from openlineage.client.serde import Serde
 from openlineage.client.uuid import generate_new_uuid
+from openlineage.common import __version__
 from openlineage.common.dataset import Dataset, Field, Source
 from openlineage.common.dataset import Dataset as OLDataset
 from openlineage.common.provider.great_expectations.facets import (
@@ -64,6 +65,11 @@ except ImportError:
 
 
 log = logging.getLogger(__name__)
+
+PRODUCER = (
+    f"https://github.com/OpenLineage/OpenLineage/tree/{__version__}"
+    "/integration/common/src/openlineage/common/provider/great_expectations"
+)
 
 
 class OpenLineageValidationAction(ValidationAction):
@@ -211,12 +217,12 @@ class OpenLineageValidationAction(ValidationAction):
             )
         run_event = RunEvent(
             eventType=RunState.COMPLETE,
-            eventTime=datetime.now().isoformat(),
+            eventTime=datetime.now(timezone.utc).isoformat(),
             run=Run(runId=str(self.openlineage_run_id), facets=run_facets),
             job=Job(self.openlineage_namespace, job_name, facets=job_facets),  # type: ignore [arg-type]
             inputs=datasets,  # type: ignore[arg-type]
             outputs=[],
-            producer="https://github.com/OpenLineage/OpenLineage/tree/$VERSION/integration/common/openlineage/provider/great_expectations",
+            producer=PRODUCER,
         )
         if self.do_publish:
             self.openlineage_client.emit(run_event)  # type: ignore [attr-defined]

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 import pandas
 import pytest
+from openlineage.common import __version__
 from openlineage.common.provider.great_expectations import OpenLineageValidationAction
 from sqlalchemy import create_engine
 
@@ -418,3 +419,44 @@ def test_data_quality_facet_and_assertions_on_ge_1x():
         "expect_table_row_count_to_equal",
         "expect_column_sum_to_be_between",
     }
+
+
+def test_emitted_event_producer_and_event_time(tmpdir):
+    df = pandas.DataFrame({"name": ["Alice", "Bob"]})
+
+    ctx = get_context(context_root_dir=str(tmpdir / "gx"), mode="ephemeral")
+    ctx.suites.add(ExpectationSuite("test_suite"))
+
+    from great_expectations.datasource.fluent import PandasDatasource
+
+    datasource = PandasDatasource(name="pandas_datasource")
+    ctx.add_datasource(datasource=datasource)
+    asset = datasource.add_dataframe_asset(name="test_dataframe")
+    validator = ctx.get_validator(
+        batch_request=asset.build_batch_request(options={"dataframe": df}),
+        expectation_suite_name="test_suite",
+    )
+
+    action = OpenLineageValidationAction(
+        name="openlineage_test_action",
+        openlineage_host="http://localhost:5000",
+        openlineage_namespace="test_ns",
+        do_publish=False,
+        job_name="test_expectations_job",
+    )
+    ol_result = action._run(
+        validation_result_suite=validator.validate(),
+        validation_result_suite_identifier=ValidationResultIdentifier(
+            ExpectationSuiteIdentifier("test_suite"), RunIdentifier(run_name="test_run"), "batch_id"
+        ),
+        data_asset=validator,
+    )
+
+    # The spec types eventTime as an RFC 3339 date-time, which carries an offset.
+    assert datetime.datetime.fromisoformat(ol_result["eventTime"]).tzinfo is not None
+
+    # producer must be a usable URI: a real version and a path that exists in the repo.
+    assert ol_result["producer"] == (
+        f"https://github.com/OpenLineage/OpenLineage/tree/{__version__}"
+        "/integration/common/src/openlineage/common/provider/great_expectations"
+    )


### PR DESCRIPTION
### One-line summary for changelog:

`great_expectations`: emitted events now carry a resolvable `producer` URI and a timezone-aware `eventTime`.

### Meaningful description

Two fields of the `RunEvent` this action emits are wrong on every event, and both are visible in the emitted payload rather than only in the source.

**`producer`.** It was a literal:

```
https://github.com/OpenLineage/OpenLineage/tree/$VERSION/integration/common/openlineage/provider/great_expectations
```

`$VERSION` is never substituted — `grep -rn '\$VERSION' --include='*.py'` finds this one occurrence and nothing that rewrites it — and the path it names moved under `src/` some time ago, so even a resolved version would point at a directory that does not exist. Both siblings already do this with an f-string (`dbt/utils.py:14`, `client/constants.py:10`), so this adds a module-level `PRODUCER` in the same shape and imports `__version__` from `openlineage.common`, rather than hardcoding a third copy of the version string.

**`eventTime`.** It was `datetime.now().isoformat()` — naive local time. `spec/OpenLineage.json` types the field as `"format": "date-time"`, which is RFC 3339 and carries an offset, and `integration/dbt` already passes `timezone.utc`; this was the only naive one left. Emitting the two side by side at the same instant on a UTC+8 host:

```
before: 2026-08-05T23:30:46.058895        (no offset)
dbt:    2026-08-05T15:30:46.058905+00:00
```

A consumer that reads the naive value as UTC places the event eight hours late; one that validates RFC 3339 strictly rejects it.

#### Verification

`main` at `7c5f2e767`, dedicated venv with `client/python` and `integration/common[dev]` installed editable. Note that `tests/great_expectations` is excluded by `addopts` in `pyproject.toml`, so these runs pass `-o addopts=""`.

| step | result |
|---|---|
| new test on clean `main` (copied into a detached worktree, fix absent) | fails: `AssertionError: assert None is not None` on `tzinfo` |
| same test with the fix | `tests/great_expectations/` 10 passed |
| whole `integration/common` suite, this branch | 358 passed, 2 skipped |
| whole suite, clean `main` with only the new test added | 357 passed, 2 skipped, 1 failed — the new test, and nothing else |
| emitted value, read off the installed package rather than the source | `.../tree/1.53.0/integration/common/src/openlineage/common/provider/great_expectations`, and that directory exists |
| `mypy --ignore-missing-imports src` | no issues in 22 files |
| `ruff` 0.12.3 (the pinned version) check + format | clean |

The new test drives `_run` end to end through an ephemeral GX context and asserts on the returned event, so it covers the emitted payload rather than the constant.

### Checklist
- [x] AI was used in creating this PR
