### PR TITLE
spark: fix Databricks CTAS output dataset lineage

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/V2CreateTablePlanUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/V2CreateTablePlanUtils.java
@@ -1,0 +1,131 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Reflective accessors for {@code V2CreateTablePlan} nodes: {@code CreateTableAsSelect}, {@code
+ * ReplaceTableAsSelect}, {@code CreateTable} and {@code ReplaceTable}.
+ *
+ * <p>Databricks runtimes ship a catalyst whose signatures for these nodes differ from the Apache
+ * Spark release the runtime is based on - {@code tableSpec()} returning {@code TableSpec} instead
+ * of {@code TableSpecBase} is the best known example. Calling such a member through the compile
+ * time API throws {@link NoSuchMethodError}, which the builder framework swallows, so the event is
+ * still emitted but without any output dataset. Resolving the members reflectively, with fallbacks
+ * for the shapes seen across runtimes, keeps output extraction working on those platforms.
+ */
+@Slf4j
+public class V2CreateTablePlanUtils {
+
+  private V2CreateTablePlanUtils() {}
+
+  /**
+   * Resolves the catalog the table is created in. Since Spark 3.3 the catalog is reachable through
+   * the {@code ResolvedIdentifier} held in {@code name()}; older plans expose {@code catalog()}
+   * directly.
+   */
+  public static Optional<TableCatalog> catalog(LogicalPlan plan) {
+    return firstOf(
+        () ->
+            cast(invoke(plan, "name").flatMap(name -> invoke(name, "catalog")), TableCatalog.class),
+        () -> cast(invoke(plan, "catalog"), TableCatalog.class));
+  }
+
+  /** Resolves the identifier of the table being created or replaced. */
+  public static Optional<Identifier> identifier(LogicalPlan plan) {
+    return firstOf(
+        () -> cast(invoke(plan, "tableName"), Identifier.class),
+        () ->
+            cast(
+                invoke(plan, "name").flatMap(name -> invoke(name, "identifier")),
+                Identifier.class));
+  }
+
+  /**
+   * Table properties declared by the command, with the write options merged on top of them. Both
+   * are used to resolve the dataset location, so a missing one must not prevent the other from
+   * being read.
+   */
+  public static Map<String, String> properties(LogicalPlan plan) {
+    Map<String, String> properties = new LinkedHashMap<>();
+    Optional<Object> specProperties =
+        invoke(plan, "tableSpec").flatMap(spec -> invoke(spec, "properties"));
+
+    if (specProperties.isPresent()) {
+      properties.putAll(toJavaMap(specProperties.get()));
+    } else {
+      invoke(plan, "properties").ifPresent(p -> properties.putAll(toJavaMap(p)));
+    }
+
+    invoke(plan, "writeOptions").ifPresent(options -> properties.putAll(toJavaMap(options)));
+    return properties;
+  }
+
+  /**
+   * Schema of the table being created. Falls back to the schema of the select query for plans that
+   * do not expose {@code tableSchema()}, and to an empty schema when neither is available.
+   */
+  public static StructType schema(LogicalPlan plan) {
+    return firstOf(
+            () -> cast(invoke(plan, "tableSchema"), StructType.class),
+            () ->
+                cast(
+                    invoke(plan, "query").flatMap(query -> invoke(query, "schema")),
+                    StructType.class))
+        .orElseGet(StructType::new);
+  }
+
+  private static Optional<Object> invoke(Object target, String methodName) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(MethodUtils.invokeMethod(target, methodName));
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.debug("Could not call {} on {}", methodName, target.getClass().getCanonicalName(), e);
+      return Optional.empty();
+    }
+  }
+
+  private static <T> Optional<T> cast(Optional<Object> value, Class<T> type) {
+    return value.filter(type::isInstance).map(type::cast);
+  }
+
+  @SafeVarargs
+  private static <T> Optional<T> firstOf(Supplier<Optional<T>>... suppliers) {
+    for (Supplier<Optional<T>> supplier : suppliers) {
+      Optional<T> value = supplier.get();
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> toJavaMap(Object map) {
+    if (map instanceof scala.collection.immutable.Map) {
+      return ScalaConversionUtils.<String, String>fromMap(
+          (scala.collection.immutable.Map<String, String>) map);
+    } else if (map instanceof Map) {
+      return new HashMap<>((Map<String, String>) map);
+    }
+    log.debug("Unsupported properties type {}", map.getClass().getCanonicalName());
+    return new HashMap<>();
+  }
+}

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -9,19 +9,18 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
-import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
-import java.lang.reflect.InvocationTargetException;
+import io.openlineage.spark3.agent.utils.V2CreateTablePlanUtils;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
@@ -38,6 +37,10 @@ import org.apache.spark.sql.types.StructType;
  * {@link LogicalPlan} visitor that matches an {@link CreateTableAsSelect} and extracts the output
  * {@link OpenLineage.Dataset} being written. Although the builder is within spark35 package, it's
  * added as a dataset builder for Spark 3.4 on Databricks runtime.
+ *
+ * <p>Plan members are read through {@link V2CreateTablePlanUtils} because Databricks runtimes
+ * change the signatures of these nodes, and a {@link NoSuchMethodError} here would leave the event
+ * without any output dataset.
  */
 @Slf4j
 public class CreateReplaceOutputDatasetBuilder
@@ -62,88 +65,28 @@ public class CreateReplaceOutputDatasetBuilder
 
   @Override
   protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
-    if (plan instanceof CreateTableAsSelect) {
-      return apply(event, (CreateTableAsSelect) plan);
-    } else if (plan instanceof ReplaceTableAsSelect) {
-      return apply(event, (ReplaceTableAsSelect) plan);
-    } else if (plan instanceof CreateTable) {
-      return apply(event, (CreateTable) plan);
-    } else {
-      return apply(event, (ReplaceTable) plan);
+    Optional<TableCatalog> catalog = V2CreateTablePlanUtils.catalog(plan);
+    Optional<Identifier> identifier = V2CreateTablePlanUtils.identifier(plan);
+
+    if (!catalog.isPresent() || !identifier.isPresent()) {
+      log.warn(
+          "Could not obtain catalog and identifier from {}", plan.getClass().getCanonicalName());
+      return Collections.emptyList();
     }
+
+    return apply(
+        event,
+        catalog.get(),
+        V2CreateTablePlanUtils.properties(plan),
+        identifier.get(),
+        V2CreateTablePlanUtils.schema(plan),
+        lifecycleStateChange(plan));
   }
 
-  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, CreateTable plan) {
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.CREATE))
-        .orElse(Collections.emptyList());
-  }
-
-  protected List<OpenLineage.OutputDataset> apply(
-      SparkListenerEvent event, CreateTableAsSelect plan) {
-    Map<String, String> tableProperties =
-        new HashMap(ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()));
-    tableProperties.putAll(ScalaConversionUtils.<String, String>fromMap(plan.writeOptions()));
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    tableProperties,
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.CREATE))
-        .orElse(Collections.emptyList());
-  }
-
-  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, ReplaceTable plan) {
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.OVERWRITE))
-        .orElse(Collections.emptyList());
-  }
-
-  protected List<OpenLineage.OutputDataset> apply(
-      SparkListenerEvent event, ReplaceTableAsSelect plan) {
-    Map<String, String> tableProperties =
-        new HashMap(ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()));
-    tableProperties.putAll(ScalaConversionUtils.<String, String>fromMap(plan.writeOptions()));
-    return callCatalogMethod(plan.name())
-        .map(
-            catalogPlugin ->
-                apply(
-                    event,
-                    catalogPlugin,
-                    tableProperties,
-                    plan.tableName(),
-                    plan.tableSchema(),
-                    LifecycleStateChange.OVERWRITE))
-        .orElse(Collections.emptyList());
-  }
-
-  private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
-    try {
-      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", (Object[]) null));
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-      log.error("Could not obtain catalog plugin", e);
-      return Optional.empty();
-    }
+  private static LifecycleStateChange lifecycleStateChange(LogicalPlan plan) {
+    return (plan instanceof ReplaceTable || plan instanceof ReplaceTableAsSelect)
+        ? LifecycleStateChange.OVERWRITE
+        : LifecycleStateChange.CREATE;
   }
 
   private List<OpenLineage.OutputDataset> apply(
@@ -154,8 +97,7 @@ public class CreateReplaceOutputDatasetBuilder
       StructType schema,
       LifecycleStateChange lifecycleStateChange) {
 
-    Optional<DatasetIdentifier> di =
-        PlanUtils3.getDatasetIdentifier(context, catalog, identifier, tableProperties);
+    Optional<DatasetIdentifier> di = datasetIdentifier(catalog, identifier, tableProperties);
 
     if (!di.isPresent()) {
       return Collections.emptyList();
@@ -168,14 +110,70 @@ public class CreateReplaceOutputDatasetBuilder
             .schema(schema)
             .lifecycleStateChange(lifecycleStateChange);
 
-    if (includeDatasetVersion(event)) {
-      CatalogUtils.getDatasetVersion(context, catalog, identifier, tableProperties)
-          .ifPresent(sparkBuilder::version);
+    // A catalog that cannot describe the table must not cost the output dataset itself
+    try {
+      if (includeDatasetVersion(event)) {
+        CatalogUtils.getDatasetVersion(context, catalog, identifier, tableProperties)
+            .ifPresent(sparkBuilder::version);
+      }
+      CatalogUtils.addStorageAndCatalogFacets(
+          context, catalog, tableProperties, sparkBuilder.getInner());
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not add catalog facets of table {}", identifier, e);
     }
 
-    CatalogUtils.addStorageAndCatalogFacets(
-        context, catalog, tableProperties, sparkBuilder.getInner());
     return Collections.singletonList(sparkBuilder.build());
+  }
+
+  private Optional<DatasetIdentifier> datasetIdentifier(
+      TableCatalog catalog, Identifier identifier, Map<String, String> tableProperties) {
+    Optional<DatasetIdentifier> di;
+    try {
+      di = PlanUtils3.getDatasetIdentifier(context, catalog, identifier, tableProperties);
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not resolve dataset identifier of table {}", identifier, e);
+      di = Optional.empty();
+    }
+
+    if (di.isPresent()) {
+      return di;
+    }
+
+    Optional<DatasetIdentifier> fallback = unityCatalogIdentifier(catalog, identifier);
+    if (!fallback.isPresent()) {
+      log.warn(
+          "No dataset identifier resolved for table {} of catalog {}",
+          identifier,
+          catalog.getClass().getCanonicalName());
+    }
+    return fallback;
+  }
+
+  /**
+   * Unity Catalog managed tables have no location available at the time the create command is
+   * built, and the session catalog cannot resolve a default path for a Unity Catalog namespace. In
+   * that case the table is identified by its {@code catalog.schema.table} name, which is the same
+   * name attached as a symlink when the location is known, so both forms refer to the same table.
+   */
+  private Optional<DatasetIdentifier> unityCatalogIdentifier(
+      TableCatalog catalog, Identifier identifier) {
+    boolean unityCatalogEnabled =
+        context
+            .getSparkContext()
+            .map(SparkContext::getConf)
+            .map(DatabricksUtils::isDatabricksUnityCatalogEnabled)
+            .orElse(false);
+
+    if (!unityCatalogEnabled) {
+      return Optional.empty();
+    }
+
+    String name = DatabricksUtils.qualifiedUnityCatalogTableName(catalog, identifier);
+    log.warn(
+        "Could not resolve the location of Unity Catalog table {}, falling back to its qualified name",
+        name);
+    return Optional.of(
+        new DatasetIdentifier(name, DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE));
   }
 
   @Override
@@ -184,17 +182,6 @@ public class CreateReplaceOutputDatasetBuilder
       return Optional.empty();
     }
 
-    Identifier identifier = null;
-    if (plan instanceof CreateTableAsSelect) {
-      identifier = ((CreateTableAsSelect) plan).tableName();
-    } else if (plan instanceof ReplaceTable) {
-      identifier = ((ReplaceTable) plan).tableName();
-    } else if (plan instanceof ReplaceTableAsSelect) {
-      identifier = ((ReplaceTableAsSelect) plan).tableName();
-    } else if (plan instanceof CreateTable) {
-      identifier = ((CreateTable) plan).tableName();
-    }
-
-    return Optional.of(identToSuffix(identifier));
+    return V2CreateTablePlanUtils.identifier(plan).map(this::identToSuffix);
   }
 }

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -20,6 +20,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
@@ -27,6 +28,7 @@ import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
@@ -51,10 +53,13 @@ import scala.collection.immutable.Map;
 class CreateReplaceDatasetBuilderTest {
 
   private static final String TABLE = "table";
+  private static final String SOME_KEY = "some-key";
+  private static final String SOME_VALUE = "some-value";
+  SparkContext sparkContext = mock(SparkContext.class);
   OpenLineageContext openLineageContext =
       OpenLineageContext.builder()
           .sparkSession(mock(SparkSession.class))
-          .sparkContext(mock(SparkContext.class))
+          .sparkContext(sparkContext)
           .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
           .meterRegistry(new SimpleMeterRegistry())
           .openLineageConfig(new SparkOpenLineageConfig())
@@ -100,7 +105,7 @@ class CreateReplaceDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.writeOptions())
         .thenReturn(
-            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
     verifyApply(
         (LogicalPlan) logicalPlan,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
@@ -127,7 +132,7 @@ class CreateReplaceDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.writeOptions())
         .thenReturn(
-            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
     verifyApply(
         (LogicalPlan) logicalPlan,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
@@ -244,7 +249,7 @@ class CreateReplaceDatasetBuilderTest {
       when(logicalPlan.tableSchema()).thenReturn(schema);
       when(logicalPlan.writeOptions())
           .thenReturn(
-              ScalaConversionUtils.fromJavaMap(Collections.singletonMap("some-key", "some-value")));
+              ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
 
       when(PlanUtils3.getDatasetIdentifier(
               openLineageContext,
@@ -257,6 +262,95 @@ class CreateReplaceDatasetBuilderTest {
           builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
       assertEquals(0, outputDatasets.size());
     }
+  }
+
+  @Test
+  void testApplyWhenTableSpecIsNotAvailable() {
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenThrow(new NoSuchMethodError("tableSpec"));
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    when(logicalPlan.writeOptions())
+        .thenReturn(
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap(SOME_KEY, SOME_VALUE)));
+
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+  }
+
+  @Test
+  void testApplyFallsBackToQuerySchema() {
+    StructType querySchema = new StructType().add("id", "int");
+    LogicalPlan query = mock(LogicalPlan.class);
+    when(query.schema()).thenReturn(querySchema);
+
+    CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenThrow(new NoSuchMethodError("tableSchema"));
+    when(logicalPlan.query()).thenReturn(query);
+    when(logicalPlan.writeOptions()).thenReturn(new HashMap<>());
+
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              eq(openLineageContext), eq(catalog), eq(tableName), anyMap()))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals(
+          "id", outputDatasets.get(0).getFacets().getSchema().getFields().get(0).getName());
+    }
+  }
+
+  @Test
+  void testApplyFallsBackToUnityCatalogName() {
+    SparkConf sparkConf = new SparkConf();
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    when(logicalPlan.writeOptions()).thenReturn(new HashMap<>());
+
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic<DatabricksUtils> databricks = mockStatic(DatabricksUtils.class)) {
+        databricks
+            .when(() -> DatabricksUtils.isDatabricksUnityCatalogEnabled(sparkConf))
+            .thenReturn(true);
+        databricks
+            .when(() -> DatabricksUtils.qualifiedUnityCatalogTableName(catalog, tableName))
+            .thenReturn("catalog.db.table");
+        when(PlanUtils3.getDatasetIdentifier(
+                eq(openLineageContext), eq(catalog), eq(tableName), anyMap()))
+            .thenThrow(new IllegalStateException("no default path for a unity catalog namespace"));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals("catalog.db.table", outputDatasets.get(0).getName());
+        assertEquals("unity-catalog", outputDatasets.get(0).getNamespace());
+      }
+    }
+  }
+
+  @Test
+  void testApplyWhenCatalogCannotBeResolved() {
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(mock(LogicalPlan.class));
+    when(logicalPlan.tableName()).thenReturn(tableName);
+
+    assertThat(builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan))
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->
related: #4807

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Fixes missing output datasets for `CREATE TABLE AS SELECT` (and related V2 create/replace table commands) on Databricks runtimes.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
Databricks ships a Catalyst plan whose signatures for `CreateTableAsSelect`, `ReplaceTableAsSelect`, `CreateTable`, and `ReplaceTable` differ from the upstream Apache Spark release. Direct compile-time calls to plan members such as `tableSpec()` can throw `NoSuchMethodError`, which the builder framework swallows — leaving the OpenLineage event without an output dataset.

This PR:

- Adds `V2CreateTablePlanUtils` to resolve catalog, identifier, properties, and schema reflectively with runtime fallbacks
- Refactors `CreateReplaceOutputDatasetBuilder` to use those utilities and consolidate the four plan-type code paths
- Adds a Unity Catalog fallback that identifies managed tables by their qualified `catalog.schema.table` name when no storage location is available at plan time
- Ensures catalog facet resolution failures do not suppress the output dataset itself

**Validation artifacts**

Validation notebook:
https://gist.github.com/mishrasangeeta87/3e16e755b7d16ec38c57959abaeda6df

OpenLineage events:
| Scenario | Before | After |
|------|--------|--------|
| inputs |  [{"name":"unity-catalog/7474644317745272/sangeeta/__unitystorage/catalogs/3d92ab1b-c9c7-41e7-9b7b-77c689e76698/tables/a446b585-4716-4ef2-ba8c-be60a429a7b7","namespace":"s3://databricks-workspace-stack-93947-bucket","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"s3://databricks-workspace-stack-93947-bucket","uri":"s3://databricks-workspace-stack-93947-bucket"},"storage":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/StorageDatasetFacet.json#/$defs/StorageDatasetFacet","storageLayer":"unity","fileFormat":"parquet"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"catalog":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-1-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet","framework":"delta","type":"unity","name":"sangeeta_catalog","source":"spark"},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"unity-catalog","name":"sangeeta_catalog.openlineage_dml.source_table","type":"TABLE"}]}},"inputFacets":{"inputStatistics":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.51.0/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-0/InputStatisticsInputDatasetFacet.json#/$defs/InputStatisticsInputDatasetFacet","size":1275}},"outputFacets":{}}]  |   [{"name":"unity-catalog/7474644317745272/sangeeta/__unitystorage/catalogs/3d92ab1b-c9c7-41e7-9b7b-77c689e76698/tables/a446b585-4716-4ef2-ba8c-be60a429a7b7","namespace":"s3://databricks-workspace-stack-93947-bucket","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"s3://databricks-workspace-stack-93947-bucket","uri":"s3://databricks-workspace-stack-93947-bucket"},"storage":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/StorageDatasetFacet.json#/$defs/StorageDatasetFacet","storageLayer":"unity","fileFormat":"parquet"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"catalog":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-1-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet","framework":"delta","type":"unity","name":"sangeeta_catalog","source":"spark"},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"unity-catalog","name":"sangeeta_catalog.openlineage_dml.source_table","type":"TABLE"}]}},"inputFacets":{"inputStatistics":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-0/InputStatisticsInputDatasetFacet.json#/$defs/InputStatisticsInputDatasetFacet","size":1275}},"outputFacets":{}}] |
| outputs |  [] | [{"name":"sangeeta_catalog.openlineage_dml.ctas_table","namespace":"unity-catalog","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"unity-catalog","uri":"unity-catalog"},"storage":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/StorageDatasetFacet.json#/$defs/StorageDatasetFacet","storageLayer":"unity","fileFormat":"parquet"},"lifecycleStateChange":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/LifecycleStateChangeDatasetFacet.json#/$defs/LifecycleStateChangeDatasetFacet","lifecycleStateChange":"CREATE"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"},{"name":"created_at","type":"timestamp"}]},"catalog":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-1-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet","framework":"delta","type":"unity","name":"sangeeta_catalog","source":"spark"}},"inputFacets":{},"outputFacets":{"outputStatistics":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-2/OutputStatisticsOutputDatasetFacet.json#/$defs/OutputStatisticsOutputDatasetFacet","rowCount":3,"size":1827,"fileCount":1}}}] |


### Checklist
- [x] AI was used in creating this PR

AI Disclosure — This pull request was generated with AI assistance (Cursor). All proposed changes were reviewed and validated by verifying the expected input and output lineage for the affected scenarios as specified under , Validation artifacts section.
