### PR TITLE
dbt: support the fabricspark adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.52.0...HEAD)
 
+### Added
+
+* **dbt: Support the `fabricspark` adapter** [`#4874`](https://github.com/OpenLineage/OpenLineage/pull/4874) [@calvinchengx](https://github.com/calvinchengx)  
+  *Adds `dbt-fabricspark` to the supported adapters, so a dbt project building a Fabric Lakehouse emits lineage instead of silently producing no events.*
+
 ## [1.52.0](https://github.com/OpenLineage/OpenLineage/compare/1.51.0...1.52.0)
 
 ### Added

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -69,6 +69,7 @@ class Adapter(Enum):
     GLUE = "glue"
     CLICKHOUSE = "clickhouse"
     FABRIC = "fabric"
+    FABRICSPARK = "fabricspark"
 
     @staticmethod
     def adapters() -> str:
@@ -1058,6 +1059,18 @@ class DbtArtifactProcessor:
             if "port" in profile:
                 return f"fabric-warehouse://{profile['server']}:{profile['port']}"
             return f"fabric-warehouse://{profile['server']}"
+        elif self.adapter_type == Adapter.FABRICSPARK:
+            # A Fabric lakehouse has no host of its own to key on: every tenant
+            # reaches the same `api.fabric.microsoft.com` endpoint, so a
+            # namespace built from it would collide across workspaces. The
+            # workspace and lakehouse ids are the stable, unique address, and
+            # they are what the profile carries.
+            if "workspaceid" not in profile or "lakehouseid" not in profile:
+                raise NotImplementedError(
+                    "fabricspark profiles must define `workspaceid` and "
+                    "`lakehouseid` to build a dataset namespace."
+                )
+            return f"fabric-lakehouse://{profile['workspaceid']}/{profile['lakehouseid']}"
         elif self.adapter_type == Adapter.DREMIO:
             return f"dremio://{profile['software_host']}:{profile['port']}"
         elif self.adapter_type == Adapter.ATHENA:

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -149,6 +149,50 @@ def test_get_query_id_missing_adapter_response(dbt_artifact_processor, run_resul
     assert generated_query_id is None
 
 
+def test_fabricspark_lakehouse_namespace(dbt_artifact_processor):
+    """A lakehouse is addressed by workspace and lakehouse id, not by host.
+
+    Every Fabric tenant reaches the same `api.fabric.microsoft.com` endpoint,
+    so a namespace derived from the profile's `endpoint` would be identical for
+    two different workspaces.
+    """
+    dbt_artifact_processor.adapter_type = Adapter.FABRICSPARK
+    dbt_artifact_processor.extract_dataset_namespace(
+        {
+            "type": "fabricspark",
+            "method": "livy",
+            "endpoint": "https://api.fabric.microsoft.com/v1",
+            "workspaceid": "11111111-2222-3333-4444-555555555555",
+            "lakehouseid": "66666666-7777-8888-9999-000000000000",
+            "lakehouse": "lake",
+        }
+    )
+
+    assert dbt_artifact_processor.dataset_namespace == (
+        "fabric-lakehouse://11111111-2222-3333-4444-555555555555"
+        "/66666666-7777-8888-9999-000000000000"
+    )
+
+
+def test_fabricspark_namespace_requires_the_ids_it_is_built_from(dbt_artifact_processor):
+    # Failing by name beats emitting a namespace that silently collides with
+    # every other workspace's.
+    dbt_artifact_processor.adapter_type = Adapter.FABRICSPARK
+
+    with pytest.raises(NotImplementedError, match="workspaceid"):
+        dbt_artifact_processor.extract_dataset_namespace(
+            {"type": "fabricspark", "endpoint": "https://api.fabric.microsoft.com/v1"}
+        )
+
+
+def test_fabricspark_dialect_is_its_own(dbt_artifact_processor):
+    # The SQL facet's dialect comes from the adapter name; fabricspark is Spark
+    # SQL through Livy, not the warehouse's T-SQL.
+    dbt_artifact_processor.adapter_type = Adapter.FABRICSPARK
+
+    assert dbt_artifact_processor.extract_dialect() == "fabricspark"
+
+
 def test_fabric_warehouse_namespace_with_port(dbt_artifact_processor):
     dbt_artifact_processor.adapter_type = Adapter.FABRIC
     dbt_artifact_processor.extract_dataset_namespace(

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -169,8 +169,7 @@ def test_fabricspark_lakehouse_namespace(dbt_artifact_processor):
     )
 
     assert dbt_artifact_processor.dataset_namespace == (
-        "fabric-lakehouse://11111111-2222-3333-4444-555555555555"
-        "/66666666-7777-8888-9999-000000000000"
+        "fabric-lakehouse://11111111-2222-3333-4444-555555555555/66666666-7777-8888-9999-000000000000"
     )
 
 


### PR DESCRIPTION
## Problem

`dbt-fabricspark` — the adapter for building a **Fabric Lakehouse** over Livy — is not in the `Adapter` enum. `extract_adapter_type` therefore raises `NotImplementedError`, the caller catches it, and the run yields **no events at all**.

The failure is silent in practice. `astronomer-cosmos` (which depends on `openlineage-integration-common`) wraps the parse in:

```python
except (FileNotFoundError, NotImplementedError, ValueError, KeyError, jinja2.exceptions.UndefinedError):
    self.log.debug("Unable to parse OpenLineage events", stack_info=True)
```

At the default INFO level nothing is logged, so a dbt project on this adapter emits no lineage and no Airflow assets, with no indication why. What the task log shows is just:

```
Inlets: []
Outlets: []
```

A sibling project on `dbt-fabric` (the Warehouse adapter, already supported) emits full lineage from the same DAG, which makes the gap look like a bug in the project rather than an unsupported adapter.

## Change

1. `FABRICSPARK = "fabricspark"` in the `Adapter` enum.
2. A namespace branch in `extract_namespace`.

`extract_dialect` then works unchanged, returning `fabricspark`.

## On the namespace

`fabric` (Warehouse) keys on `server`/`port` because it is a TDS endpoint. A lakehouse has no host of its own — **every Fabric tenant reaches the same `api.fabric.microsoft.com`** — so a namespace derived from the profile's `endpoint` would be identical for two different workspaces. The profile carries `workspaceid` and `lakehouseid`, which are the stable, unique address:

```
fabric-lakehouse://{workspaceid}/{lakehouseid}
```

A profile missing either fails by name, rather than emitting a namespace that silently collides with every other workspace's.

**One open question for maintainers.** I have used a distinct `fabric-lakehouse://` scheme, since a lakehouse and a warehouse are different surfaces. But in a normal Fabric medallion, gold (`dbt-fabric`, `fabric-warehouse://…`) reads silver (`dbt-fabricspark`) through the lakehouse's SQL analytics endpoint — the *same* tables under two namespaces, so lineage will not join across that hop. If you would prefer these to converge on one naming, I am happy to change it; it seemed wrong to decide unilaterally.

## Verification

Against a real `dbt-fabricspark` project (8 models over Livy into a Fabric lakehouse), running `DbtLocalArtifactProcessor` over its own `manifest.json` and `run_results.json`.

**Before:** `events.completes: 0`

**After:**

```
events.completes: 1
  lake.lake.contoso_silver.silver_product_hierarchy
    namespace: fabric-lakehouse://<workspaceid>/<lakehouseid>
    inputs:  ['lake.lake.bronze_ref_product_hierarchy']
    outputs: ['lake.lake.silver_product_hierarchy']
```

Worth noting for anyone reproducing it: artifacts from `dbt compile` produce zero events regardless of this change, because `compile` is not in the supported command list — my first attempt at this measurement was invalid for that reason. The numbers above come from `dbt run`.

## Tests

Three added to `integration/common/tests/dbt/test_processor.py`:

- the namespace is built from the two ids;
- a profile missing them raises rather than emitting a colliding namespace;
- the dialect is `fabricspark`.

`integration/common`: **351 passed, 2 skipped**.
