### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you discover a vulnerability in the project, please [open an issue](https://g
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenLineage/OpenLineage&type=Date)](https://www.star-history.com/#OpenLineage/OpenLineage&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenLineage/OpenLineage&type=Date)](https://star-history.dera.page/#OpenLineage/OpenLineage&Date)
 
 ----
 SPDX-License-Identifier: Apache-2.0\


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders because the GitHub stargazer API behind it has limited its access. This change points the chart at a working source that does not require an API token, restoring the chart so contributors can continue to see the project's growth.