### PR TITLE
docs: symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,9 +176,6 @@ changes.txt
 # Cursor
 .cursor/
 
-# Claude Code
-CLAUDE.md
-
 # UV lock files (ignore in subdirectories only, keep root uv.lock)
 **/uv.lock
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### One-line summary for changelog:
Commit `CLAUDE.md` as a symlink to `AGENTS.md` so Claude Code automatically picks up the repo's AI agent guidelines.

### Meaningful description
#4322 added `AGENTS.md` with tool-agnostic AI agent contribution guidelines. Most agentic tools now follow the agents.md convention, but Claude Code only auto-loads `CLAUDE.md`, so for Claude Code users those guidelines are silently missed unless they wire something up locally.

This PR commits `CLAUDE.md` as a **symlink** pointing to `AGENTS.md` — the same approach apache/airflow uses ([apache/airflow CLAUDE.md](https://github.com/apache/airflow/blob/main/CLAUDE.md)) — and removes the corresponding `.gitignore` entry, which is obsolete once the symlink is tracked.

**Relation to the #4322 discussion** ([thread](https://github.com/OpenLineage/OpenLineage/pull/4322#discussion_r2769882004)): committing a `CLAUDE.md` was considered there and rejected, for two reasons. I believe a symlink addresses both:

1. *"a one-line 'read AGENTS.md' file works only if the agent follows the instruction"* — a symlink has no instruction to follow: its content **is** `AGENTS.md`, byte for byte, kept in sync by construction with zero maintenance.
2. *"if we add CLAUDE.md, why not .cursor or the next tool popular in a week"* — the symlink is effectively just an alias for `AGENTS.md`, only needed for tools that don't follow the agents.md convention. That set is small and shrinking: Cursor, Codex, Gemini CLI and others already read `AGENTS.md` natively, and with agents.md now under the Linux Foundation, tools keep converging on it. Today the notable holdout is Claude Code — so in practice this is one symlink, not the first of many.

Happy to close if the maintainers still prefer keeping agent-specific files out of the repo — just wanted to put the symlink option on the table, since it wasn't considered in that thread.

### Checklist
- [x] AI was used in creating this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)