### PR TITLE
spark: emit LOAD DATA source path as input dataset

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitorTest.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.execution.command.LoadDataCommand;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+class LoadDataCommandInputVisitorTest {
+
+  @Test
+  void testLoadDataCommandSourcePathIsAnInput() {
+    SparkSession session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+    String database = session.catalog().currentDatabase();
+
+    LoadDataCommandInputVisitor visitor =
+        new LoadDataCommandInputVisitor(SparkAgentTestExtension.newContext(session));
+
+    LoadDataCommand command =
+        new LoadDataCommand(
+            TableIdentifier$.MODULE$.apply("table", Option.apply(database)),
+            "/path/to/data",
+            true,
+            false,
+            Option.empty());
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+
+    List<OpenLineage.InputDataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/path/to/data")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -29,6 +29,7 @@ import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveDirVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveTableVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.KafkaRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.KustoRelationVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandInputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
@@ -78,6 +79,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     }
 
     inputVisitors.add(new ExternalRDDVisitor(context));
+    inputVisitors.add(new LoadDataCommandInputVisitor(context));
     return inputVisitors;
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandInputVisitor.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.LoadDataCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches a {@link LoadDataCommand} and extracts the source
+ * location being read as an input {@link OpenLineage.Dataset}. The target table is emitted as the
+ * output by {@link LoadDataCommandVisitor}.
+ */
+@Slf4j
+public class LoadDataCommandInputVisitor
+    extends QueryPlanVisitor<LoadDataCommand, OpenLineage.InputDataset> {
+
+  public LoadDataCommandInputVisitor(OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<OpenLineage.InputDataset> apply(LogicalPlan x) {
+    String path = ((LoadDataCommand) x).path();
+    if (StringUtils.isBlank(path)) {
+      return Collections.emptyList();
+    }
+
+    try {
+      return Collections.singletonList(
+          inputDataset().sparkDatasetBuilder().dataset(PathUtils.fromPath(new Path(path))).build());
+    } catch (Exception e) {
+      // A LOAD DATA path may be a glob or an otherwise unparsable location
+      log.warn("Could not build an input dataset from LOAD DATA path {}", path, e);
+      return Collections.emptyList();
+    }
+  }
+}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

related: #4807

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Emit the source filesystem path as an input dataset for `LOAD DATA INPATH` statements.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
`LOAD DATA INPATH '…' INTO TABLE t` previously produced **output-only** lineage: the target table appeared in `outputs`, but the path being read never appeared in `inputs`. That left the run with no read side and no dataset→dataset edge from source to target.

**Root cause:** `LoadDataCommandVisitor` handles the target table only. `LoadDataCommand.path()` was never converted into an input dataset.

**Solution:**
- Add `LoadDataCommandInputVisitor` — reads `command.path()` and builds an input via `PathUtils.fromPath`
- Register the visitor in `BaseVisitorFactory.getInputVisitors` (alongside the existing output visitor)


**Expected event shape:**

| Statement | `inputs` | `outputs` |
|-----------|----------|-----------|
| `LOAD DATA INPATH '/path/to/data' INTO TABLE t` | source path | target table `t` |

**Tests:** `LoadDataCommandInputVisitorTest` — verifies path → input with `file` namespace.

**Validation Artifacts:** 
Validation notebook:

https://gist.github.com/mishrasangeeta87/3e16e755b7d16ec38c57959abaeda6df
OpenLineage events:


| Scenario | Before | After |
|-----------|----------|-----------|
| inputs| []  | [{"name":"/user/hive/warehouse/load_table","namespace":"dbfs","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"dbfs","uri":"dbfs"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"dbfs:/user/hive/warehouse","name":"default.load_table","type":"TABLE"}]}},"inputFacets":{},"outputFacets":{}}]|
outputs| [{"name":"/tmp/csv_input","namespace":"dbfs","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"dbfs","uri":"dbfs"}},"inputFacets":{},"outputFacets":{}}]| [{"name":"/user/hive/warehouse/load_table","namespace":"dbfs","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"dbfs","uri":"dbfs"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"dbfs:/user/hive/warehouse","name":"default.load_table","type":"TABLE"}]}},"inputFacets":{},"outputFacets":{}}]|

### Checklist
- [x] AI was used in creating this PR

> ⚠️ **AI Disclosure** — This pull request was generated with AI assistance (Cursor). All proposed changes were reviewed and validated by verifying the expected input and output lineage for the affected scenarios as specified under , Validation artifacts section.