### PR TITLE
flink: add Kinesis lineage visitors (dataset identifier + type facet)

### DIFF
--- a/integration/flink/flink2/build.gradle
+++ b/integration/flink/flink2/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testImplementation "org.apache.flink:flink-table-planner_2.12:$testedflinkVersion"
     testImplementation "org.apache.flink:flink-connector-base:$testedflinkVersion"
     testImplementation "org.apache.flink:flink-json:$testedflinkVersion"
+    testImplementation "org.apache.flink:flink-avro:$testedflinkVersion"
     testImplementation "org.apache.flink:flink-connector-kafka:4.0.1-2.0"
     testImplementation "org.apache.flink:flink-connector-test-utils:$testedflinkVersion"
     testImplementation "org.apache.kafka:kafka-clients:4.1.1"

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
@@ -10,6 +10,7 @@ import io.openlineage.flink.config.FlinkConfigParser;
 import io.openlineage.flink.visitor.Flink2VisitorFactory;
 import io.openlineage.flink.visitor.facet.ConfigFacetVisitor;
 import io.openlineage.flink.visitor.facet.DatasetFacetVisitor;
+import io.openlineage.flink.visitor.facet.KinesisTypeDatasetFacetVisitor;
 import io.openlineage.flink.visitor.facet.SchemaFacetVisitor;
 import io.openlineage.flink.visitor.facet.TableLineageFacetVisitor;
 import io.openlineage.flink.visitor.facet.TypeDatasetFacetVisitor;
@@ -18,6 +19,7 @@ import io.openlineage.flink.visitor.identifier.JdbcTableLineageDatasetIdentifier
 import io.openlineage.flink.visitor.identifier.KafkaTableLineageDatasetIdentifierVisitor;
 import io.openlineage.flink.visitor.identifier.KafkaTopicListDatasetIdentifierVisitor;
 import io.openlineage.flink.visitor.identifier.KafkaTopicPatternDatasetIdentifierVisitor;
+import io.openlineage.flink.visitor.identifier.KinesisTableLineageDatasetIdentifierVisitor;
 import java.util.Arrays;
 import java.util.Collection;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +46,7 @@ public class OpenLineageJobStatusChangedListenerFactory implements JobStatusChan
       public Collection<DatasetFacetVisitor> loadDatasetFacetVisitors(OpenLineageContext context) {
         return Arrays.asList(
             new TypeDatasetFacetVisitor(context),
+            new KinesisTypeDatasetFacetVisitor(context),
             new TableLineageFacetVisitor(context),
             new ConfigFacetVisitor(context),
             new SchemaFacetVisitor(context));
@@ -56,7 +59,8 @@ public class OpenLineageJobStatusChangedListenerFactory implements JobStatusChan
             new KafkaTopicPatternDatasetIdentifierVisitor(context),
             new KafkaTopicListDatasetIdentifierVisitor(),
             new JdbcTableLineageDatasetIdentifierVisitor(),
-            new KafkaTableLineageDatasetIdentifierVisitor());
+            new KafkaTableLineageDatasetIdentifierVisitor(),
+            new KinesisTableLineageDatasetIdentifierVisitor());
       }
     };
   }

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/util/TypeDatasetFacetUtil.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/util/TypeDatasetFacetUtil.java
@@ -31,13 +31,17 @@ public class TypeDatasetFacetUtil {
   }
 
   /**
-   * Extracts kafka facet from {@link LineageDataset}
+   * Extracts kafka facet from {@link LineageDataset}. Other connectors (e.g. Kinesis, FLINK-39813)
+   * publish their own facet under the same {@code type} facet name, so the facet is type-checked
+   * before casting: a non-Kafka type facet yields {@link Optional#empty()} instead of a {@link
+   * ClassCastException}.
    *
    * @param dataset
    * @return
    */
   public static Optional<TypeDatasetFacet> getFacet(LineageDataset dataset) {
     return Optional.ofNullable(dataset.facets().get(TYPE_FACET_NAME))
+        .filter(f -> f instanceof TypeDatasetFacet)
         .map(f -> (TypeDatasetFacet) f);
   }
 }

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/AvroTypeDatasetFacetVisitorDelegate.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/AvroTypeDatasetFacetVisitorDelegate.java
@@ -60,6 +60,7 @@ public class AvroTypeDatasetFacetVisitorDelegate {
    * accessor, so it is read reflectively. This covers records deserialized from schema registries
    * (e.g. Confluent Schema Registry, AWS Glue Schema Registry) as {@code GenericRecord}.
    */
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   private Optional<Schema> genericRecordSchema(GenericRecordAvroTypeInfo typeInfo) {
     try {
       java.lang.reflect.Field schemaField =

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/AvroTypeDatasetFacetVisitorDelegate.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/AvroTypeDatasetFacetVisitorDelegate.java
@@ -17,6 +17,7 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 
 /** Class used to extract type information from the facets returned by the collector */
 @Slf4j
@@ -34,17 +35,39 @@ public class AvroTypeDatasetFacetVisitorDelegate {
 
   public boolean isDefinedAt(TypeInformation typeInformation) {
     // check if this class has schema
-    return typeInformation instanceof AvroTypeInfo;
+    return typeInformation instanceof AvroTypeInfo
+        || typeInformation instanceof GenericRecordAvroTypeInfo;
   }
 
   Optional<SchemaDatasetFacet> delegate(TypeInformation avroTypeInfo) {
     // check if this class has schema
+    if (avroTypeInfo instanceof GenericRecordAvroTypeInfo) {
+      return genericRecordSchema((GenericRecordAvroTypeInfo) avroTypeInfo)
+          .map(schema -> convert(context.getOpenLineage(), schema));
+    }
     Class typeClazz = avroTypeInfo.getTypeClass();
     if (SpecificRecordBase.class.isAssignableFrom(typeClazz)) {
       Schema schema = SpecificData.get().getSchema(typeClazz);
       return Optional.of(convert(context.getOpenLineage(), schema));
     } else {
       log.warn("Unsupported Avro Type: {}", typeClazz);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * {@link GenericRecordAvroTypeInfo} carries the Avro schema in a private field without an
+   * accessor, so it is read reflectively. This covers records deserialized from schema registries
+   * (e.g. Confluent Schema Registry, AWS Glue Schema Registry) as {@code GenericRecord}.
+   */
+  private Optional<Schema> genericRecordSchema(GenericRecordAvroTypeInfo typeInfo) {
+    try {
+      java.lang.reflect.Field schemaField =
+          GenericRecordAvroTypeInfo.class.getDeclaredField("schema");
+      schemaField.setAccessible(true);
+      return Optional.ofNullable((Schema) schemaField.get(typeInfo));
+    } catch (ReflectiveOperationException | SecurityException e) {
+      log.warn("Could not extract Avro schema from GenericRecordAvroTypeInfo", e);
       return Optional.empty();
     }
   }

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/KinesisTypeDatasetFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/KinesisTypeDatasetFacetVisitor.java
@@ -1,0 +1,110 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.facet;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFieldsBuilder;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+/**
+ * Visitor to extract type information from the Kinesis connector's {@code type} lineage facet
+ * ({@code org.apache.flink.connector.kinesis.lineage.TypeDatasetFacet}, added in FLINK-39813) and
+ * convert it into an OpenLineage schema facet.
+ *
+ * <p>The facet is accessed reflectively so that this integration does not require a compile-time
+ * dependency on the Kinesis connector. When the connector's type information is Avro-based (e.g.
+ * records deserialized via AWS Glue Schema Registry), the Avro delegate extracts the full
+ * field-level schema — the same behavior the Kafka type facet receives.
+ */
+@Slf4j
+public class KinesisTypeDatasetFacetVisitor implements DatasetFacetVisitor {
+
+  private static final String KINESIS_TYPE_FACET_CLASS =
+      "org.apache.flink.connector.kinesis.lineage.TypeDatasetFacet";
+  private static final String TYPE_FACET_NAME = "type";
+
+  private final OpenLineageContext context;
+  private final AvroTypeDatasetFacetVisitorDelegate avroDelegate;
+
+  public KinesisTypeDatasetFacetVisitor(OpenLineageContext context) {
+    this.context = context;
+    if (AvroTypeDatasetFacetVisitorDelegate.isApplicable()) {
+      avroDelegate = new AvroTypeDatasetFacetVisitorDelegate(context);
+    } else {
+      avroDelegate = null;
+    }
+  }
+
+  @Override
+  public boolean isDefinedAt(LineageDatasetWithIdentifier dataset) {
+    return getTypeInformation(dataset).isPresent();
+  }
+
+  @Override
+  public void apply(
+      LineageDatasetWithIdentifier dataset, OpenLineage.DatasetFacetsBuilder builder) {
+    TypeInformation<?> typeInformation = getTypeInformation(dataset).orElse(null);
+    if (typeInformation == null) {
+      return;
+    }
+
+    if (avroDelegate != null && avroDelegate.isDefinedAt(typeInformation)) {
+      avroDelegate.delegate(typeInformation).ifPresent(builder::schema);
+    } else if (typeInformation instanceof GenericTypeInfo
+        || typeInformation instanceof PojoTypeInfo) {
+      builder.schema(
+          context
+              .getOpenLineage()
+              .newSchemaDatasetFacetBuilder()
+              .fields(fromFields(typeInformation.getTypeClass().getFields()))
+              .build());
+    }
+  }
+
+  private Optional<TypeInformation<?>> getTypeInformation(LineageDatasetWithIdentifier dataset) {
+    LineageDatasetFacet facet = dataset.getFlinkDataset().facets().get(TYPE_FACET_NAME);
+
+    if (facet == null || !KINESIS_TYPE_FACET_CLASS.equals(facet.getClass().getName())) {
+      return Optional.empty();
+    }
+
+    try {
+      Object typeInformation = facet.getClass().getMethod("getTypeInformation").invoke(facet);
+      if (typeInformation instanceof TypeInformation) {
+        return Optional.of((TypeInformation<?>) typeInformation);
+      }
+    } catch (ReflectiveOperationException e) {
+      log.warn("Could not extract type information from Kinesis type facet", e);
+    }
+    return Optional.empty();
+  }
+
+  private List<SchemaDatasetFacetFields> fromFields(Field... fields) {
+    return Arrays.stream(fields)
+        .filter(f -> Modifier.isPublic(f.getModifiers()))
+        .filter(field -> !Modifier.isStatic(field.getModifiers()))
+        .map(
+            f ->
+                new SchemaDatasetFacetFieldsBuilder()
+                    .type(f.getType().getSimpleName())
+                    .name(f.getName())
+                    .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/KinesisTableLineageDatasetIdentifierVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/KinesisTableLineageDatasetIdentifierVisitor.java
@@ -1,0 +1,82 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.identifier;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.Symlink;
+import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import io.openlineage.flink.wrapper.TableLineageDatasetWrapper;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+
+/**
+ * Visitor to extract a physical dataset identifier from a table lineage dataset backed by the
+ * Kinesis SQL connector ({@code connector = 'kinesis'}).
+ *
+ * <p>The identifier follows the convention emitted by the Kinesis connector's {@code
+ * LineageVertexProvider} on the DataStream path (FLINK-39813), so DataStream and SQL jobs operating
+ * on the same stream converge on the same dataset:
+ *
+ * <ul>
+ *   <li>namespace: {@code arn:{partition}:kinesis:{region}:{account}}
+ *   <li>name: {@code stream/{streamName}}
+ * </ul>
+ *
+ * <p>The catalog table identity is preserved as a {@code TABLE} symlink, mirroring {@link
+ * KafkaTableLineageDatasetIdentifierVisitor}.
+ */
+@Slf4j
+public class KinesisTableLineageDatasetIdentifierVisitor implements DatasetIdentifierVisitor {
+
+  private static final String KINESIS_CONNECTOR = "kinesis";
+  private static final String STREAM_ARN_OPTION = "stream.arn";
+  private static final int ARN_PARTS = 6;
+
+  @Override
+  public boolean isDefinedAt(LineageDataset dataset) {
+    CatalogBaseTable table = new TableLineageDatasetWrapper(dataset).getTable().orElse(null);
+
+    if (table == null) {
+      return false;
+    }
+
+    Map<String, String> options = table.getOptions();
+    if (options == null) {
+      return false;
+    }
+
+    return KINESIS_CONNECTOR.equals(options.get("connector"))
+        && isValidStreamArn(options.get(STREAM_ARN_OPTION));
+  }
+
+  @Override
+  public Collection<DatasetIdentifier> apply(LineageDataset dataset) {
+    CatalogBaseTable table = new TableLineageDatasetWrapper(dataset).getTable().orElseThrow();
+    String streamArn = table.getOptions().get(STREAM_ARN_OPTION);
+
+    log.debug("Extracting dataset identifier from table option stream.arn={}", streamArn);
+
+    // arn:{partition}:kinesis:{region}:{account}:stream/{streamName}
+    String[] parts = streamArn.split(":", ARN_PARTS);
+    String namespace = String.format("arn:%s:kinesis:%s:%s", parts[1], parts[3], parts[4]);
+    String name = parts[5];
+
+    return Collections.singletonList(
+        new DatasetIdentifier(
+            name, namespace, List.of(new Symlink(dataset.name(), namespace, SymlinkType.TABLE))));
+  }
+
+  private boolean isValidStreamArn(String streamArn) {
+    return streamArn != null
+        && streamArn.startsWith("arn:")
+        && streamArn.split(":", ARN_PARTS).length == ARN_PARTS;
+  }
+}

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/KinesisTypeDatasetFacetVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/KinesisTypeDatasetFacetVisitorTest.java
@@ -1,0 +1,96 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.facet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.client.Versions;
+import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.connector.kinesis.lineage.TypeDatasetFacet;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class KinesisTypeDatasetFacetVisitorTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  KinesisTypeDatasetFacetVisitor facetVisitor = new KinesisTypeDatasetFacetVisitor(context);
+  OpenLineage.DatasetFacetsBuilder builder =
+      new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI).newDatasetFacetsBuilder();
+  LineageDataset flinkDataset = mock(LineageDataset.class);
+  LineageDatasetWithIdentifier dataset = mock(LineageDatasetWithIdentifier.class);
+
+  @BeforeEach
+  public void beforeEach() {
+    when(dataset.getFlinkDataset()).thenReturn(flinkDataset);
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+  }
+
+  @Test
+  void testIsDefinedAt() {
+    when(flinkDataset.facets()).thenReturn(Map.of("type", mock(LineageDatasetFacet.class)));
+    assertThat(facetVisitor.isDefinedAt(dataset)).isFalse();
+
+    TypeDatasetFacet kinesisTypeFacet =
+        new TypeDatasetFacet(new GenericTypeInfo<>(TestingTypeClass.class));
+    when(flinkDataset.facets()).thenReturn(Map.of("type", kinesisTypeFacet));
+    assertThat(facetVisitor.isDefinedAt(dataset)).isTrue();
+  }
+
+  @Test
+  void testFieldsExtractedFromGenericTypeInfo() {
+    TypeDatasetFacet facet = new TypeDatasetFacet(new GenericTypeInfo<>(TestingTypeClass.class));
+    when(flinkDataset.facets()).thenReturn(Map.of("type", facet));
+
+    facetVisitor.apply(dataset, builder);
+
+    List<SchemaDatasetFacetFields> fields = builder.build().getSchema().getFields();
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "fieldA")
+        .hasFieldOrPropertyWithValue("type", "String");
+  }
+
+  @Test
+  void testAvroSchemaExtracted() {
+    Schema avroSchema =
+        SchemaBuilder.record("Order")
+            .namespace("io.test")
+            .fields()
+            .requiredString("orderId")
+            .requiredDouble("amount")
+            .endRecord();
+    TypeDatasetFacet facet = new TypeDatasetFacet(new GenericRecordAvroTypeInfo(avroSchema));
+    when(flinkDataset.facets()).thenReturn(Map.of("type", facet));
+
+    facetVisitor.apply(dataset, builder);
+
+    List<SchemaDatasetFacetFields> fields = builder.build().getSchema().getFields();
+    assertThat(fields).hasSize(2);
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "orderId")
+        .hasFieldOrPropertyWithValue("type", "string");
+    assertThat(fields.get(1))
+        .hasFieldOrPropertyWithValue("name", "amount")
+        .hasFieldOrPropertyWithValue("type", "double");
+  }
+
+  public static class TestingTypeClass {
+    public String fieldA;
+    public int fieldB;
+  }
+}

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/TypeDatasetFacetVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/TypeDatasetFacetVisitorTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.flink.visitor.facet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.client.Versions;
 import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import io.openlineage.flink.util.TypeDatasetFacetUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +57,22 @@ class TypeDatasetFacetVisitorTest {
     when(typeDatasetFacet.getTypeInformation().getTypeClass()).thenReturn(GenericTypeInfo.class);
     when(flinkDataset.facets()).thenReturn(Map.of("type", typeDatasetFacet));
     assertThat(facetVisitor.isDefinedAt(dataset)).isTrue();
+  }
+
+  @Test
+  void testIsNotDefinedAtKinesisTypeFacet() {
+    // Mixed-classpath scenario (FLINK-39813): with both the Kafka and Kinesis connector facet
+    // classes loaded, a Kinesis "type" facet must not be force-cast to the Kafka
+    // TypeDatasetFacet (previously a ClassCastException that suppressed the START event) —
+    // the Kafka visitor skips it and leaves it to KinesisTypeDatasetFacetVisitor.
+    org.apache.flink.connector.kinesis.lineage.TypeDatasetFacet kinesisTypeFacet =
+        new org.apache.flink.connector.kinesis.lineage.TypeDatasetFacet(
+            new GenericTypeInfo(TestingTypeClass.class));
+    when(flinkDataset.facets()).thenReturn(Map.of("type", kinesisTypeFacet));
+
+    assertThatCode(() -> facetVisitor.isDefinedAt(dataset)).doesNotThrowAnyException();
+    assertThat(facetVisitor.isDefinedAt(dataset)).isFalse();
+    assertThat(TypeDatasetFacetUtil.getFacet(flinkDataset)).isEmpty();
   }
 
   @Test

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/KinesisTableLineageDatasetIdentifierVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/KinesisTableLineageDatasetIdentifierVisitorTest.java
@@ -1,0 +1,111 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.identifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.Symlink;
+import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.planner.lineage.TableLineageDataset;
+import org.apache.flink.table.planner.lineage.TableLineageDatasetImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class KinesisTableLineageDatasetIdentifierVisitorTest {
+
+  private static final String STREAM_ARN = "arn:aws:kinesis:eu-west-1:123456789012:stream/orders";
+
+  KinesisTableLineageDatasetIdentifierVisitor visitor =
+      new KinesisTableLineageDatasetIdentifierVisitor();
+  ContextResolvedTable contextResolvedTable = mock(ContextResolvedTable.class, RETURNS_DEEP_STUBS);
+  CatalogBaseTable catalogBaseTable = mock(CatalogBaseTable.class);
+  TableLineageDataset table;
+
+  @BeforeEach
+  void setup() {
+    when(contextResolvedTable.getTable()).thenReturn(catalogBaseTable);
+    when(contextResolvedTable.getIdentifier().asSummaryString()).thenReturn("tableName");
+    table =
+        new TableLineageDatasetImpl(
+            contextResolvedTable,
+            Optional.of(
+                new LineageDataset() {
+                  @Override
+                  public String name() {
+                    return "tableName";
+                  }
+
+                  @Override
+                  public String namespace() {
+                    return "";
+                  }
+
+                  @Override
+                  public Map<String, LineageDatasetFacet> facets() {
+                    return Map.of();
+                  }
+                }));
+  }
+
+  @Test
+  void testIsDefinedAt() {
+    assertThat(visitor.isDefinedAt(mock(LineageDataset.class))).isFalse();
+    assertThat(visitor.isDefinedAt(table)).isFalse();
+
+    when(catalogBaseTable.getOptions()).thenReturn(Map.of("connector", "kinesis"));
+    assertThat(visitor.isDefinedAt(table)).isFalse();
+
+    when(catalogBaseTable.getOptions())
+        .thenReturn(Map.of("connector", "kinesis", "stream.arn", "not-an-arn"));
+    assertThat(visitor.isDefinedAt(table)).isFalse();
+
+    when(catalogBaseTable.getOptions())
+        .thenReturn(Map.of("connector", "kinesis", "stream.arn", STREAM_ARN));
+    assertThat(visitor.isDefinedAt(table)).isTrue();
+  }
+
+  @Test
+  void testApply() {
+    when(catalogBaseTable.getOptions())
+        .thenReturn(Map.of("connector", "kinesis", "stream.arn", STREAM_ARN));
+
+    Collection<DatasetIdentifier> identifiers = visitor.apply(table);
+
+    assertThat(identifiers).hasSize(1);
+    DatasetIdentifier identifier = identifiers.iterator().next();
+    assertThat(identifier.getNamespace()).isEqualTo("arn:aws:kinesis:eu-west-1:123456789012");
+    assertThat(identifier.getName()).isEqualTo("stream/orders");
+    assertThat(identifier.getSymlinks())
+        .containsExactly(
+            new Symlink("tableName", "arn:aws:kinesis:eu-west-1:123456789012", SymlinkType.TABLE));
+  }
+
+  @Test
+  void testApplyDifferentPartition() {
+    when(catalogBaseTable.getOptions())
+        .thenReturn(
+            Map.of(
+                "connector",
+                "kinesis",
+                "stream.arn",
+                "arn:aws-cn:kinesis:cn-north-1:999888777666:stream/cn-orders"));
+
+    DatasetIdentifier identifier = visitor.apply(table).iterator().next();
+    assertThat(identifier.getNamespace()).isEqualTo("arn:aws-cn:kinesis:cn-north-1:999888777666");
+    assertThat(identifier.getName()).isEqualTo("stream/cn-orders");
+  }
+}

--- a/integration/flink/flink2/src/test/java/org/apache/flink/connector/kinesis/lineage/TypeDatasetFacet.java
+++ b/integration/flink/flink2/src/test/java/org/apache/flink/connector/kinesis/lineage/TypeDatasetFacet.java
@@ -1,0 +1,34 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.apache.flink.connector.kinesis.lineage;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+/**
+ * Test stub matching the fully-qualified class name of the Kinesis connector's type facet
+ * (FLINK-39813). Lets {@code KinesisTypeDatasetFacetVisitor}'s reflective access be tested without
+ * a dependency on the connector artifact.
+ */
+public class TypeDatasetFacet implements LineageDatasetFacet {
+
+  public static final String TYPE_FACET_NAME = "type";
+
+  private final TypeInformation<?> typeInformation;
+
+  public TypeDatasetFacet(TypeInformation<?> typeInformation) {
+    this.typeInformation = typeInformation;
+  }
+
+  public TypeInformation<?> getTypeInformation() {
+    return typeInformation;
+  }
+
+  @Override
+  public String name() {
+    return TYPE_FACET_NAME;
+  }
+}


### PR DESCRIPTION
## Problem

The Apache Flink Kinesis connector is gaining native FLIP-314 lineage
(`LineageVertexProvider` on `KinesisStreamsSource`/`KinesisStreamsSink` —
[apache/flink-connector-aws#250](https://github.com/apache/flink-connector-aws/pull/250),
FLINK-39813). The Flink 2 integration currently handles connector lineage only for Kafka
and JDBC, so Kinesis datasets have two gaps:

1. **SQL/DataStream identity split.** Flink's table planner names SQL datasets by catalog
   identity (`default_catalog.default_database.my_table`). For Kafka,
   `KafkaTableLineageDatasetIdentifierVisitor` re-derives the physical identifier from the
   table options so DataStream and SQL jobs converge on one dataset. Kinesis has no such
   visitor — the same physical stream appears as two unrelated datasets.
2. **No schema facet.** `TypeDatasetFacetVisitor` is bound to the Kafka connector's facet
   classes, so the Kinesis connector's `type` facet is never converted to an OpenLineage
   schema facet.

## Changes

- **`KinesisTableLineageDatasetIdentifierVisitor`** — for table lineage datasets with
  `connector = 'kinesis'`, derives the physical identifier from the `stream.arn` option:
  namespace `arn:{partition}:kinesis:{region}:{account}`, name `stream/{streamName}` —
  matching the convention the connector emits on the DataStream path. Catalog identity is
  preserved as a `TABLE` symlink (mirrors the Kafka visitor).
- **`KinesisTypeDatasetFacetVisitor`** — converts the Kinesis connector's `type` facet
  into an OL schema facet. The facet is accessed reflectively
  (`org.apache.flink.connector.kinesis.lineage.TypeDatasetFacet#getTypeInformation`) so no
  compile-time dependency on the connector is needed (the connector release containing the
  facet classes is pending).
- **`AvroTypeDatasetFacetVisitorDelegate`** — additionally supports
  `GenericRecordAvroTypeInfo` (schema read reflectively from its private field), covering
  records deserialized as Avro `GenericRecord`, e.g. via Confluent Schema Registry or AWS
  Glue Schema Registry. Previously only compiled `SpecificRecord` types produced a schema
  facet — this improves Kafka lineage too.
- Registered both visitors in `OpenLineageJobStatusChangedListenerFactory`; added
  `flink-avro` as a test dependency.

## Testing

- `KinesisTableLineageDatasetIdentifierVisitorTest` (3 tests: gating incl. malformed ARN,
  identifier derivation, non-default partition `aws-cn`).
- `KinesisTypeDatasetFacetVisitorTest` (3 tests: reflective gating, POJO/generic field
  extraction, full Avro schema extraction via `GenericRecordAvroTypeInfo`) — uses a test
  stub with the connector facet's FQCN.
- Full `:flink2:test` suite: **51/51 pass** (`-Pflink.version=2.0.0`), `spotlessCheck` clean.
- End-to-end (outside this repo): verified against a local build of
  flink-connector-aws#250 that a real Flink 2.0 job's `JobCreatedEvent` carries these
  facets, including the full Avro schema when deserializing via Glue Schema Registry.
