### PR TITLE
sql: preserve lineage through derived PIVOT inputs

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -88,6 +88,7 @@ impl Visit for TableFactor {
                 Ok(())
             }
             TableFactor::Pivot { table, alias, .. } => {
+                table.visit(context)?;
                 if let Some(ident) = get_table_name_from_table_factor(table, &*context) {
                     if let Some(pivot_alias) = alias {
                         context.add_table_alias(
@@ -100,7 +101,6 @@ impl Visit for TableFactor {
                             vec![pivot_alias.clone().name],
                         );
                     }
-                    context.add_input(ident);
                 }
                 Ok(())
             }

--- a/integration/sql/impl/tests/table_lineage/tests_copy.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_copy.rs
@@ -179,3 +179,25 @@ fn parse_pivot_table() {
         }
     );
 }
+
+#[test]
+fn parse_pivot_derived_table() {
+    let meta = parse_sql(
+        concat!(
+            "SELECT * FROM (SELECT region, amount FROM sales) AS s ",
+            "PIVOT(SUM(amount) FOR region IN ('EAST')) AS p"
+        ),
+        &SnowflakeDialect {},
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        meta.table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["sales"]),
+            out_tables: vec![],
+        }
+    );
+    assert!(meta.errors.is_empty());
+}


### PR DESCRIPTION
Closes: #4851

### One-line summary for changelog:

Fix SQL parser lineage for Snowflake `PIVOT` over derived tables so their source datasets are retained.

### Meaningful description

#### Problem

The SQL parser silently drops every input dataset when a Snowflake `PIVOT` wraps a derived table. For example:

```sql
SELECT *
FROM (SELECT region, amount FROM sales) AS s
PIVOT(SUM(amount) FOR region IN ('EAST')) AS p
```

returned no inputs and no errors, although both the direct-table `PIVOT` form and the derived table without `PIVOT` correctly report `sales`.

`TableFactor::Pivot` tried to reduce its wrapped table factor to a plain table name. That helper intentionally returns `None` for `TableFactor::Derived`, and the branch returned without visiting the derived query.

#### Solution

Delegate the wrapped table factor to the existing visitor before applying the established PIVOT alias mapping. This preserves lineage for derived queries and continues to handle direct tables without adding a new traversal path or changing the public API.

A focused Snowflake regression test demonstrates the failure before the patch (`in_tables` was empty) and verifies `sales` is retained afterward with no parser errors.

This continues the SQL input-lineage work in #4752, #4763, #4767, #4775, #4783, #4785, #4788, and #4791.

#### Validation

- `cargo test -p openlineage_sql parse_pivot` — 2 passed
- `cargo test` — full Rust workspace passed (144 integration tests passed, 3 ignored; all unit/conversion/doc tests passed)
- `cargo test --offline --no-default-features` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `RUN_TESTS=true bash iface-py/script/build-macos.sh` — Python conversion test, clippy, universal2 wheel build/install, and import smoke checks passed
- `bash script/compile.sh && bash script/build.sh` in `iface-java` — native build, 13 Gradle tests, Maven-local publication, shaded JAR, and integration smoke test passed
- `prek run --all-files` — all repository hooks passed

No documentation change is needed because this corrects existing lineage behavior without changing configuration or public interfaces.

### Checklist

- [x] AI was used in creating this PR
