### PR TITLE
sql: support parenthesized joins

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -139,6 +139,15 @@ impl Visit for TableFactor {
                 // treated the same here
                 Ok(())
             }
+            TableFactor::NestedJoin {
+                table_with_joins, ..
+            } => {
+                table_with_joins.relation.visit(context)?;
+                for join in &table_with_joins.joins {
+                    join.visit(context)?;
+                }
+                Ok(())
+            }
             _ => Err(anyhow!(
                 "TableFactor other than table or subquery not implemented: {self}"
             )),

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -77,6 +77,22 @@ fn select_join() {
 }
 
 #[test]
+fn select_parenthesized_join() {
+    for sql in [
+        "SELECT * FROM (foo JOIN bar ON foo.id = bar.id)",
+        "SELECT * FROM (foo JOIN bar ON foo.id = bar.id) AS joined",
+    ] {
+        assert_eq!(
+            test_sql(sql).unwrap().table_lineage,
+            TableLineage {
+                in_tables: tables(vec!["bar", "foo"]),
+                out_tables: vec![]
+            }
+        )
+    }
+}
+
+#[test]
 fn select_join_condition_subquery() {
     assert_eq!(
         test_sql(


### PR DESCRIPTION
Closes: #4857

### One-line summary for changelog:

Support table-lineage extraction from parenthesized joins.

### Meaningful description

`sqlparser` represents a parenthesized join as `TableFactor::NestedJoin`. OpenLineage's table-factor visitor did not handle that variant, so otherwise valid queries such as the following returned an unsupported-factor error instead of lineage:

```sql
SELECT * FROM (foo JOIN bar ON foo.id = bar.id)
```

This change visits the nested base relation and each join with the existing table and join visitors. That keeps lineage, alias, join-constraint, and subquery handling on the established code paths and makes parenthesized joins behave like their unparenthesized equivalents.

The regression test covers both unaliased and aliased parenthesized joins and asserts that `foo` and `bar` are reported as inputs with no outputs.

No documentation update is needed because this restores existing parser behavior for an accepted SQL construct without changing the public API or configuration.

### Validation

- `cargo test --offline -p openlineage_sql select_parenthesized_join`
- `cargo test --offline`
- `cargo test --offline --no-default-features`
- `cargo clippy --offline --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUN_TESTS=true bash iface-py/script/build-macos.sh`, followed by wheel install/import/parse smoke validation in the isolated Python environment
- `bash script/compile.sh && bash script/build.sh` in `integration/sql/iface-java` (JNI build, 13 Gradle tests, local publication, shadow jar, and smoke test)
- `prek run --files integration/sql/impl/src/visitor.rs integration/sql/impl/tests/table_lineage/tests_select.rs`

### Checklist

- [x] AI was used in creating this PR
