### PR TITLE
docs: fix 404 on /docs/integrations/ and /docs/integrations/flink/ landing pages

### DIFF
--- a/website/docs/integrations/about.md
+++ b/website/docs/integrations/about.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: About
+slug: /integrations
 ---
 
 # OpenLineage Integrations

--- a/website/docs/integrations/flink/about.md
+++ b/website/docs/integrations/flink/about.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: About
+slug: /integrations/flink
 ---
 
 **Apache Flink** is one of the most popular stream processing frameworks. Apache Flink jobs run on clusters,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -149,6 +149,18 @@ const config = {
       },
     ],
     [
+      "@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          { from: "/docs/integrations/about", to: "/docs/integrations" },
+          {
+            from: "/docs/integrations/flink/about",
+            to: "/docs/integrations/flink",
+          },
+        ],
+      },
+    ],
+    [
       "docusaurus-lunr-search",
       {
         disableVersioning: false,

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^8.0.0",
     "@docusaurus/core": "^3.10.2",
+    "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/plugin-content-blog": "^3.10.2",
     "@docusaurus/plugin-content-docs": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2673,6 +2673,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/plugin-client-redirects@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-client-redirects@npm:3.10.2"
+  dependencies:
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
+    eta: "npm:^2.2.0"
+    fs-extra: "npm:^11.1.1"
+    lodash: "npm:^4.17.21"
+    tslib: "npm:^2.6.0"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  checksum: 10c0/ab5ded6b97561047d35edf7fb6bee7e7bd795a38223873c89824e06597e762628d1ce3e72cf2c8c212c5579406a026bbacb3392d9c3b6dccbcace8239cd48801
+  languageName: node
+  linkType: hard
+
 "@docusaurus/plugin-content-blog@npm:3.10.2, @docusaurus/plugin-content-blog@npm:^3.10.2":
   version: 3.10.2
   resolution: "@docusaurus/plugin-content-blog@npm:3.10.2"
@@ -7013,6 +7033,7 @@ __metadata:
     "@babel/runtime": "npm:^8.0.0"
     "@docusaurus/core": "npm:^3.10.2"
     "@docusaurus/module-type-aliases": "npm:^3.10.2"
+    "@docusaurus/plugin-client-redirects": "npm:^3.10.2"
     "@docusaurus/plugin-content-blog": "npm:^3.10.2"
     "@docusaurus/plugin-content-docs": "npm:^3.10.2"
     "@docusaurus/preset-classic": "npm:^3.10.2"


### PR DESCRIPTION
### One-line summary for changelog:
Fix 404s at https://openlineage.io/docs/integrations/ and https://openlineage.io/docs/integrations/flink/ by serving the About docs at the category URLs and redirecting the old URLs.

### Meaningful description

<img width="1117" height="467" alt="스크린샷 2026-08-18 오후 8 46 58" src="https://github.com/user-attachments/assets/b1ef65b7-94b0-4d53-ad05-eca01ca22484" />

https://openlineage.io/docs/integrations/ and https://openlineage.io/docs/integrations/flink/ currently return **404**, even though both URLs are linked from the repo root `README.md`, `integration/README.md`, and `integration/flink/README.md` (and likely from external sites).

The cause: Docusaurus only generates a page at a category's own URL when the category has an index doc. The `integrations` category and its `flink` subcategory only have `about.md`, so no page exists at the category URLs.

This PR keeps both `about.md` docs (and their **About** entries in the sidebar) and:

- adds `slug` front matter so the docs are served at the category URLs:
  - `website/docs/integrations/about.md` → `slug: /integrations`
  - `website/docs/integrations/flink/about.md` → `slug: /integrations/flink`
- adds `@docusaurus/plugin-client-redirects` so the old URLs keep working:
  - `/docs/integrations/about` → `/docs/integrations`
  - `/docs/integrations/flink/about` → `/docs/integrations/flink`

An earlier revision of this PR renamed the docs to Docusaurus category-index names (`integrations.md` / `flink.md`), but that removed the About entries from the sidebar (see review below). The `slug` approach fixes the 404s without touching the sidebar.

Verified with a local `yarn build`: it passes with `onBrokenLinks: "throw"`; the build output contains `build/docs/integrations/index.html` and `build/docs/integrations/flink/index.html`, the sidebar keeps both About items, and the old `/about` URLs serve redirect pages to the new locations.

### Checklist
- [x] AI was used in creating this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
