### PR TITLE
spark: fix Databricks COPY INTO lineage on CopyIntoCommandEdge

### DIFF
--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportSslContextTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportSslContextTest.java
@@ -41,6 +41,9 @@ class HttpTransportSslContextTest {
   OpenLineage.RunEvent event =
       new OpenLineage(URI.create("http://test.producer")).newRunEventBuilder().build();
 
+  private static final String TLS_HANDSHAKE_FAILURE =
+      "TLS handshake failure while a client attempted to connect to";
+
   @BeforeAll
   @SneakyThrows
   public static void beforeAll() {
@@ -101,9 +104,24 @@ class HttpTransportSslContextTest {
     // make sure client exception is thrown
     assertThrows(OpenLineageClientException.class, () -> httpTransport.emit(event));
 
-    // make sure logs contain handshake failure message
-    assertThat(mockServer.retrieveLogMessages(request(API_V1_LINEAGE)))
-        .contains("TLS handshake failure while a client attempted to connect to");
+    // MockServer log retrieval can lag behind the client exception; poll briefly.
+    assertThat(retrieveLogMessagesWithRetry(request(API_V1_LINEAGE)))
+        .isNotNull()
+        .contains(TLS_HANDSHAKE_FAILURE);
+  }
+
+  @SneakyThrows
+  private String retrieveLogMessagesWithRetry(HttpRequest request) {
+    long deadlineNanos = System.nanoTime() + 5_000_000_000L;
+    String messages;
+    do {
+      messages = mockServer.retrieveLogMessages(request);
+      if (messages != null) {
+        return messages;
+      }
+      Thread.sleep(50);
+    } while (System.nanoTime() < deadlineNanos);
+    return messages;
   }
 
   @Test

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -20,6 +20,8 @@ import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
@@ -71,6 +73,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
             .add(new UpdateCommandInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
             .add(new ViewInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
@@ -93,6 +96,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new DeleteCommandOutputDatasetBuilder(context))
             .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -12,6 +12,7 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DeleteCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
@@ -44,6 +45,7 @@ public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new DeleteCommandOutputDatasetBuilder(context))
             .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -17,6 +17,8 @@ import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
@@ -71,6 +73,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DeleteCommandInputDatasetBuilder(context))
             .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new ViewInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
@@ -94,6 +97,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new DeleteCommandOutputDatasetBuilder(context))
             .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -16,6 +16,8 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
@@ -70,6 +72,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
 
@@ -91,6 +94,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new DeleteCommandOutputDatasetBuilder(context))
             .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -17,6 +17,8 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
@@ -62,6 +64,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
             .add(new DeleteCommandInputDatasetBuilder(context))
             .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new SubqueryAliasInputDatasetBuilder(context));
@@ -84,6 +87,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new DeleteCommandOutputDatasetBuilder(context))
             .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -17,6 +17,8 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CopyIntoCommandOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
@@ -73,6 +75,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new UpdateCommandInputDatasetBuilder(context))
             .add(new SparkExtensionV1InputDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new CopyIntoCommandInputDatasetBuilder(context))
             .add(new StreamingDataSourceV2ScanRelationDatasetBuilder(context))
             .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
@@ -95,6 +98,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CopyIntoCommandOutputDatasetBuilder(context))
             .add(new DeleteCommandOutputDatasetBuilder(context))
             .add(new UpdateCommandOutputDatasetBuilder(context))
             .add(new CreateReplaceOutputDatasetBuilder(context))

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
@@ -1,0 +1,92 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import io.openlineage.spark3.agent.utils.CopyIntoSqlUtils;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
+ * CopyIntoCommandEdge}. The source is typically a file path (e.g., S3, ADLS, DBFS, Unity Catalog
+ * Volumes). Since these classes belong to the Databricks runtime, reflection is used to access
+ * source-related members, with SQL parsing as a fallback.
+ */
+@Slf4j
+public class CopyIntoCommandInputDatasetBuilder
+    extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
+
+  public CopyIntoCommandInputDatasetBuilder(OpenLineageContext context) {
+    super(context, true);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return CopyIntoCommandUtils.isCopyIntoCommand(x) || isOptimizedRootWithCopyIntoSql(x);
+  }
+
+  @Override
+  protected List<InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (CopyIntoCommandUtils.isCopyIntoCommand(x)) {
+      List<InputDataset> datasets = datasetsFromCommand(event, x);
+      if (!datasets.isEmpty()) {
+        return datasets;
+      }
+      log.warn(
+          "Matched COPY INTO command {} but extracted no input datasets",
+          x.getClass().getCanonicalName());
+    }
+    return datasetsFromSql();
+  }
+
+  private List<InputDataset> datasetsFromCommand(SparkListenerEvent event, LogicalPlan x) {
+    return CopyIntoCommandUtils.sourcePath(x)
+        .flatMap(this::inputDatasetFromPath)
+        .map(Collections::singletonList)
+        .orElseGet(
+            () ->
+                CopyIntoCommandUtils.sourceQuery(x)
+                    .map(query -> delegate(query, event))
+                    .orElse(Collections.emptyList()));
+  }
+
+  private List<InputDataset> datasetsFromSql() {
+    return CopyIntoCommandUtils.sqlText(context)
+        .flatMap(CopyIntoSqlUtils::sourcePath)
+        .flatMap(this::inputDatasetFromPath)
+        .map(Collections::singletonList)
+        .orElse(Collections.emptyList());
+  }
+
+  private boolean isOptimizedRootWithCopyIntoSql(LogicalPlan x) {
+    return context.getQueryExecution().map(qe -> qe.optimizedPlan() == x).orElse(false)
+        && CopyIntoCommandUtils.sqlText(context)
+            .filter(CopyIntoSqlUtils::isCopyIntoStatement)
+            .isPresent();
+  }
+
+  private java.util.Optional<InputDataset> inputDatasetFromPath(String sourcePath) {
+    try {
+      return java.util.Optional.of(
+          inputDataset()
+              .sparkDatasetBuilder()
+              .dataset(PathUtils.fromPath(new Path(sourcePath)))
+              .build());
+    } catch (Exception e) {
+      log.warn("Failed to construct input dataset from COPY INTO source path: {}", sourcePath, e);
+      return java.util.Optional.empty();
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilder.java
@@ -7,16 +7,20 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
 import io.openlineage.spark3.agent.utils.CopyIntoSqlUtils;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import scala.PartialFunction;
 
 /**
  * Extracts input datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
@@ -58,8 +62,18 @@ public class CopyIntoCommandInputDatasetBuilder
         .orElseGet(
             () ->
                 CopyIntoCommandUtils.sourceQuery(x)
-                    .map(query -> delegate(query, event))
+                    .map(query -> datasetsFromQuery(query, event))
                     .orElse(Collections.emptyList()));
+  }
+
+  private List<InputDataset> datasetsFromQuery(LogicalPlan query, SparkListenerEvent event) {
+    PartialFunction<LogicalPlan, Collection<InputDataset>> delegateFn =
+        delegate(
+            context.getInputDatasetQueryPlanVisitors(), context.getInputDatasetBuilders(), event);
+
+    return ScalaConversionUtils.fromSeq(query.collect(delegateFn)).stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
   private List<InputDataset> datasetsFromSql() {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -1,0 +1,276 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkDatasetBuilder;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import io.openlineage.spark3.agent.utils.CopyIntoSqlUtils;
+import io.openlineage.spark3.agent.utils.UnityCatalogTableDatasetUtils;
+import io.openlineage.spark3.agent.utils.UnityCatalogTableDatasetUtils.ResolvedTableDataset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import scala.Option;
+
+/**
+ * Extracts output datasets from the Databricks-specific {@code CopyIntoCommand} or {@code
+ * CopyIntoCommandEdge}. Since these classes belong to the Databricks runtime and are not available
+ * at compile time, reflection is used to access their target relation, with SQL parsing as a
+ * fallback.
+ */
+@Slf4j
+public class CopyIntoCommandOutputDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  private static final int CATALOG_SCHEMA_TABLE_PARTS = 3;
+  private static final int SCHEMA_TABLE_PARTS = 2;
+
+  public CopyIntoCommandOutputDatasetBuilder(OpenLineageContext context) {
+    super(context, true);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return CopyIntoCommandUtils.isCopyIntoCommand(x) || isOptimizedRootWithCopyIntoSql(x);
+  }
+
+  @Override
+  protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (CopyIntoCommandUtils.isCopyIntoCommand(x)) {
+      List<OutputDataset> datasets = datasetsFromCommand(event, x);
+      if (!datasets.isEmpty()) {
+        return datasets;
+      }
+      log.warn(
+          "Matched COPY INTO command {} but extracted no output datasets",
+          x.getClass().getCanonicalName());
+    } else if (isOptimizedRootWithCopyIntoSql(x)) {
+      for (LogicalPlan command : CopyIntoCommandUtils.findAllCommands(context)) {
+        List<OutputDataset> datasets = datasetsFromCommand(event, command);
+        if (!datasets.isEmpty()) {
+          return datasets;
+        }
+      }
+    } else {
+      return Collections.emptyList();
+    }
+    return datasetsFromSql(event);
+  }
+
+  @Override
+  public Optional<String> jobNameSuffix(LogicalPlan plan) {
+    Optional<String> suffix =
+        CopyIntoCommandUtils.target(plan)
+            .flatMap(
+                target ->
+                    context.getOutputDatasetBuilders().stream()
+                        .filter(b -> b instanceof AbstractQueryPlanOutputDatasetBuilder)
+                        .map(b -> (AbstractQueryPlanOutputDatasetBuilder) b)
+                        .map(b -> b.jobNameSuffixFromLogicalPlan(target))
+                        .filter(Optional::isPresent)
+                        .map(o -> (String) o.get())
+                        .findFirst());
+    if (suffix.isPresent()) {
+      return suffix;
+    }
+    if (isOptimizedRootWithCopyIntoSql(plan)) {
+      return CopyIntoCommandUtils.sqlText(context)
+          .flatMap(CopyIntoSqlUtils::targetTable)
+          .map(table -> table.replace(".", "_"));
+    }
+    return Optional.empty();
+  }
+
+  private List<OutputDataset> datasetsFromCommand(SparkListenerEvent event, LogicalPlan command) {
+    List<OutputDataset> fromTarget =
+        CopyIntoCommandUtils.target(command)
+            .map(target -> delegate(target, event))
+            .orElse(Collections.emptyList());
+    if (!fromTarget.isEmpty()) {
+      return fromTarget;
+    }
+    List<OutputDataset> fromRelation =
+        CopyIntoCommandUtils.findTableRelation(command)
+            .map(relation -> delegate(relation, event))
+            .orElse(Collections.emptyList());
+    if (fromRelation.isEmpty()) {
+      log.warn(
+          "COPY INTO: no output dataset from command members or plan tree. {}",
+          CopyIntoCommandUtils.describeMembers(command));
+    }
+    return fromRelation;
+  }
+
+  private List<OutputDataset> datasetsFromSql(SparkListenerEvent event) {
+    return CopyIntoCommandUtils.sqlText(context)
+        .flatMap(CopyIntoSqlUtils::targetTable)
+        .map(tableName -> outputDatasetsFromTableName(tableName, event))
+        .orElse(Collections.emptyList());
+  }
+
+  /**
+   * Resolves the COPY INTO target from parsed SQL text. Does not call {@code session.table()}: on
+   * Databricks that re-analyzes the table in the SparkListener thread and fails with {@code
+   * MissingCredentialScopeException}.
+   */
+  private List<OutputDataset> outputDatasetsFromTableName(
+      String tableName, SparkListenerEvent event) {
+    return sparkSession()
+        .map(
+            session -> {
+              TableIdentifier identifier =
+                  parseTableIdentifier(tableName.replace("`", "").trim(), session);
+              try {
+                return outputDatasetFromTableName(tableName, event, session, identifier)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+              } catch (Exception e) {
+                log.warn(
+                    "COPY INTO: catalog resolution failed for target {}, falling back to name-only identity",
+                    identifier,
+                    e);
+                return outputDatasetFromTableNameFallback(tableName, session, identifier)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+              }
+            })
+        .orElse(Collections.emptyList());
+  }
+
+  private boolean isOptimizedRootWithCopyIntoSql(LogicalPlan x) {
+    return context.getQueryExecution().map(qe -> qe.optimizedPlan() == x).orElse(false)
+        && CopyIntoCommandUtils.sqlText(context)
+            .filter(CopyIntoSqlUtils::isCopyIntoStatement)
+            .isPresent();
+  }
+
+  private Optional<OutputDataset> outputDatasetFromTableName(
+      String tableName,
+      SparkListenerEvent event,
+      SparkSession session,
+      TableIdentifier identifier) {
+    Optional<OutputDataset> fromV2Catalog =
+        UnityCatalogTableDatasetUtils.resolve(context, session, identifier)
+            .map(resolved -> buildOutputDataset(resolved, event));
+    if (fromV2Catalog.isPresent()) {
+      return fromV2Catalog;
+    }
+
+    try {
+      CatalogTable catalogTable = session.sessionState().catalog().getTableMetadata(identifier);
+      return Optional.of(outputDataset().sparkDatasetBuilder().dataset(catalogTable).build());
+    } catch (Exception e) {
+      log.debug(
+          "Legacy catalog lookup failed for COPY INTO target {}, trying name-only fallback",
+          tableName,
+          e);
+    }
+
+    return outputDatasetFromTableNameFallback(tableName, session, identifier);
+  }
+
+  private Optional<OutputDataset> outputDatasetFromTableNameFallback(
+      String tableName, SparkSession session, TableIdentifier identifier) {
+    if (DatabricksUtils.isDatabricksUnityCatalogEnabled(session.sparkContext().getConf())) {
+      return Optional.of(
+          outputDataset()
+              .sparkDatasetBuilder()
+              .dataset(
+                  DatabricksUtils.qualifiedUnityCatalogTableName(identifier),
+                  DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE)
+              .build());
+    }
+    log.warn("Unable to resolve COPY INTO target table {}", tableName);
+    return Optional.empty();
+  }
+
+  private Optional<SparkSession> sparkSession() {
+    return context.getSparkSession().or(SparkSessionUtils::activeSession);
+  }
+
+  private OutputDataset buildOutputDataset(
+      ResolvedTableDataset resolved, SparkListenerEvent event) {
+    SparkDatasetBuilder<OutputDataset> sparkBuilder =
+        outputDataset()
+            .sparkDatasetBuilder()
+            .dataset(resolved.getDatasetIdentifier())
+            .schema(resolved.getSchema());
+    try {
+      if (includeDatasetVersion(event)) {
+        CatalogUtils.getDatasetVersion(
+                context, resolved.getCatalog(), resolved.getIdentifier(), resolved.getProperties())
+            .ifPresent(sparkBuilder::version);
+      }
+      CatalogUtils.addStorageAndCatalogFacets(
+          context, resolved.getCatalog(), resolved.getProperties(), sparkBuilder.getInner());
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn(
+          "Could not add catalog facets for COPY INTO target {}",
+          resolved.getDatasetIdentifier().getName(),
+          e);
+    }
+    return sparkBuilder.build();
+  }
+
+  private TableIdentifier parseTableIdentifier(String normalized, SparkSession session) {
+    String[] parts = normalized.split("\\.");
+    String defaultDatabase = session.catalog().currentDatabase();
+    Optional<String> defaultCatalog = currentCatalog(session);
+
+    if (parts.length == CATALOG_SCHEMA_TABLE_PARTS) {
+      return tableIdentifier(parts[2], parts[1], Optional.of(parts[0]));
+    }
+    if (parts.length == SCHEMA_TABLE_PARTS) {
+      return tableIdentifier(parts[1], parts[0], defaultCatalog);
+    }
+    return tableIdentifier(parts[0], defaultDatabase, defaultCatalog);
+  }
+
+  private TableIdentifier tableIdentifier(String table, String database, Optional<String> catalog) {
+    if (catalog.filter(StringUtils::isNotBlank).isPresent()) {
+      try {
+        return (TableIdentifier)
+            MethodUtils.invokeMethod(
+                TableIdentifier$.MODULE$,
+                "apply",
+                table,
+                Option.apply(database),
+                Option.apply(catalog.get()));
+      } catch (Exception e) {
+        log.debug(
+            "Could not build TableIdentifier with catalog {}, falling back to schema only",
+            catalog.get(),
+            e);
+      }
+    }
+    return TableIdentifier$.MODULE$.apply(table, Option.apply(database));
+  }
+
+  private Optional<String> currentCatalog(SparkSession session) {
+    try {
+      return Optional.ofNullable(
+              (String) MethodUtils.invokeMethod(session.catalog(), "currentCatalog"))
+          .filter(StringUtils::isNotBlank);
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -54,6 +54,11 @@ public class CopyIntoCommandOutputDatasetBuilder
 
   @Override
   protected List<OutputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (CopyIntoCommandUtils.sqlText(context)
+        .filter(CopyIntoSqlUtils::isValidateStatement)
+        .isPresent()) {
+      return Collections.emptyList();
+    }
     if (CopyIntoCommandUtils.isCopyIntoCommand(x)) {
       List<OutputDataset> datasets = datasetsFromCommand(event, x);
       if (!datasets.isEmpty()) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilder.java
@@ -203,7 +203,11 @@ public class CopyIntoCommandOutputDatasetBuilder
   }
 
   private Optional<SparkSession> sparkSession() {
-    return context.getSparkSession().or(SparkSessionUtils::activeSession);
+    Optional<SparkSession> session = context.getSparkSession();
+    if (!session.isPresent()) {
+      session = SparkSessionUtils.activeSession();
+    }
+    return session;
   }
 
   private OutputDataset buildOutputDataset(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
@@ -1,0 +1,563 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import scala.Option;
+
+/**
+ * Recognises the Databricks Delta commands that a {@code COPY INTO} statement is turned into, and
+ * reads their target relation and source location.
+ *
+ * <p>On newer Databricks runtimes (Spark 4.0+) the logical plan is {@code CopyIntoCommandEdge}
+ * rather than {@code CopyIntoCommand}. Neither class is on the compile classpath, so builders match
+ * by canonical class name suffix and reach into the command reflectively, with fallbacks for the
+ * member names and shapes seen across runtimes. When the command is not the optimized-plan root, or
+ * reflection still fails, SQL text from the logical plan origin is parsed as a last resort.
+ */
+@Slf4j
+public class CopyIntoCommandUtils {
+
+  private static final List<String> COMMAND_CLASS_SUFFIXES =
+      Arrays.asList(
+          "sql.transaction.tahoe.commands.CopyIntoCommand",
+          "sql.transaction.tahoe.commands.CopyIntoCommandEdge");
+
+  private static final List<String> TARGET_METHOD_NAMES =
+      Arrays.asList("target", "targetTable", "table", "copyIntoTarget", "copyIntoTable");
+
+  private static final List<String> TARGET_FIELD_NAMES =
+      Arrays.asList("target", "targetTable", "table", "copyIntoTarget", "copyIntoTable");
+
+  private static final List<String> SOURCE_PATH_METHOD_NAMES =
+      Arrays.asList(
+          "sourcePath",
+          "path",
+          "sourceLocation",
+          "location",
+          "sourceUri",
+          "inputPath",
+          "copyIntoSourcePath",
+          "from");
+
+  private static final List<String> SOURCE_PATH_FIELD_NAMES =
+      Arrays.asList(
+          "sourcePath",
+          "path",
+          "sourceLocation",
+          "location",
+          "sourceUri",
+          "inputPath",
+          "copyIntoSourcePath",
+          "from");
+
+  private static final String SOURCE_MEMBER = "source";
+
+  private static final List<String> SOURCE_QUERY_METHOD_NAMES =
+      Arrays.asList("query", SOURCE_MEMBER, "copyIntoSource", "sourceQuery");
+
+  private static final List<String> SOURCE_QUERY_FIELD_NAMES =
+      Arrays.asList("query", SOURCE_MEMBER, "copyIntoSource", "sourceQuery");
+
+  private static final List<String> NESTED_SOURCE_MEMBERS =
+      Arrays.asList(
+          "sourceOptions", "copyIntoOptions", "options", "readerOptions", "formatOptions");
+
+  private CopyIntoCommandUtils() {}
+
+  public static boolean isCopyIntoCommand(LogicalPlan plan) {
+    return matchesCommandClassName(plan.getClass().getCanonicalName());
+  }
+
+  /** Package-visible for tests; Databricks command classes are not on the classpath. */
+  static boolean matchesCommandClassName(String canonicalName) {
+    if (canonicalName == null) {
+      return false;
+    }
+    if (COMMAND_CLASS_SUFFIXES.stream().anyMatch(canonicalName::endsWith)) {
+      return true;
+    }
+    return canonicalName.contains("CopyInto")
+        && (canonicalName.endsWith("CommandEdge")
+            || canonicalName.endsWith("Command")
+            || canonicalName.endsWith("CopyIntoCommandEdge")
+            || canonicalName.endsWith("CopyIntoCommand"));
+  }
+
+  /** Finds every COPY INTO command node across optimized, analyzed, and logical plans. */
+  public static List<LogicalPlan> findAllCommands(OpenLineageContext context) {
+    return context
+        .getQueryExecution()
+        .map(CopyIntoCommandUtils::findAllCommands)
+        .orElse(Collections.emptyList());
+  }
+
+  private static List<LogicalPlan> findAllCommands(QueryExecution queryExecution) {
+    Set<LogicalPlan> commands = new LinkedHashSet<>();
+    findInTree(queryExecution.optimizedPlan()).ifPresent(commands::add);
+    findInTree(queryExecution.analyzed()).ifPresent(commands::add);
+    findInTree(queryExecution.logical()).ifPresent(commands::add);
+    return new ArrayList<>(commands);
+  }
+
+  public static Optional<LogicalPlan> findInTree(LogicalPlan root) {
+    if (root == null) {
+      return Optional.empty();
+    }
+    java.util.ArrayDeque<LogicalPlan> stack = new java.util.ArrayDeque<>();
+    stack.push(root);
+    while (!stack.isEmpty()) {
+      LogicalPlan plan = stack.pop();
+      if (isCopyIntoCommand(plan)) {
+        return Optional.of(plan);
+      }
+      ScalaConversionUtils.fromSeq(plan.children()).forEach(stack::push);
+    }
+    return Optional.empty();
+  }
+
+  /** Finds a table scan relation under a COPY INTO command for delegate-based extraction. */
+  public static Optional<LogicalPlan> findTableRelation(LogicalPlan root) {
+    Optional<LogicalPlan> dataSourceV2Relation = findDataSourceV2Relation(root);
+    if (dataSourceV2Relation.isPresent()) {
+      return dataSourceV2Relation;
+    }
+    return findLogicalRelation(root);
+  }
+
+  /**
+   * Finds a {@link DataSourceV2Relation} under a COPY INTO command for delegate-based extraction.
+   */
+  public static Optional<LogicalPlan> findDataSourceV2Relation(LogicalPlan root) {
+    return findInTreeByType(root, DataSourceV2Relation.class);
+  }
+
+  private static Optional<LogicalPlan> findLogicalRelation(LogicalPlan root) {
+    return findInTreeByType(root, LogicalRelation.class);
+  }
+
+  private static Optional<LogicalPlan> findInTreeByType(LogicalPlan root, Class<?> type) {
+    if (root == null) {
+      return Optional.empty();
+    }
+    java.util.ArrayDeque<LogicalPlan> stack = new java.util.ArrayDeque<>();
+    stack.push(root);
+    while (!stack.isEmpty()) {
+      LogicalPlan plan = stack.pop();
+      if (type.isInstance(plan)) {
+        return Optional.of(plan);
+      }
+      ScalaConversionUtils.fromSeq(plan.children()).forEach(stack::push);
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<String> sqlText(OpenLineageContext context) {
+    return context
+        .getQueryExecution()
+        .flatMap(
+            qe ->
+                firstOf(
+                    () -> sqlFromPlanTree(qe.logical()),
+                    () -> sqlFromPlanTree(qe.analyzed()),
+                    () -> sqlFromPlanTree(qe.optimizedPlan())))
+        .filter(CopyIntoSqlUtils::isCopyIntoStatement);
+  }
+
+  private static Optional<String> sqlFromPlanTree(LogicalPlan root) {
+    if (root == null) {
+      return Optional.empty();
+    }
+    java.util.ArrayDeque<LogicalPlan> stack = new java.util.ArrayDeque<>();
+    stack.push(root);
+    while (!stack.isEmpty()) {
+      LogicalPlan plan = stack.pop();
+      Optional<String> sql = sqlFromOrigin(plan);
+      if (sql.isPresent()) {
+        return sql;
+      }
+      ScalaConversionUtils.fromSeq(plan.children()).forEach(stack::push);
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> sqlFromOrigin(LogicalPlan plan) {
+    if (plan.origin() == null) {
+      return Optional.empty();
+    }
+    Object origin = plan.origin();
+    return firstOf(
+        () -> stringFromOriginMember(invoke(origin, "sqlText")),
+        () -> stringFromOriginMember(invoke(origin, "sql")),
+        () -> stringFromOriginMember(readField(origin, "sqlText")),
+        () -> stringFromOriginMember(readField(origin, "sql")));
+  }
+
+  private static Optional<String> stringFromOriginMember(Optional<Object> value) {
+    if (value.isEmpty()) {
+      return Optional.empty();
+    }
+    Object object = value.get();
+    if (object instanceof Option) {
+      Option<?> option = (Option<?>) object;
+      if (option.isDefined() && option.get() instanceof String) {
+        return Optional.of((String) option.get()).filter(StringUtils::isNotBlank);
+      }
+      return Optional.empty();
+    }
+    return stringValue(Optional.of(object));
+  }
+
+  /**
+   * Reads the target relation, unwrapping the {@link SubqueryAlias} the command keeps when the
+   * statement uses a table alias.
+   */
+  public static Optional<LogicalPlan> target(LogicalPlan plan) {
+    return targetFromCommand(plan);
+  }
+
+  /**
+   * Package-visible so tests can pass a stand-in for the Databricks command, which cannot extend
+   * {@link LogicalPlan} from Java.
+   */
+  static Optional<LogicalPlan> targetFromCommand(Object command) {
+    Optional<LogicalPlan> target =
+        firstOf(
+            () -> logicalPlanFromMethods(command, TARGET_METHOD_NAMES),
+            () -> logicalPlanFromFields(command, TARGET_FIELD_NAMES),
+            () -> targetFromAnyMember(command));
+
+    return target.map(CopyIntoCommandUtils::unwrapSubqueryAlias);
+  }
+
+  /**
+   * Picks the target out of the runtime-only members when none of the known accessor names match.
+   * Databricks renames these members between runtimes, and a miss costs the whole output dataset:
+   * the builder then falls back to the table name alone, which is a different lineage node than the
+   * storage location that DELETE and CTAS resolve for the same table.
+   */
+  private static Optional<LogicalPlan> targetFromAnyMember(Object command) {
+    // Only a catalog-backed relation is accepted. Falling back to "any plan member" would let the
+    // source scan be reported as the table the statement wrote to, which is worse than degrading to
+    // the SQL text.
+    return logicalPlanMembers(command).stream()
+        .filter(plan -> findCatalogRelation(plan).isPresent())
+        .findFirst();
+  }
+
+  /**
+   * Reads every {@link LogicalPlan} held by the command, in declaration order. Only fields are
+   * read: the command also declares methods such as {@code run}, and invoking those to discover a
+   * member would re-execute the statement.
+   */
+  private static List<LogicalPlan> logicalPlanMembers(Object command) {
+    List<LogicalPlan> plans = new ArrayList<>();
+    for (java.lang.reflect.Field field : runtimeFields(command)) {
+      readField(command, field).flatMap(CopyIntoCommandUtils::asLogicalPlan).ifPresent(plans::add);
+    }
+    return plans;
+  }
+
+  /**
+   * Fields declared by the command itself and its runtime-specific supertypes. Spark and Scala base
+   * classes are skipped: their members are tree bookkeeping, never the COPY INTO operands.
+   */
+  private static List<java.lang.reflect.Field> runtimeFields(Object command) {
+    List<java.lang.reflect.Field> fields = new ArrayList<>();
+    Class<?> type = command.getClass();
+    while (type != null && isRuntimeClass(type)) {
+      fields.addAll(Arrays.asList(type.getDeclaredFields()));
+      type = type.getSuperclass();
+    }
+    return fields;
+  }
+
+  private static boolean isRuntimeClass(Class<?> type) {
+    String name = type.getName();
+    return !name.startsWith("org.apache.spark.")
+        && !name.startsWith("scala.")
+        && !name.startsWith("java.");
+  }
+
+  private static Optional<LogicalPlan> asLogicalPlan(Object value) {
+    if (value instanceof LogicalPlan) {
+      return Optional.of((LogicalPlan) value);
+    }
+    if (value instanceof Option) {
+      Option<?> option = (Option<?>) value;
+      return option.isDefined() ? asLogicalPlan(option.get()) : Optional.empty();
+    }
+    return Optional.empty();
+  }
+
+  /** A relation that a catalog can resolve, which is what distinguishes the target from a scan. */
+  private static Optional<DataSourceV2Relation> findCatalogRelation(LogicalPlan plan) {
+    return findInTreeByType(plan, DataSourceV2Relation.class)
+        .map(DataSourceV2Relation.class::cast)
+        .filter(relation -> relation.identifier() != null && relation.identifier().isDefined());
+  }
+
+  private static Optional<Object> readField(Object target, java.lang.reflect.Field field) {
+    try {
+      return Optional.ofNullable(FieldUtils.readField(field, target, true));
+    } catch (IllegalAccessException | RuntimeException e) {
+      log.debug("Could not read {} from {}", field.getName(), target.getClass().getName(), e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Lists the zero-argument methods and fields declared by a runtime-only command class. The
+   * Databricks classes are not on the compile classpath, so when every known accessor name misses
+   * this is the only way to learn the real member names from a driver log.
+   */
+  public static String describeMembers(Object plan) {
+    if (plan == null) {
+      return "<null>";
+    }
+    Class<?> type = plan.getClass();
+    String methods =
+        Arrays.stream(type.getDeclaredMethods())
+            .filter(method -> method.getParameterCount() == 0)
+            .map(method -> method.getName() + ":" + method.getReturnType().getSimpleName())
+            .sorted()
+            .collect(Collectors.joining(", "));
+    String fields =
+        Arrays.stream(type.getDeclaredFields())
+            .map(field -> field.getName() + ":" + field.getType().getSimpleName())
+            .sorted()
+            .collect(Collectors.joining(", "));
+    return type.getCanonicalName() + " methods=[" + methods + "] fields=[" + fields + "]";
+  }
+
+  /** Reads the source file path when the command stores it as a string or in reader options. */
+  public static Optional<String> sourcePath(LogicalPlan plan) {
+    return sourcePathFromCommand(plan);
+  }
+
+  /** Package-visible for tests; see {@link #targetFromCommand(Object)}. */
+  static Optional<String> sourcePathFromCommand(Object command) {
+    return firstOf(
+        () -> stringFromMethods(command, SOURCE_PATH_METHOD_NAMES),
+        () -> stringFromFields(command, SOURCE_PATH_FIELD_NAMES),
+        () -> pathFromNestedMembers(command),
+        () -> pathFromOptions(invoke(command, "sourceOptions")),
+        () -> pathFromOptions(readField(command, "sourceOptions")),
+        () -> stringFromSourceMember(command),
+        () -> pathFromAnyMember(command));
+  }
+
+  /**
+   * Picks the source location out of the runtime-only members when none of the known accessor names
+   * match. Only values shaped like a location are considered, so sibling members such as the file
+   * format are not mistaken for a path.
+   */
+  private static Optional<String> pathFromAnyMember(Object command) {
+    for (java.lang.reflect.Field field : runtimeFields(command)) {
+      Optional<String> path =
+          readField(command, field)
+              .flatMap(value -> stringValue(Optional.of(value)))
+              .filter(CopyIntoCommandUtils::looksLikeLocation);
+      if (path.isPresent()) {
+        return path;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean looksLikeLocation(String value) {
+    return value.startsWith("/") || value.contains("://");
+  }
+
+  /** Reads a nested select over the source when the command does not expose a plain path. */
+  public static Optional<LogicalPlan> sourceQuery(LogicalPlan plan) {
+    return sourceQueryFromCommand(plan);
+  }
+
+  /** Package-visible for tests; see {@link #targetFromCommand(Object)}. */
+  static Optional<LogicalPlan> sourceQueryFromCommand(Object command) {
+    return firstOf(
+        () -> logicalPlanFromMethods(command, SOURCE_QUERY_METHOD_NAMES),
+        () -> logicalPlanFromFields(command, SOURCE_QUERY_FIELD_NAMES),
+        () -> sourceQueryFromAnyMember(command));
+  }
+
+  /** The plan member that is not the target, so a source select is not reported as the output. */
+  private static Optional<LogicalPlan> sourceQueryFromAnyMember(Object command) {
+    Optional<LogicalPlan> target = targetFromAnyMember(command);
+    return logicalPlanMembers(command).stream()
+        .filter(plan -> !target.filter(t -> t == plan).isPresent())
+        .findFirst();
+  }
+
+  private static Optional<String> pathFromNestedMembers(Object plan) {
+    for (String member : NESTED_SOURCE_MEMBERS) {
+      Optional<String> path =
+          firstOf(
+              () -> pathFromOptions(invoke(plan, member)),
+              () -> pathFromOptions(readField(plan, member)),
+              () -> stringValue(invoke(plan, member)),
+              () -> stringValue(readField(plan, member)));
+      if (path.isPresent()) {
+        return path;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<LogicalPlan> logicalPlanFromMethods(
+      Object plan, List<String> methodNames) {
+    for (String methodName : methodNames) {
+      Optional<LogicalPlan> logicalPlan = logicalPlan(invoke(plan, methodName));
+      if (logicalPlan.isPresent()) {
+        return logicalPlan;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<LogicalPlan> logicalPlanFromFields(Object plan, List<String> fieldNames) {
+    for (String fieldName : fieldNames) {
+      Optional<LogicalPlan> logicalPlan = logicalPlan(readField(plan, fieldName));
+      if (logicalPlan.isPresent()) {
+        return logicalPlan;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> stringFromMethods(Object plan, List<String> methodNames) {
+    for (String methodName : methodNames) {
+      Optional<String> value = stringValue(invoke(plan, methodName));
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> stringFromFields(Object plan, List<String> fieldNames) {
+    for (String fieldName : fieldNames) {
+      Optional<String> value = stringValue(readField(plan, fieldName));
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> stringFromSourceMember(Object plan) {
+    return stringValue(
+        firstOf(() -> invoke(plan, SOURCE_MEMBER), () -> readField(plan, SOURCE_MEMBER)));
+  }
+
+  private static Optional<String> pathFromOptions(Optional<Object> options) {
+    return options.flatMap(CopyIntoCommandUtils::pathFromOptionsMap);
+  }
+
+  private static Optional<String> pathFromOptionsMap(Object options) {
+    Map<String, String> optionMap = toJavaMap(options);
+    return firstOf(
+        () -> Optional.ofNullable(optionMap.get("path")).filter(StringUtils::isNotBlank),
+        () -> Optional.ofNullable(optionMap.get("location")).filter(StringUtils::isNotBlank),
+        () -> Optional.ofNullable(optionMap.get("uri")).filter(StringUtils::isNotBlank));
+  }
+
+  private static Optional<Object> invoke(Object target, String methodName) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(MethodUtils.invokeMethod(target, methodName));
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.debug("Could not call {} on {}", methodName, target.getClass().getCanonicalName(), e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Object> readField(Object target, String fieldName) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(FieldUtils.readField(target, fieldName, true));
+    } catch (IllegalAccessException | IllegalArgumentException e) {
+      log.debug("Could not read {} from {}", fieldName, target.getClass().getCanonicalName(), e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<LogicalPlan> logicalPlan(Optional<Object> value) {
+    if (value.isEmpty()) {
+      return Optional.empty();
+    }
+    Object object = value.get();
+    if (object instanceof LogicalPlan) {
+      return Optional.of((LogicalPlan) object);
+    }
+    return firstOf(
+        () -> logicalPlan(invoke(object, "table")),
+        () -> logicalPlan(invoke(object, "child")),
+        () -> logicalPlan(invoke(object, "plan")),
+        () -> logicalPlan(invoke(object, "target")));
+  }
+
+  private static Optional<String> stringValue(Optional<Object> value) {
+    return value
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .filter(StringUtils::isNotBlank);
+  }
+
+  private static LogicalPlan unwrapSubqueryAlias(LogicalPlan plan) {
+    if (plan instanceof SubqueryAlias) {
+      return ((SubqueryAlias) plan).child();
+    }
+    return plan;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> toJavaMap(Object map) {
+    if (map instanceof scala.collection.immutable.Map) {
+      return ScalaConversionUtils.fromMap((scala.collection.immutable.Map<String, String>) map);
+    } else if (map instanceof Map) {
+      return new HashMap<>((Map<String, String>) map);
+    }
+    return new HashMap<>();
+  }
+
+  @SafeVarargs
+  private static <T> Optional<T> firstOf(Supplier<Optional<T>>... suppliers) {
+    for (Supplier<Optional<T>> supplier : suppliers) {
+      Optional<T> value = supplier.get();
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtils.java
@@ -218,7 +218,7 @@ public class CopyIntoCommandUtils {
   }
 
   private static Optional<String> stringFromOriginMember(Optional<Object> value) {
-    if (value.isEmpty()) {
+    if (!value.isPresent()) {
       return Optional.empty();
     }
     Object object = value.get();
@@ -512,7 +512,7 @@ public class CopyIntoCommandUtils {
   }
 
   private static Optional<LogicalPlan> logicalPlan(Optional<Object> value) {
-    if (value.isEmpty()) {
+    if (!value.isPresent()) {
       return Optional.empty();
     }
     Object object = value.get();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
@@ -21,7 +21,12 @@ public class CopyIntoSqlUtils {
   private static final Pattern COPY_INTO_SOURCE =
       Pattern.compile("(?is)\\bFROM\\s+'([^']+)'|\\bFROM\\s+\"([^\"]+)\"");
   private static final Pattern COPY_INTO_VALIDATE =
-      Pattern.compile("(?is)\\bVALIDATE\\b(?:\\s+(?:ALL|\\d+\\s+ROWS))?");
+      Pattern.compile(
+          "(?is)\\bFILEFORMAT\\s*=\\s*[A-Z][A-Z0-9_]*"
+              + "\\s+VALIDATE\\b"
+              + "(?:\\s+(?:ALL|[1-9]\\d*\\s+ROWS))?"
+              + "(?=\\s*(?:FILES\\s*=|PATTERN\\s*=|FORMAT_OPTIONS\\s*\\(|"
+              + "COPY_OPTIONS\\s*\\(|;|$))");
 
   private CopyIntoSqlUtils() {}
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
@@ -1,0 +1,55 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+/** Parses {@code COPY INTO} statements when tahoe command reflection is unavailable. */
+public class CopyIntoSqlUtils {
+
+  private static final Pattern COPY_INTO_TARGET =
+      Pattern.compile("(?is)\\bCOPY\\s+INTO\\s+([`\\w.]+)");
+  private static final Pattern COPY_INTO_SOURCE =
+      Pattern.compile("(?is)\\bFROM\\s+'([^']+)'|\\bFROM\\s+\"([^\"]+)\"");
+
+  private CopyIntoSqlUtils() {}
+
+  public static boolean isCopyIntoStatement(String sql) {
+    return sql != null && COPY_INTO_TARGET.matcher(sql).find();
+  }
+
+  public static Optional<String> targetTable(String sql) {
+    if (StringUtils.isBlank(sql)) {
+      return Optional.empty();
+    }
+    Matcher matcher = COPY_INTO_TARGET.matcher(sql);
+    if (!matcher.find()) {
+      return Optional.empty();
+    }
+    return Optional.of(stripQuotes(matcher.group(1)));
+  }
+
+  public static Optional<String> sourcePath(String sql) {
+    if (StringUtils.isBlank(sql)) {
+      return Optional.empty();
+    }
+    Matcher matcher = COPY_INTO_SOURCE.matcher(sql);
+    if (!matcher.find()) {
+      return Optional.empty();
+    }
+    String singleQuoted = matcher.group(1);
+    String doubleQuoted = matcher.group(2);
+    return Optional.ofNullable(StringUtils.firstNonBlank(singleQuoted, doubleQuoted))
+        .filter(StringUtils::isNotBlank);
+  }
+
+  private static String stripQuotes(String value) {
+    return value.replace("`", "").trim();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtils.java
@@ -14,14 +14,24 @@ import org.apache.commons.lang3.StringUtils;
 public class CopyIntoSqlUtils {
 
   private static final Pattern COPY_INTO_TARGET =
-      Pattern.compile("(?is)\\bCOPY\\s+INTO\\s+([`\\w.]+)");
+      Pattern.compile(
+          "(?is)\\bCOPY\\s+INTO\\s+"
+              + "((?:`(?:``|[^`])+`|[\\w-]+)"
+              + "(?:\\.(?:`(?:``|[^`])+`|[\\w-]+))*)");
   private static final Pattern COPY_INTO_SOURCE =
       Pattern.compile("(?is)\\bFROM\\s+'([^']+)'|\\bFROM\\s+\"([^\"]+)\"");
+  private static final Pattern COPY_INTO_VALIDATE =
+      Pattern.compile("(?is)\\bVALIDATE\\b(?:\\s+(?:ALL|\\d+\\s+ROWS))?");
 
   private CopyIntoSqlUtils() {}
 
   public static boolean isCopyIntoStatement(String sql) {
     return sql != null && COPY_INTO_TARGET.matcher(sql).find();
+  }
+
+  /** Returns true when the statement validates source data without writing to the target table. */
+  public static boolean isValidateStatement(String sql) {
+    return isCopyIntoStatement(sql) && COPY_INTO_VALIDATE.matcher(sql).find();
   }
 
   public static Optional<String> targetTable(String sql) {
@@ -50,6 +60,24 @@ public class CopyIntoSqlUtils {
   }
 
   private static String stripQuotes(String value) {
-    return value.replace("`", "").trim();
+    if (StringUtils.isBlank(value)) {
+      return value;
+    }
+    String[] parts = value.split("\\.", -1);
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        result.append('.');
+      }
+      result.append(unescapeBacktickIdentifier(parts[i]));
+    }
+    return result.toString().trim();
+  }
+
+  private static String unescapeBacktickIdentifier(String part) {
+    if (part.startsWith("`") && part.endsWith("`") && part.length() >= 2) {
+      return part.substring(1, part.length() - 1).replace("``", "`");
+    }
+    return part;
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
@@ -1,0 +1,153 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+import scala.Option;
+
+/**
+ * Resolves Unity Catalog table identity through the V2 catalog API when legacy {@code
+ * getTableMetadata} is unavailable, matching the path used by {@code DataSourceV2Relation} and
+ * {@code CreateReplaceOutputDatasetBuilder}.
+ */
+@Slf4j
+public final class UnityCatalogTableDatasetUtils {
+
+  private UnityCatalogTableDatasetUtils() {}
+
+  @Value
+  public static class ResolvedTableDataset {
+    DatasetIdentifier datasetIdentifier;
+    TableCatalog catalog;
+    Identifier identifier;
+    Map<String, String> properties;
+    StructType schema;
+  }
+
+  public static Optional<ResolvedTableDataset> resolve(
+      OpenLineageContext context, SparkSession session, TableIdentifier identifier) {
+    Optional<String> catalogName =
+        tableIdentifierCatalog(identifier).or(() -> currentCatalog(session));
+    if (catalogName.isEmpty() || !identifier.database().isDefined()) {
+      return Optional.empty();
+    }
+
+    String schema = identifier.database().get();
+    String table = identifier.table();
+    Optional<CatalogPlugin> catalogPlugin = SparkSessionUtils.catalog(session, catalogName.get());
+    if (catalogPlugin.isEmpty() || !(catalogPlugin.get() instanceof TableCatalog)) {
+      log.warn(
+          "COPY INTO: catalog {} resolved to {}, which is not a TableCatalog",
+          catalogName.get(),
+          catalogPlugin.map(plugin -> plugin.getClass().getCanonicalName()).orElse("<empty>"));
+      return Optional.empty();
+    }
+
+    TableCatalog tableCatalog = (TableCatalog) catalogPlugin.get();
+    Identifier v2Identifier = Identifier.of(new String[] {schema}, table);
+    try {
+      Table loadedTable = tableCatalog.loadTable(v2Identifier);
+      Map<String, String> properties = loadedTable.properties();
+      Optional<DatasetIdentifier> datasetIdentifier =
+          datasetIdentifier(context, tableCatalog, v2Identifier, properties);
+      if (datasetIdentifier.isEmpty()) {
+        log.warn(
+            "COPY INTO: no catalog handler resolved {} from catalog {}",
+            v2Identifier,
+            tableCatalog.getClass().getCanonicalName());
+        return Optional.empty();
+      }
+      return Optional.of(
+          new ResolvedTableDataset(
+              datasetIdentifier.get(),
+              tableCatalog,
+              v2Identifier,
+              properties,
+              loadedTable.schema()));
+    } catch (NoSuchTableException e) {
+      log.debug(
+          "Unity Catalog table {}.{} not found in catalog {}", schema, table, catalogName.get());
+      return Optional.empty();
+    } catch (Exception e) {
+      log.warn(
+          "Unable to load Unity Catalog table {}.{} from catalog {}",
+          schema,
+          table,
+          catalogName.get(),
+          e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<DatasetIdentifier> datasetIdentifier(
+      OpenLineageContext context,
+      TableCatalog catalog,
+      Identifier identifier,
+      Map<String, String> properties) {
+    try {
+      return PlanUtils3.getDatasetIdentifier(context, catalog, identifier, properties);
+    } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+      log.warn("Could not resolve dataset identifier of table {}", identifier, e);
+      return unityCatalogIdentifier(context, catalog, identifier);
+    }
+  }
+
+  private static Optional<DatasetIdentifier> unityCatalogIdentifier(
+      OpenLineageContext context, TableCatalog catalog, Identifier identifier) {
+    boolean unityCatalogEnabled =
+        context
+            .getSparkContext()
+            .map(SparkContext::getConf)
+            .map(DatabricksUtils::isDatabricksUnityCatalogEnabled)
+            .orElse(false);
+    if (!unityCatalogEnabled) {
+      return Optional.empty();
+    }
+    String name = DatabricksUtils.qualifiedUnityCatalogTableName(catalog, identifier);
+    return Optional.of(
+        new DatasetIdentifier(name, DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE));
+  }
+
+  private static Optional<String> tableIdentifierCatalog(TableIdentifier identifier) {
+    try {
+      Option<String> catalog = (Option<String>) MethodUtils.invokeMethod(identifier, "catalog");
+      if (catalog != null && catalog.isDefined()) {
+        return Optional.of(catalog.get()).filter(StringUtils::isNotBlank);
+      }
+    } catch (Exception e) {
+      // TableIdentifier.catalog() is unavailable on older Spark versions
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> currentCatalog(SparkSession session) {
+    try {
+      return Optional.ofNullable(
+              (String) MethodUtils.invokeMethod(session.catalog(), "currentCatalog"))
+          .filter(StringUtils::isNotBlank);
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
@@ -47,16 +47,18 @@ public final class UnityCatalogTableDatasetUtils {
 
   public static Optional<ResolvedTableDataset> resolve(
       OpenLineageContext context, SparkSession session, TableIdentifier identifier) {
-    Optional<String> catalogName =
-        tableIdentifierCatalog(identifier).or(() -> currentCatalog(session));
-    if (catalogName.isEmpty() || !identifier.database().isDefined()) {
+    Optional<String> catalogName = tableIdentifierCatalog(identifier);
+    if (!catalogName.isPresent()) {
+      catalogName = currentCatalog(session);
+    }
+    if (!catalogName.isPresent() || !identifier.database().isDefined()) {
       return Optional.empty();
     }
 
     String schema = identifier.database().get();
     String table = identifier.table();
     Optional<CatalogPlugin> catalogPlugin = SparkSessionUtils.catalog(session, catalogName.get());
-    if (catalogPlugin.isEmpty() || !(catalogPlugin.get() instanceof TableCatalog)) {
+    if (!catalogPlugin.isPresent() || !(catalogPlugin.get() instanceof TableCatalog)) {
       log.warn(
           "COPY INTO: catalog {} resolved to {}, which is not a TableCatalog",
           catalogName.get(),
@@ -71,7 +73,7 @@ public final class UnityCatalogTableDatasetUtils {
       Map<String, String> properties = loadedTable.properties();
       Optional<DatasetIdentifier> datasetIdentifier =
           datasetIdentifier(context, tableCatalog, v2Identifier, properties);
-      if (datasetIdentifier.isEmpty()) {
+      if (!datasetIdentifier.isPresent()) {
         log.warn(
             "COPY INTO: no catalog handler resolved {} from catalog {}",
             v2Identifier,

--- a/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
+++ b/integration/spark/spark3/src/test/java/com/databricks/sql/transaction/tahoe/commands/CopyIntoCommandEdge.java
@@ -1,0 +1,42 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package com.databricks.sql.transaction.tahoe.commands;
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Stands in for the Databricks {@code CopyIntoCommandEdge} that a {@code COPY INTO} statement is
+ * resolved to on Spark 4.0 runtimes. The real class is not on any compile classpath, so extraction
+ * has to work by reflection and cannot assume the member names.
+ *
+ * <p>The members are deliberately named nothing like {@code target} or {@code sourcePath}, and the
+ * format name is declared before the location, so a test using this class only passes when
+ * extraction is genuinely name-independent.
+ *
+ * <p>This is not a {@link LogicalPlan}: Java cannot extend the Scala plan classes because of the
+ * covariant {@code withNewChildrenInternal} override. The reflective extraction works on plain
+ * objects, so the fixture exercises the same code the runtime hits.
+ */
+@SuppressWarnings(
+    "PMD.UnusedPrivateField") // fields are read by CopyIntoCommandUtils via reflection
+public class CopyIntoCommandEdge {
+
+  private final String fileFormatName;
+  private final LogicalPlan copyIntoTargetRelation;
+  private final LogicalPlan copyIntoSourceRelation;
+  private final String ingestLocationUri;
+
+  public CopyIntoCommandEdge(
+      String fileFormatName,
+      LogicalPlan copyIntoTargetRelation,
+      LogicalPlan copyIntoSourceRelation,
+      String ingestLocationUri) {
+    this.fileFormatName = fileFormatName;
+    this.copyIntoTargetRelation = copyIntoTargetRelation;
+    this.copyIntoSourceRelation = copyIntoSourceRelation;
+    this.ingestLocationUri = ingestLocationUri;
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
+
+class CopyIntoCommandInputDatasetBuilderTest {
+
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  CopyIntoCommandInputDatasetBuilder builder = new CopyIntoCommandInputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+
+  @Test
+  void testIsNotDefinedForNonCopyIntoPlans() {
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+  }
+
+  @Test
+  void testApplyDelegatesWhenOnlySourceQueryIsPresent() {
+    LogicalPlan command = mock(LogicalPlan.class);
+    LogicalPlan sourceQuery = mock(LogicalPlan.class);
+    givenInputVisitorReturning("source_table", "unity-catalog");
+
+    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.isCopyIntoCommand(command)).thenReturn(true);
+      utils.when(() -> CopyIntoCommandUtils.sourcePath(command)).thenReturn(Optional.empty());
+      utils
+          .when(() -> CopyIntoCommandUtils.sourceQuery(command))
+          .thenReturn(Optional.of(sourceQuery));
+
+      List<InputDataset> inputs = builder.apply(event, command);
+
+      assertThat(inputs)
+          .singleElement()
+          .hasFieldOrPropertyWithValue("name", "source_table")
+          .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  private void givenInputVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<InputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<InputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return true;
+          }
+
+          @Override
+          public List<InputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newInputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getInputDatasetQueryPlanVisitors()).thenReturn(Collections.singletonList(visitor));
+    when(context.getInputDatasetBuilders()).thenReturn(Collections.emptyList());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandInputDatasetBuilderTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
 import java.util.Collections;
@@ -22,6 +23,8 @@ import java.util.Optional;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -46,8 +49,9 @@ class CopyIntoCommandInputDatasetBuilderTest {
   @Test
   void testApplyDelegatesWhenOnlySourceQueryIsPresent() {
     LogicalPlan command = mock(LogicalPlan.class);
-    LogicalPlan sourceQuery = mock(LogicalPlan.class);
-    givenInputVisitorReturning("source_table", "unity-catalog");
+    OneRowRelation nestedRelation = new OneRowRelation();
+    LogicalPlan sourceQuery = new Project(ScalaConversionUtils.asScalaSeqEmpty(), nestedRelation);
+    givenInputVisitorReturning(OneRowRelation.class, "source_table", "unity-catalog");
 
     try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
       utils.when(() -> CopyIntoCommandUtils.isCopyIntoCommand(command)).thenReturn(true);
@@ -65,12 +69,13 @@ class CopyIntoCommandInputDatasetBuilderTest {
     }
   }
 
-  private void givenInputVisitorReturning(String name, String namespace) {
+  private void givenInputVisitorReturning(
+      Class<? extends LogicalPlan> planType, String name, String namespace) {
     PartialFunction<LogicalPlan, List<InputDataset>> visitor =
         new AbstractPartialFunction<LogicalPlan, List<InputDataset>>() {
           @Override
           public boolean isDefinedAt(LogicalPlan x) {
-            return true;
+            return planType.isInstance(x);
           }
 
           @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
@@ -16,6 +16,7 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import io.openlineage.spark3.agent.utils.CopyIntoSqlUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -61,6 +62,24 @@ class CopyIntoCommandOutputDatasetBuilderTest {
           .singleElement()
           .hasFieldOrPropertyWithValue("name", "copy_into_table")
           .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  @Test
+  void testApplySkipsOutputForValidateStatement() {
+    givenTargetVisitorReturning("copy_into_table", "unity-catalog");
+    LogicalPlan command = mock(LogicalPlan.class);
+    String sql = "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = CSV VALIDATE";
+
+    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class);
+        MockedStatic<CopyIntoSqlUtils> sqlUtils = mockStatic(CopyIntoSqlUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.isCopyIntoCommand(command)).thenReturn(true);
+      utils.when(() -> CopyIntoCommandUtils.sqlText(context)).thenReturn(Optional.of(sql));
+      sqlUtils.when(() -> CopyIntoSqlUtils.isValidateStatement(sql)).thenReturn(true);
+
+      List<OutputDataset> outputs = builder.apply(event, command);
+
+      assertThat(outputs).isEmpty();
     }
   }
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CopyIntoCommandOutputDatasetBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.CopyIntoCommandUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.PartialFunction;
+import scala.runtime.AbstractPartialFunction;
+
+class CopyIntoCommandOutputDatasetBuilderTest {
+
+  private static final OpenLineage OPEN_LINEAGE =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  CopyIntoCommandOutputDatasetBuilder builder = new CopyIntoCommandOutputDatasetBuilder(context);
+  SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+
+  @Test
+  void testIsNotDefinedForNonCopyIntoPlans() {
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(AppendData.class)));
+  }
+
+  @Test
+  void testApplyEmitsTargetAsOutput() {
+    givenTargetVisitorReturning("copy_into_table", "unity-catalog");
+    LogicalPlan command = mock(LogicalPlan.class);
+
+    try (MockedStatic<CopyIntoCommandUtils> utils = mockStatic(CopyIntoCommandUtils.class)) {
+      utils.when(() -> CopyIntoCommandUtils.isCopyIntoCommand(command)).thenReturn(true);
+      utils
+          .when(() -> CopyIntoCommandUtils.target(command))
+          .thenReturn(Optional.of(new OneRowRelation()));
+
+      List<OutputDataset> outputs = builder.apply(event, command);
+
+      assertThat(outputs)
+          .singleElement()
+          .hasFieldOrPropertyWithValue("name", "copy_into_table")
+          .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+    }
+  }
+
+  private void givenTargetVisitorReturning(String name, String namespace) {
+    PartialFunction<LogicalPlan, List<OutputDataset>> visitor =
+        new AbstractPartialFunction<LogicalPlan, List<OutputDataset>>() {
+          @Override
+          public boolean isDefinedAt(LogicalPlan x) {
+            return x instanceof OneRowRelation;
+          }
+
+          @Override
+          public List<OutputDataset> apply(LogicalPlan x) {
+            return Collections.singletonList(
+                OPEN_LINEAGE.newOutputDatasetBuilder().name(name).namespace(namespace).build());
+          }
+        };
+
+    when(context.getOutputDatasetQueryPlanVisitors())
+        .thenReturn(Collections.singletonList(visitor));
+    when(context.getOutputDatasetBuilders()).thenReturn(Collections.emptyList());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoCommandUtilsTest.java
@@ -1,0 +1,102 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.databricks.sql.transaction.tahoe.commands.CopyIntoCommandEdge;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import scala.Option;
+
+class CopyIntoCommandUtilsTest {
+
+  private static final String FILE_FORMAT = "CSV";
+  private static final String VOLUME_PATH =
+      "/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input";
+
+  @Test
+  void testMatchesCommandClassName() {
+    assertThat(
+            CopyIntoCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.CopyIntoCommand"))
+        .isTrue();
+    assertThat(
+            CopyIntoCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.CopyIntoCommandEdge"))
+        .isTrue();
+    assertThat(
+            CopyIntoCommandUtils.matchesCommandClassName(
+                "com.databricks.sql.transaction.tahoe.commands.edge.CopyIntoCommandEdge"))
+        .isTrue();
+    assertThat(CopyIntoCommandUtils.matchesCommandClassName("AppendData")).isFalse();
+    assertThat(CopyIntoCommandUtils.matchesCommandClassName(null)).isFalse();
+  }
+
+  @Test
+  void testTargetWhenCommandHasNoSuchMember() {
+    LogicalPlan plan = Mockito.mock(LogicalPlan.class);
+    assertThat(CopyIntoCommandUtils.target(plan)).isEmpty();
+    assertThat(CopyIntoCommandUtils.sourcePath(plan)).isEmpty();
+    assertThat(CopyIntoCommandUtils.sourceQuery(plan)).isEmpty();
+  }
+
+  /**
+   * On Databricks the emitted event carried a name-only {@code unity-catalog} dataset instead of
+   * the storage location that {@code DELETE} produces for the same table. That happens when the
+   * target relation is never found and the builder degrades to parsing the SQL text, so extraction
+   * must not depend on the command spelling its members {@code target} / {@code sourcePath}.
+   */
+  @Test
+  void testTargetFromMemberWithUnknownName() {
+    DataSourceV2Relation targetRelation = catalogRelation();
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge(FILE_FORMAT, targetRelation, new OneRowRelation(), VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.targetFromCommand(command)).contains(targetRelation);
+  }
+
+  @Test
+  void testSourcePathFromMemberWithUnknownName() {
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge(FILE_FORMAT, catalogRelation(), new OneRowRelation(), VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.sourcePathFromCommand(command)).contains(VOLUME_PATH);
+  }
+
+  @Test
+  void testSourceQueryIsNotTheTargetRelation() {
+    DataSourceV2Relation targetRelation = catalogRelation();
+    OneRowRelation sourceRelation = new OneRowRelation();
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge(FILE_FORMAT, targetRelation, sourceRelation, VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.sourceQueryFromCommand(command)).contains(sourceRelation);
+  }
+
+  /** A source scan must never be reported as the table the statement wrote to. */
+  @Test
+  void testTargetIsEmptyWhenNoMemberIsCatalogBacked() {
+    CopyIntoCommandEdge command =
+        new CopyIntoCommandEdge(
+            FILE_FORMAT, new OneRowRelation(), new OneRowRelation(), VOLUME_PATH);
+
+    assertThat(CopyIntoCommandUtils.targetFromCommand(command)).isEmpty();
+  }
+
+  /** A catalog-backed target, which is what makes the delegate emit Unity Catalog identity. */
+  private static DataSourceV2Relation catalogRelation() {
+    DataSourceV2Relation relation = Mockito.mock(DataSourceV2Relation.class);
+    Mockito.when(relation.identifier())
+        .thenReturn(
+            Option.apply(Identifier.of(new String[] {"openlineage_dml"}, "copy_into_table")));
+    return relation;
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -52,6 +52,22 @@ class CopyIntoSqlUtilsTest {
   }
 
   @Test
+  void testParsesBacktickQuotedTargetTable() {
+    String sql = "COPY INTO `catalog`.`schema`.`copy_into_table` FROM '/path/to/source'";
+
+    assertThat(CopyIntoSqlUtils.targetTable(sql)).contains("catalog.schema.copy_into_table");
+  }
+
+  @Test
+  void testDetectsCaseInsensitiveCopyInto() {
+    String sql = "copy into my_table from '/path/to/source'";
+
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement(sql)).isTrue();
+    assertThat(CopyIntoSqlUtils.targetTable(sql)).contains("my_table");
+    assertThat(CopyIntoSqlUtils.sourcePath(sql)).contains("/path/to/source");
+  }
+
+  @Test
   void testReturnsEmptyForBlankSql() {
     assertThat(CopyIntoSqlUtils.targetTable(null)).isEmpty();
     assertThat(CopyIntoSqlUtils.targetTable("   ")).isEmpty();

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -36,4 +36,26 @@ class CopyIntoSqlUtilsTest {
     assertThat(CopyIntoSqlUtils.isCopyIntoStatement(SQL)).isTrue();
     assertThat(CopyIntoSqlUtils.isCopyIntoStatement("SELECT 1")).isFalse();
   }
+
+  @Test
+  void testParsesCatalogQualifiedTargetTable() {
+    String sql = "COPY INTO catalog.schema.copy_into_table FROM '/path/to/source'";
+
+    assertThat(CopyIntoSqlUtils.targetTable(sql)).contains("catalog.schema.copy_into_table");
+  }
+
+  @Test
+  void testParsesDoubleQuotedSourcePath() {
+    String sql = "COPY INTO copy_into_table FROM \"/Volumes/catalog/schema/vol/input\"";
+
+    assertThat(CopyIntoSqlUtils.sourcePath(sql)).contains("/Volumes/catalog/schema/vol/input");
+  }
+
+  @Test
+  void testReturnsEmptyForBlankSql() {
+    assertThat(CopyIntoSqlUtils.targetTable(null)).isEmpty();
+    assertThat(CopyIntoSqlUtils.targetTable("   ")).isEmpty();
+    assertThat(CopyIntoSqlUtils.sourcePath(null)).isEmpty();
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement(null)).isFalse();
+  }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -138,10 +138,7 @@ class CopyIntoSqlUtilsTest {
 
   @Test
   void testDoesNotDetectValidateWhenValidateAppearsInSourcePath() {
-    String sql =
-        "COPY INTO target\n"
-            + "FROM '/data/validate/files'\n"
-            + "FILEFORMAT = CSV";
+    String sql = "COPY INTO target\n" + "FROM '/data/validate/files'\n" + "FILEFORMAT = CSV";
 
     assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isFalse();
     assertThat(CopyIntoSqlUtils.isCopyIntoStatement(sql)).isTrue();

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -59,6 +59,37 @@ class CopyIntoSqlUtilsTest {
   }
 
   @Test
+  void testParsesBacktickQuotedTargetTableWithHyphen() {
+    String sql = "COPY INTO `sales-data` FROM '/path/to/source'";
+
+    assertThat(CopyIntoSqlUtils.targetTable(sql)).contains("sales-data");
+  }
+
+  @Test
+  void testParsesBacktickQuotedTargetTableWithSpace() {
+    String sql = "COPY INTO `sales data` FROM '/path/to/source'";
+
+    assertThat(CopyIntoSqlUtils.targetTable(sql)).contains("sales data");
+  }
+
+  @Test
+  void testParsesBacktickQuotedTargetTableWithEscapedBacktick() {
+    String sql = "COPY INTO `sales``data` FROM '/path/to/source'";
+
+    assertThat(CopyIntoSqlUtils.targetTable(sql)).contains("sales`data");
+  }
+
+  @Test
+  void testDetectsValidateStatement() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = CSV VALIDATE 15 ROWS";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isTrue();
+    assertThat(CopyIntoSqlUtils.isValidateStatement("COPY INTO t FROM '/p' FILEFORMAT = CSV"))
+        .isFalse();
+  }
+
+  @Test
   void testDetectsCaseInsensitiveCopyInto() {
     String sql = "copy into my_table from '/path/to/source'";
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -90,6 +90,73 @@ class CopyIntoSqlUtilsTest {
   }
 
   @Test
+  void testDetectsValidateStatementWithAllRows() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = PARQUET VALIDATE ALL";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isTrue();
+  }
+
+  @Test
+  void testDetectsValidateStatementWithoutRowLimit() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = CSV VALIDATE FORMAT_OPTIONS ('header' = 'true')";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isTrue();
+  }
+
+  @Test
+  void testDetectsValidateStatementFollowedByFilesClause() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = JSON VALIDATE FILES = ('a.json')";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isTrue();
+  }
+
+  @Test
+  void testDetectsValidateStatementFollowedByPatternClause() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = CSV VALIDATE PATTERN = '*.csv'";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isTrue();
+  }
+
+  @Test
+  void testDetectsValidateStatementFollowedByCopyOptions() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = CSV VALIDATE COPY_OPTIONS ('force' = 'true')";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isTrue();
+  }
+
+  @Test
+  void testDoesNotDetectValidateWithoutFileformat() {
+    String sql = "COPY INTO copy_into_table FROM '/path/to/source' VALIDATE 15 ROWS";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isFalse();
+  }
+
+  @Test
+  void testDoesNotDetectValidateWhenValidateAppearsInSourcePath() {
+    String sql =
+        "COPY INTO target\n"
+            + "FROM '/data/validate/files'\n"
+            + "FILEFORMAT = CSV";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isFalse();
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement(sql)).isTrue();
+    assertThat(CopyIntoSqlUtils.sourcePath(sql)).contains("/data/validate/files");
+  }
+
+  @Test
+  void testDoesNotDetectValidateWhenValidateAppearsOnlyInFormatOptions() {
+    String sql =
+        "COPY INTO copy_into_table FROM '/path/to/source' FILEFORMAT = CSV FORMAT_OPTIONS ('validateSchema' = 'true')";
+
+    assertThat(CopyIntoSqlUtils.isValidateStatement(sql)).isFalse();
+  }
+
+  @Test
   void testDetectsCaseInsensitiveCopyInto() {
     String sql = "copy into my_table from '/path/to/source'";
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/CopyIntoSqlUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CopyIntoSqlUtilsTest {
+
+  private static final String SQL =
+      "COPY INTO copy_into_table\n"
+          + "FROM '/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input'\n"
+          + "FILEFORMAT = CSV\n"
+          + "FORMAT_OPTIONS (\n"
+          + "    'header' = 'true',\n"
+          + "    'inferSchema' = 'true'\n"
+          + ")";
+
+  @Test
+  void testParsesTargetTable() {
+    assertThat(CopyIntoSqlUtils.targetTable(SQL)).contains("copy_into_table");
+  }
+
+  @Test
+  void testParsesSourcePath() {
+    assertThat(CopyIntoSqlUtils.sourcePath(SQL))
+        .contains("/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input");
+  }
+
+  @Test
+  void testDetectsCopyIntoStatement() {
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement(SQL)).isTrue();
+    assertThat(CopyIntoSqlUtils.isCopyIntoStatement("SELECT 1")).isFalse();
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+class UnityCatalogTableDatasetUtilsTest {
+
+  private static final String CATALOG = "sangeeta_catalog";
+  private static final String SCHEMA = "openlineage_dml";
+  private static final String TABLE = "copy_into_table";
+
+  @Test
+  void resolveUsesV2CatalogWhenLegacyLookupIsUnavailable() throws Exception {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    SparkSession session = mock(SparkSession.class);
+    TableCatalog tableCatalog = mock(TableCatalog.class);
+    Table table = mock(Table.class);
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    Identifier v2Identifier = Identifier.of(new String[] {SCHEMA}, TABLE);
+    DatasetIdentifier datasetIdentifier =
+        new DatasetIdentifier("unity-catalog/path", "s3://bucket");
+
+    when(tableIdentifier.database()).thenReturn(Option.apply(SCHEMA));
+    when(tableIdentifier.table()).thenReturn(TABLE);
+    when(table.properties()).thenReturn(Collections.singletonMap("location", "s3://bucket/path"));
+    when(table.schema()).thenReturn(new StructType());
+    when(tableCatalog.loadTable(v2Identifier)).thenReturn(table);
+
+    try (MockedStatic<SparkSessionUtils> sparkSessionUtils = mockStatic(SparkSessionUtils.class);
+        MockedStatic<PlanUtils3> planUtils3 = mockStatic(PlanUtils3.class);
+        MockedStatic<MethodUtils> methodUtils = mockStatic(MethodUtils.class)) {
+      methodUtils
+          .when(() -> MethodUtils.invokeMethod(tableIdentifier, "catalog"))
+          .thenReturn(Option.apply(CATALOG));
+      sparkSessionUtils
+          .when(() -> SparkSessionUtils.catalog(session, CATALOG))
+          .thenReturn(Optional.of(tableCatalog));
+      planUtils3
+          .when(
+              () ->
+                  PlanUtils3.getDatasetIdentifier(
+                      context, tableCatalog, v2Identifier, table.properties()))
+          .thenReturn(Optional.of(datasetIdentifier));
+
+      Optional<UnityCatalogTableDatasetUtils.ResolvedTableDataset> resolved =
+          UnityCatalogTableDatasetUtils.resolve(context, session, tableIdentifier);
+
+      assertThat(resolved).isPresent();
+      assertThat(resolved.get().getDatasetIdentifier()).isEqualTo(datasetIdentifier);
+      assertThat(resolved.get().getIdentifier()).isEqualTo(v2Identifier);
+    }
+  }
+}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->
related: #4807

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Fixes missing OpenLineage events for Databricks `COPY INTO` statements.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
On Databricks, `COPY INTO` is resolved to proprietary tahoe plan nodes (`CopyIntoCommand` on older runtimes, `CopyIntoCommandEdge` on Spark 4.0+) that are not on the compile classpath. The existing builders were never registered in the dataset builder factories, so lineage was not emitted. On Spark 4.0+, member names on `CopyIntoCommandEdge` differ from `CopyIntoCommand`, so hard-coded accessor names also fail.

This PR:

- Registers `CopyIntoCommandInputDatasetBuilder` and `CopyIntoCommandOutputDatasetBuilder` across Spark 3.2–4.0 dataset builder factories
- Adds `CopyIntoCommandUtils` to match both command variants and scan fields by type/shape instead of fixed member names
- Adds `CopyIntoSqlUtils` to parse `COPY INTO … FROM '…'` SQL when command reflection misses
- Adds `UnityCatalogTableDatasetUtils` to resolve Unity Catalog target tables through the V2 catalog API (avoiding `session.table()` re-analysis in the SparkListener thread)
- Emits source path/query as **input** and the target UC table as a **storage-backed output** dataset

**New tests**
- `CopyIntoCommandEdge` test fixture (non-standard member names)
- Unit tests for all new builders and utils

**Validation Artifacts:**

Validation notebook: https://gist.github.com/mishrasangeeta87/3e16e755b7d16ec38c57959abaeda6df

Before/After OpenLineage events inputs and outputs: 

| Scenario | Before | After |
|----------|--------|------|
| inputs | [] |  [{"name":"/Volumes/sangeeta_catalog/default/sangeeta_vol/input/csv_input","namespace":"file","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"file","uri":"file"}},"inputFacets":{},"outputFacets":{}}]|
| outputs | [] |  [{"name":"unity-catalog/7474644317745272/sangeeta/__unitystorage/catalogs/3d92ab1b-c9c7-41e7-9b7b-77c689e76698/tables/ee382edb-102c-4c57-8c41-59ea9652b55c","namespace":"s3://databricks-workspace-stack-93947-bucket","facets":{"dataSource":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet","name":"s3://databricks-workspace-stack-93947-bucket","uri":"s3://databricks-workspace-stack-93947-bucket"},"storage":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/StorageDatasetFacet.json#/$defs/StorageDatasetFacet","storageLayer":"unity","fileFormat":"parquet"},"schema":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet","fields":[{"name":"id","type":"integer"},{"name":"name","type":"string"},{"name":"salary","type":"integer"}]},"catalog":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-1-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet","framework":"delta","type":"unity","name":"sangeeta_catalog","source":"spark"},"symlinks":{"_producer":"https://github.com/OpenLineage/OpenLineage/tree/1.53.0-SNAPSHOT/integration/spark","_schemaURL":"https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet","identifiers":[{"namespace":"unity-catalog","name":"sangeeta_catalog.openlineage_dml.copy_into_table","type":"TABLE"}]}},"inputFacets":{},"outputFacets":{}}] |

### Checklist
- [x] AI was used in creating this PR
- ⚠️ AI Disclosure — This pull request was generated with AI assistance (Cursor). All proposed changes were reviewed and validated by verifying the expected input and output lineage for the affected scenarios as specified under , Validation artifacts section.
