### PR TITLE
sql: include MERGE predicate subquery inputs

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -695,6 +695,7 @@ impl Visit for Statement {
                     context.add_output(table_name);
                 }
                 merge.source.visit(context)?;
+                merge.on.visit(context)?;
             }
             Statement::CreateTable(ct) => {
                 if let Some(query) = &ct.query {

--- a/integration/sql/impl/tests/table_lineage/tests_merge.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_merge.rs
@@ -39,6 +39,24 @@ fn merge_subquery_when_not_matched() {
 }
 
 #[test]
+fn merge_on_subquery() {
+    assert_eq!(
+        test_sql(
+            "MERGE INTO target
+             USING source
+             ON target.id IN (SELECT id FROM lookup)
+             WHEN MATCHED THEN UPDATE SET value = source.value"
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["lookup", "source"]),
+            out_tables: tables(vec!["target"]),
+        }
+    );
+}
+
+#[test]
 fn merge_identifier_function() {
     let test_cases = vec![
         (


### PR DESCRIPTION
### One-line summary for changelog:

SQL parser: include input tables referenced by subqueries in `MERGE ON` predicates.

### Meaningful description

#### Problem

The `Statement::Merge` visitor traversed the `USING` source but not the `ON` expression. A table read only by an `ON`-predicate subquery was therefore silently omitted from input lineage:

```sql
MERGE INTO target
USING source
ON target.id IN (SELECT id FROM lookup)
WHEN MATCHED THEN
UPDATE SET value = source.value
```

Before this change, the parser returned `source` as the only input even though the statement also reads `lookup`.

#### Solution

Visit `merge.on` through the existing expression visitor after visiting the source. This reuses the same subquery traversal used by SELECT predicates, JOIN conditions, HAVING clauses, and UPDATE expressions.

Add a focused table-lineage regression test asserting that both `source` and `lookup` are inputs and `target` remains the output.

#### Scope and risk

The change is limited to one visitor call and one Rust regression test. It does not change SQL parsing, public APIs, specification files, generated code, or dependencies.

#### Validation

- `cargo test -p openlineage_sql merge_on_subquery --offline`
- `cargo test -p openlineage_sql table_lineage::tests_merge --offline`
- `cargo test --no-default-features --offline` — 145 passed, 3 existing ignored; Java/Python binding and doc tests passed
- `cargo clippy --all-targets --all-features --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `uv tool run prek run --files integration/sql/impl/src/visitor.rs integration/sql/impl/tests/table_lineage/tests_merge.rs`
- Required pre-commit hook during `git commit`

Closes #4854

### Checklist

- [x] AI was used in creating this PR
