### PR TITLE
sql: include aggregate filter predicate lineage

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -425,6 +425,9 @@ impl Visit for Function {
                 }
             }
         }
+        if let Some(filter) = &self.filter {
+            filter.visit(context)?;
+        }
         if let Some(spec) = &self.over {
             spec.visit(context)?;
         }

--- a/integration/sql/impl/tests/column_lineage/tests_simple.rs
+++ b/integration/sql/impl/tests/column_lineage/tests_simple.rs
@@ -300,6 +300,28 @@ fn test_simple_count() {
 }
 
 #[test]
+fn test_aggregate_filter() {
+    let output = test_sql(
+        "SELECT COUNT(*) FILTER (WHERE status = 'paid') AS paid_orders
+         FROM orders",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![ColumnLineage {
+            descendant: ColumnMeta {
+                origin: None,
+                name: "paid_orders".to_string()
+            },
+            lineage: vec![ColumnMeta {
+                origin: Some(table("orders")),
+                name: "status".to_string()
+            },]
+        },]
+    );
+}
+
+#[test]
 fn test_simple_aggregate() {
     let output = test_sql(
         "SELECT RANK() OVER (PARTITION BY i.a ORDER BY i.b DESC) AS c

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -46,6 +46,23 @@ fn select_having_exists_subquery() {
 }
 
 #[test]
+fn select_aggregate_filter_subquery() {
+    assert_eq!(
+        test_sql(
+            "SELECT count(*) FILTER (
+                 WHERE EXISTS (SELECT 1 FROM customers)
+             ) FROM orders;"
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["customers", "orders"]),
+            out_tables: vec![]
+        }
+    )
+}
+
+#[test]
 fn select_from_schema_table() {
     assert_eq!(
         test_sql("SELECT * FROM schema0.table0;",)


### PR DESCRIPTION
### One-line summary for changelog:

Include SQL aggregate `FILTER` predicates when extracting table and column lineage.

### Meaningful description

The SQL AST visitor traversed function arguments and window specifications, but skipped `Function.filter`. As a result, lineage referenced only inside an aggregate filter was lost: predicate columns did not contribute column lineage, and subqueries inside the filter did not contribute input tables.

This change visits the optional filter expression at the same visitor boundary as the function arguments and window specification. It adds focused regression coverage for both observable effects:

- `COUNT(*) FILTER (WHERE status = 'paid')` now records `orders.status` as an input to the output column.
- `FILTER (WHERE EXISTS (SELECT ... FROM customers))` now records `customers` as an input table.

Validation:

- `cargo test -p openlineage_sql --test tests aggregate_filter`
- `cargo test --no-default-features`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `prek run --all-files`

Closes: #4864

### Checklist

- [x] AI was used to help develop this contribution.
