### PR TITLE
fix(spark): Iceberg writes under SparkSessionCatalog/hive can emit empty output or a fabricated path

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
@@ -82,10 +81,13 @@ abstract class BaseCatalogTypeHandler {
   @SneakyThrows
   protected Optional<Table> getIcebergTable(TableCatalog tableCatalog, Identifier identifier) {
     try {
-      if (tableCatalog instanceof SparkCatalog) {
-        SparkCatalog sparkCatalog = (SparkCatalog) tableCatalog;
-        org.apache.spark.sql.connector.catalog.Table loadedTable =
-            sparkCatalog.loadTable(identifier);
+      if (tableCatalog instanceof SparkCatalog || tableCatalog instanceof SparkSessionCatalog) {
+        // Both use Spark's V2 loadTable(Identifier), which understands Spark's branch-qualified
+        // identifiers (e.g. "table.branch_xxx") and resolves them to the underlying Iceberg
+        // table. Going through TableIdentifier.parse(identifier.toString()) and Iceberg's raw
+        // Catalog.loadTable(TableIdentifier) instead (as SparkSessionCatalog previously did)
+        // treats the branch suffix as a literal table name segment and always fails to find it.
+        org.apache.spark.sql.connector.catalog.Table loadedTable = tableCatalog.loadTable(identifier);
 
         // Handle different table implementations safely
         if (loadedTable instanceof SparkTable) {
@@ -116,10 +118,6 @@ abstract class BaseCatalogTypeHandler {
               identifier);
           return Optional.empty();
         }
-      } else if (tableCatalog instanceof SparkSessionCatalog) {
-        TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
-        SparkSessionCatalog sparkCatalog = (SparkSessionCatalog) tableCatalog;
-        return Optional.ofNullable(sparkCatalog.icebergCatalog().loadTable(tableIdentifier));
       } else {
         log.warn(
             "Unknown catalog type: {} for identifier: {}. Expected SparkCatalog or SparkSessionCatalog.",

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
@@ -89,12 +89,19 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
                           identifierToString(identifier), tableCatalog.name())));
     }
 
-    return super.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog)
-        .withSymlink(
-            new DatasetIdentifier.Symlink(
-                identifier.toString(),
-                PathUtils.prepareHiveUri(getUri(session, catalogConf)).toString(),
-                DatasetIdentifier.SymlinkType.TABLE));
+    DatasetIdentifier base = super.getPrimaryIdentifier(session, catalogConf, identifier, tableCatalog);
+    try {
+      return base.withSymlink(
+          new DatasetIdentifier.Symlink(
+              identifier.toString(),
+              PathUtils.prepareHiveUri(getUri(session, catalogConf)).toString(),
+              DatasetIdentifier.SymlinkType.TABLE));
+    } catch (Exception e) {
+      // The Hive symlink is supplementary; a metastore URI we can't resolve shouldn't take down
+      // the whole dataset identifier that was already successfully computed above.
+      log.debug("Couldn't resolve Hive metastore URI for symlink on {}, skipping", identifier, e);
+      return base;
+    }
   }
 
   private static URI getUri(SparkSession session, Map<String, String> catalogConf)

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -150,6 +150,45 @@ class IcebergHandlerTest {
 
   @Test
   @SneakyThrows
+  void testGetDatasetIdentifierForHiveWhenMetastoreUriUnresolvable() {
+    // Regression: if the catalog has no `.uri` property and no metastore URI can be found in
+    // SparkConf or the Hadoop configuration either, resolving the identifier must still succeed
+    // -- the Hive symlink is supplementary, and a failure to build it must not discard the
+    // already-correctly-computed dataset identifier (which previously happened because the
+    // MissingDatasetIdentifierCatalogException thrown while building the symlink propagated out
+    // of the whole method instead of just skipping the symlink).
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.test.type",
+                "hive",
+                "spark.sql.catalog.test.warehouse",
+                "/tmp/warehouse"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+    assertThat(datasetIdentifier.getSymlinks()).isEmpty();
+  }
+
+  @Test
+  @SneakyThrows
   void testGetDatasetIdentifierForRestCatalog() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -28,9 +28,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
@@ -318,12 +315,10 @@ class IcebergHandlerTest {
                 warehouseLocation));
 
     SparkSessionCatalog sparkCatalog = mock(SparkSessionCatalog.class);
-    Catalog icebergCatalog = mock(Catalog.class);
-    Table table = mock(Table.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
     when(sparkCatalog.name()).thenReturn(catalogName);
-    when(sparkCatalog.icebergCatalog()).thenReturn(icebergCatalog);
-    when(icebergCatalog.loadTable(TableIdentifier.parse(identifier.toString()))).thenReturn(table);
-    when(table.location()).thenReturn("gs://bucket/path/from/table/location");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("gs://bucket/path/from/table/location");
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
@@ -566,15 +561,10 @@ class IcebergHandlerTest {
     SparkSessionCatalog sparkCatalog = mock(SparkSessionCatalog.class);
     when(sparkCatalog.name()).thenReturn("test");
 
-    Catalog icebergCatalog = mock(Catalog.class);
-    when(sparkCatalog.icebergCatalog()).thenReturn(icebergCatalog);
-
-    TableIdentifier tableIdentifier = TableIdentifier.of("database", "table");
-    Table icebergTable = mock(Table.class, RETURNS_DEEP_STUBS);
-    when(icebergCatalog.loadTable(tableIdentifier)).thenReturn(icebergTable);
-    when(icebergTable.location()).thenReturn("file:/tmp/warehouse/database/table");
-
     Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
             sparkSession, sparkCatalog, identifier, new HashMap<>());
@@ -588,6 +578,48 @@ class IcebergHandlerTest {
         .hasFieldOrPropertyWithValue("namespace", "file:/tmp/warehouse")
         .hasFieldOrPropertyWithValue("name", "database.table")
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierForIcebergTableWithSparkSessionCatalogBranchIdentifier() {
+    // Regression for a branch-qualified write (e.g. MERGE INTO catalog.db.table.branch_x) against
+    // a hive-type catalog, where spark_catalog resolves to SparkSessionCatalog rather than
+    // SparkCatalog. Previously this went through TableIdentifier.parse(identifier.toString())
+    // and Iceberg's raw Catalog.loadTable(TableIdentifier), which has no notion of Spark's
+    // branch-qualified identifiers and always failed to find the table -- silently producing a
+    // fabricated location (branch suffix baked in as a literal path segment) instead of the real
+    // one. The fix routes SparkSessionCatalog through the same Spark V2 loadTable(Identifier)
+    // used for SparkCatalog, which understands the branch suffix and resolves it to the real
+    // underlying table.
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3<>(
+                "spark.sql.catalog.test",
+                "org.apache.iceberg.spark.SparkSessionCatalog",
+                "spark.sql.catalog.test.type",
+                "hive",
+                "spark.sql.catalog.test.warehouse",
+                "file:/tmp/warehouse"));
+
+    SparkSessionCatalog sparkCatalog = mock(SparkSessionCatalog.class);
+    when(sparkCatalog.name()).thenReturn("test");
+
+    Identifier identifier =
+        Identifier.of(new String[] {"database"}, "table.branch_cloverleaf_audit");
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    // The identifier resolves to the real underlying table location -- not a fabricated one.
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
   }
 
   @ParameterizedTest
@@ -609,12 +641,7 @@ class IcebergHandlerTest {
     SparkSessionCatalog sparkCatalog = mock(SparkSessionCatalog.class);
     when(sparkCatalog.name()).thenReturn("test");
 
-    Catalog icebergCatalog = mock(Catalog.class);
-    when(sparkCatalog.icebergCatalog()).thenReturn(icebergCatalog);
-
-    TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
-    when(icebergCatalog.loadTable(tableIdentifier))
-        .thenThrow(new org.apache.iceberg.exceptions.NoSuchTableException(identifier.toString()));
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
@@ -788,13 +815,8 @@ class IcebergHandlerTest {
     SparkSessionCatalog sparkCatalog = mock(SparkSessionCatalog.class);
     when(sparkCatalog.name()).thenReturn("test");
 
-    Catalog icebergCatalog = mock(Catalog.class);
-    when(sparkCatalog.icebergCatalog()).thenReturn(icebergCatalog);
-
     Identifier identifier = Identifier.of(new String[] {"database"}, "table");
-    TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
-    when(icebergCatalog.loadTable(tableIdentifier))
-        .thenThrow(new org.apache.iceberg.exceptions.NoSuchTableException(identifier.toString()));
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(


### PR DESCRIPTION
## Summary

Fixes #4858 — a `MERGE INTO` targeting an Iceberg **branch** (`catalog.db.table.branch_x`) under `spark_catalog = org.apache.iceberg.spark.SparkSessionCatalog` with `type=hive` (any Hive-Metastore-backed Iceberg catalog) could silently emit an empty `outputs: []` OpenLineage `COMPLETE` event, with no warning anywhere. Two distinct bugs are fixed together here; see below for which one is actually responsible for the empty-output symptom in practice. (One of them was originally filed as a separate issue, #4862, which has since been **closed and merged with this** — its fix is included in this PR.)

## Root cause 1 (primary) — branch-qualified identifier resolution fails silently

`BaseCatalogTypeHandler.getIcebergTable` resolved `SparkSessionCatalog` identifiers via `TableIdentifier.parse(identifier.toString())` + Iceberg's raw `Catalog.loadTable(TableIdentifier)`. That API has no concept of Spark's branch-qualified identifiers (`table.branch_x`) — it treats the branch suffix as a literal table-name segment and always fails to find the table, throwing `org.apache.iceberg.exceptions.NoSuchTableException`.

That exception propagates up through `getPrimaryIdentifier` → `IcebergHandler.getDatasetIdentifier` → `CatalogUtils.getDatasetIdentifier`, and `PlanUtils3.getDatasetIdentifier` catches it — but its catch block treats `NoSuchTableException` as the *expected*, benign case of "probably trying to obtain table details on a `START` event while the table doesn't exist yet," and returns `Optional.empty()` with **no logging at all**. `DataSourceV2RelationDatasetExtractor` then turns that empty `Optional` into zero datasets for the whole relation — which is exactly `outputs: []`, and it happens even on a `COMPLETE` event for a table that clearly exists and was clearly written to, with nothing printed anywhere to explain why.

**Fix:** `BaseCatalogTypeHandler.getIcebergTable`: route `SparkSessionCatalog` through the same branch-aware `TableCatalog.loadTable(Identifier)` V2 API already used for `SparkCatalog` (which never had this bug), instead of the raw Iceberg `Catalog.loadTable(TableIdentifier)`.

## Root cause 2 (secondary, independent) — metastore URI resolution can also discard the identifier

Separately, `HiveCatalogTypeHandler.getPrimaryIdentifier` computes the dataset identifier, then attaches an optional "symlink" facet pointing at the Hive Metastore. Building that symlink requires resolving a metastore URI via `SparkConfUtils.getMetastoreUri(...)`. If that lookup fails to find a URI in `spark.sql.hive.metastore.uris` / `hive.metastore.uris` (SparkConf) or `hive.metastore.uris` (Hadoop `Configuration`) — even though Iceberg's own `HiveCatalog` connects to the real metastore fine through a completely separate configuration path — `getUri()` throws `MissingDatasetIdentifierCatalogException`.

Because that exception is thrown while evaluating the constructor argument to `.withSymlink(...)`, it aborts the *entire* expression, discarding the already-correctly-computed base `DatasetIdentifier` along with it — the same `PlanUtils3` catch-and-swallow behavior applies, again with no `WARN`, only `DEBUG`. This is a real, independently-triggerable bug (it fires whenever the metastore URI genuinely isn't resolvable via those specific keys, regardless of branches), It's worth fixing since it's a real crash-and-discard path, hence included in the same PR.

**Fix:** `HiveCatalogTypeHandler.getPrimaryIdentifier`: catch the metastore-URI resolution failure and skip the (optional) symlink instead of discarding the whole identifier.

## Test plan

- [x] New regression test `testGetDatasetIdentifierForIcebergTableWithSparkSessionCatalogBranchIdentifier`: `SparkSessionCatalog` + a branch-qualified `Identifier`, asserts the identifier resolves to the real table location, not a fabricated one (root cause 1).
- [x] Updated 4 existing `IcebergHandlerTest` tests that mocked the old `icebergCatalog().loadTable(TableIdentifier)` path (now unused for `SparkSessionCatalog`).
- [x] New unit test `IcebergHandlerTest.testGetDatasetIdentifierForHiveWhenMetastoreUriUnresolvable`: no `.uri` catalog property and no resolvable SparkConf/Hadoop metastore URI — asserts the dataset identifier still resolves correctly, with no symlink, rather than throwing/returning nothing (root cause 2).
- [x] Full `:spark3:test` suite: 236/236 pass.
- [ ] A real end-to-end integration test (live Spark session + embedded Hive Metastore + real `MERGE INTO` a branch) covering both fixes together is raised as a separate PR: rahul139vermaa/OpenLineage#2.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
