### PR TITLE
dbt-athena: add glue dataset symlink

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -1072,18 +1072,13 @@ class DbtArtifactProcessor:
 
     @staticmethod
     def _extract_profile_aws_account_id(profile: dict) -> str | None:
-        """Extract an AWS account ID from values already present in a dbt profile."""
-        account_id = profile.get("account_id")
-        if account_id is not None and str(account_id).strip():
-            return str(account_id).strip()
-
-        for key in ("assume_role_arn", "role_arn"):
-            role_arn = profile.get(key)
-            if not isinstance(role_arn, str):
-                continue
-            parts = role_arn.split(":")
-            if len(parts) > 4 and parts[0] == "arn" and parts[2] == "iam" and parts[4]:
-                return parts[4]
+        """Extract the account ID from dbt-athena's supported role ARN setting."""
+        role_arn = profile.get("assume_role_arn")
+        if not isinstance(role_arn, str):
+            return None
+        parts = role_arn.split(":")
+        if len(parts) > 4 and parts[0] == "arn" and parts[2] == "iam" and parts[4]:
+            return parts[4]
         return None
 
     def _lookup_aws_account_id(self, profile: dict) -> str | None:
@@ -1114,7 +1109,7 @@ class DbtArtifactProcessor:
                 profile_name=profile.get("aws_profile_name"),
             )
 
-            role_arn = profile.get("assume_role_arn") or profile.get("role_arn")
+            role_arn = profile.get("assume_role_arn")
             if role_arn:
                 assume_role_kwargs = {
                     "RoleArn": role_arn,
@@ -1149,9 +1144,9 @@ class DbtArtifactProcessor:
         if self.adapter_type != Adapter.ATHENA:
             return None
 
-        # Avoid an AWS call when dbt already exposes the catalog account in the
-        # profile, but fall back to the effective credential identity for the
-        # common aws_profile_name/default credential-chain case.
+        # Avoid an AWS call when the supported assume_role_arn already exposes
+        # the target account, but fall back to the effective credential identity
+        # for the common aws_profile_name/default credential-chain case.
         account_id = self._extract_profile_aws_account_id(profile) or self._lookup_aws_account_id(profile)
         if not account_id:
             return None

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -31,6 +31,7 @@ from openlineage.client.facet_v2 import (
     processing_engine_run,
     schema_dataset,
     sql_job,
+    symlinks_dataset,
     tags_run,
     test_run,
 )
@@ -195,6 +196,10 @@ class DbtArtifactProcessor:
         self.selector = selector
         self.manifest_version = None
         self.adapter_type: Adapter | None = None
+        # Set for adapters that can provide a stable catalog identifier in addition to
+        # the primary dataset namespace. For Athena, this is populated from the dbt
+        # profile's account ID or assume-role ARN; no AWS API call is made.
+        self.dataset_symlink_namespace: str | None = None
         # Populated by parse(); retained so manifest-declared exposures can be indexed
         # and attached to the datasets they depend on.
         self.manifest: dict[str, Any] = {}
@@ -441,9 +446,12 @@ class DbtArtifactProcessor:
                 assertions=node_assertions
             )
 
-            namespace, name, _, _ = self.extract_dataset_data(
+            namespace, name, dataset_facets, _ = self.extract_dataset_data(
                 ModelNode(type=node_type, metadata_node=node), assertion_facet, has_facets=False
             )
+            # Keep the assertion facet in both locations for compatibility, while
+            # retaining dataset facets such as the Athena Glue symlink.
+            dataset_facets["dataQualityAssertions"] = assertion_facet  # type: ignore[assignment]
 
             job_name = self._format_dataset_name(
                 node["database"],
@@ -472,7 +480,6 @@ class DbtArtifactProcessor:
                 run_facets["tags"] = tags_facet
 
             run_id = str(generate_new_uuid())
-            dataset_facets: dict[str, InputDatasetFacet] = {"dataQualityAssertions": assertion_facet}
             # The aggregate per-model test event is FAIL when any of its assertions failed.
             # Warn-severity failures count as success so they don't block the pipeline,
             # mirroring dbt's own success/failure semantics.
@@ -492,7 +499,7 @@ class DbtArtifactProcessor:
                         InputDataset(
                             namespace=namespace,
                             name=name,
-                            inputFacets=dataset_facets,
+                            inputFacets={"dataQualityAssertions": assertion_facet},
                             # TODO: remove this next release
                             facets=dataset_facets,  # type: ignore
                         )
@@ -572,10 +579,10 @@ class DbtArtifactProcessor:
             parent_node = manifest_nodes.get(parent_id)
             if parent_node:
                 ptype = "source" if parent_id.startswith("source.") else "model"
-                ns, nm, _, _ = self.extract_dataset_data(
+                ns, nm, facets, _ = self.extract_dataset_data(
                     ModelNode(type=ptype, metadata_node=parent_node), None, has_facets=False
                 )
-                inputs.append(InputDataset(namespace=ns, name=nm))
+                inputs.append(InputDataset(namespace=ns, name=nm, facets=facets))
         return inputs
 
     def _build_test_execution(
@@ -812,14 +819,14 @@ class DbtArtifactProcessor:
         assertions: data_quality_assertions_dataset.DataQualityAssertionsDatasetFacet | None,
         has_facets: bool = False,
     ) -> tuple[str, str, dict, dict]:
-        facets: dict[str, DatasetFacet]
+        facets: dict[str, DatasetFacet] = {}
         input_facets: dict[str, InputDatasetFacet] = {}
+        if symlink := self._create_dataset_symlink(node):
+            facets["symlinks"] = symlink
         if has_facets:
-            facets = {
-                "dataSource": datasource_dataset.DatasourceDatasetFacet(
-                    name=self.dataset_namespace, uri=self.dataset_namespace
-                ),
-            }
+            facets["dataSource"] = datasource_dataset.DatasourceDatasetFacet(
+                name=self.dataset_namespace, uri=self.dataset_namespace
+            )
 
             documentation = node.metadata_node.get("description", "")
             if documentation:
@@ -848,8 +855,6 @@ class DbtArtifactProcessor:
 
             if dbt_model_facet := self._create_dbt_model_dataset_facet(node):
                 facets["dbt_model"] = dbt_model_facet
-        else:
-            facets = {}
         if node.type == "source":
             table = node.metadata_node["name"]
         else:
@@ -863,6 +868,34 @@ class DbtArtifactProcessor:
             ),
             facets,
             input_facets,
+        )
+
+    def _create_dataset_symlink(self, node: ModelNode) -> symlinks_dataset.SymlinksDatasetFacet | None:
+        """Create an alternate catalog identifier for an Athena dataset.
+
+        dbt-athena identifies the catalog and Glue database separately in its
+        manifest: ``database`` is the catalog (usually ``awsdatacatalog``) and
+        ``schema`` is the Glue database. The AWS account is only available to
+        this integration when dbt exposes it in the profile, either directly or
+        in an assume-role ARN. In all other cases the existing Athena identifier
+        is retained and no symlink is emitted.
+        """
+        if self.adapter_type != Adapter.ATHENA or not self.dataset_symlink_namespace:
+            return None
+
+        database = node.metadata_node.get("schema")
+        table = node.metadata_node.get("name" if node.type == "source" else "alias")
+        if not database or not table:
+            return None
+
+        return symlinks_dataset.SymlinksDatasetFacet(
+            identifiers=[
+                symlinks_dataset.Identifier(
+                    namespace=self.dataset_symlink_namespace,
+                    name=f"table/{database}/{table}",
+                    type="TABLE",
+                )
+            ]
         )
 
     def _create_dbt_model_dataset_facet(self, node: ModelNode) -> DbtModelDatasetFacet | None:
@@ -1035,6 +1068,95 @@ class DbtArtifactProcessor:
 
     def extract_dataset_namespace(self, profile: dict):
         self.dataset_namespace = self.extract_namespace(profile)
+        self.dataset_symlink_namespace = self._extract_dataset_symlink_namespace(profile)
+
+    @staticmethod
+    def _extract_profile_aws_account_id(profile: dict) -> str | None:
+        """Extract an AWS account ID from values already present in a dbt profile."""
+        account_id = profile.get("account_id")
+        if account_id is not None and str(account_id).strip():
+            return str(account_id).strip()
+
+        for key in ("assume_role_arn", "role_arn"):
+            role_arn = profile.get(key)
+            if not isinstance(role_arn, str):
+                continue
+            parts = role_arn.split(":")
+            if len(parts) > 4 and parts[0] == "arn" and parts[2] == "iam" and parts[4]:
+                return parts[4]
+        return None
+
+    def _lookup_aws_account_id(self, profile: dict) -> str | None:
+        """Best-effort account lookup using the credentials described by a dbt profile.
+
+        dbt-athena resolves its credentials through boto3 and optionally assumes an
+        IAM role. This method mirrors that resolution lazily so importing the dbt
+        integration does not require boto3. Every import, credential, and network
+        error is swallowed because account enrichment must never fail dbt or event
+        processing.
+        """
+        try:
+            import boto3  # type: ignore[import-not-found]
+        except Exception as error:
+            self.logger.debug(
+                "Skipping Athena Glue account lookup; boto3 is unavailable (%s).",
+                type(error).__name__,
+            )
+            return None
+
+        try:
+            region_name = profile.get("region_name")
+            session = boto3.session.Session(
+                aws_access_key_id=profile.get("aws_access_key_id"),
+                aws_secret_access_key=profile.get("aws_secret_access_key"),
+                aws_session_token=profile.get("aws_session_token"),
+                region_name=region_name,
+                profile_name=profile.get("aws_profile_name"),
+            )
+
+            role_arn = profile.get("assume_role_arn") or profile.get("role_arn")
+            if role_arn:
+                assume_role_kwargs = {
+                    "RoleArn": role_arn,
+                    "RoleSessionName": profile.get("assume_role_session_name") or "dbt-athena",
+                }
+                if profile.get("assume_role_external_id"):
+                    assume_role_kwargs["ExternalId"] = profile["assume_role_external_id"]
+                if profile.get("assume_role_duration_seconds") is not None:
+                    assume_role_kwargs["DurationSeconds"] = int(profile["assume_role_duration_seconds"])
+
+                assumed_role = session.client("sts").assume_role(**assume_role_kwargs)
+                credentials = assumed_role["Credentials"]
+                session = boto3.session.Session(
+                    aws_access_key_id=credentials["AccessKeyId"],
+                    aws_secret_access_key=credentials["SecretAccessKey"],
+                    aws_session_token=credentials["SessionToken"],
+                    region_name=region_name,
+                )
+
+            account_id = session.client("sts").get_caller_identity().get("Account")
+            if account_id is None or not str(account_id).strip():
+                return None
+            return str(account_id).strip()
+        except Exception as error:
+            self.logger.debug(
+                "Skipping Athena Glue account lookup after an AWS error (%s).",
+                type(error).__name__,
+            )
+            return None
+
+    def _extract_dataset_symlink_namespace(self, profile: dict) -> str | None:
+        if self.adapter_type != Adapter.ATHENA:
+            return None
+
+        # Avoid an AWS call when dbt already exposes the catalog account in the
+        # profile, but fall back to the effective credential identity for the
+        # common aws_profile_name/default credential-chain case.
+        account_id = self._extract_profile_aws_account_id(profile) or self._lookup_aws_account_id(profile)
+        if not account_id:
+            return None
+
+        return f"arn:aws:glue:{profile['region_name']}:{account_id}"
 
     def extract_namespace(self, profile: dict) -> str:
         """Extract namespace from profile's type"""

--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -197,8 +197,8 @@ class DbtArtifactProcessor:
         self.manifest_version = None
         self.adapter_type: Adapter | None = None
         # Set for adapters that can provide a stable catalog identifier in addition to
-        # the primary dataset namespace. For Athena, this is populated from the dbt
-        # profile's account ID or assume-role ARN; no AWS API call is made.
+        # the primary dataset namespace. For Athena, this is populated from the supported
+        # assume-role ARN or a best-effort STS lookup; lookup failures leave it unset.
         self.dataset_symlink_namespace: str | None = None
         # Populated by parse(); retained so manifest-declared exposures can be indexed
         # and attached to the datasets they depend on.
@@ -875,10 +875,10 @@ class DbtArtifactProcessor:
 
         dbt-athena identifies the catalog and Glue database separately in its
         manifest: ``database`` is the catalog (usually ``awsdatacatalog``) and
-        ``schema`` is the Glue database. The AWS account is only available to
-        this integration when dbt exposes it in the profile, either directly or
-        in an assume-role ARN. In all other cases the existing Athena identifier
-        is retained and no symlink is emitted.
+        ``schema`` is the Glue database. The AWS account is taken from the
+        supported ``assume_role_arn`` when available, or resolved with a
+        best-effort STS lookup. If neither path succeeds, the existing Athena
+        identifier is retained and no symlink is emitted.
         """
         if self.adapter_type != Adapter.ATHENA or not self.dataset_symlink_namespace:
             return None

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -195,15 +195,13 @@ def test_spark_namespace_separates_the_port(dbt_artifact_processor, profile, exp
 @pytest.mark.parametrize(
     "profile",
     [
-        {"region_name": "us-east-1", "account_id": "123456789012"},
         {
             "region_name": "us-east-1",
             "assume_role_arn": "arn:aws:iam::123456789012:role/dbt-athena",
         },
-        {"region_name": "us-east-1", "role_arn": "arn:aws:iam::123456789012:role/dbt-athena"},
     ],
 )
-def test_athena_dataset_symlink_uses_profile_account(dbt_artifact_processor, profile):
+def test_athena_dataset_symlink_uses_assume_role_account(dbt_artifact_processor, profile):
     dbt_artifact_processor.adapter_type = Adapter.ATHENA
     dbt_artifact_processor.extract_dataset_namespace(profile)
 

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -3,13 +3,15 @@
 
 
 import os
+import sys
+import types
 from unittest.mock import MagicMock
 
 import pytest
 from openlineage.client.facet_v2 import external_query_run, processing_engine_run
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import DbtRunRunFacet, DbtVersionRunFacet
-from openlineage.common.provider.dbt.processor import Adapter, DbtArtifactProcessor, DbtRunContext
+from openlineage.common.provider.dbt.processor import Adapter, DbtArtifactProcessor, DbtRunContext, ModelNode
 from openlineage.common.provider.dbt.utils import __version__ as openlineage_version
 from openlineage.common.provider.dbt.utils import get_dbt_profiles_dir
 
@@ -188,6 +190,105 @@ def test_spark_namespace_separates_the_port(dbt_artifact_processor, profile, exp
     dbt_artifact_processor.extract_dataset_namespace(profile)
 
     assert dbt_artifact_processor.dataset_namespace == expected
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        {"region_name": "us-east-1", "account_id": "123456789012"},
+        {
+            "region_name": "us-east-1",
+            "assume_role_arn": "arn:aws:iam::123456789012:role/dbt-athena",
+        },
+        {"region_name": "us-east-1", "role_arn": "arn:aws:iam::123456789012:role/dbt-athena"},
+    ],
+)
+def test_athena_dataset_symlink_uses_profile_account(dbt_artifact_processor, profile):
+    dbt_artifact_processor.adapter_type = Adapter.ATHENA
+    dbt_artifact_processor.extract_dataset_namespace(profile)
+
+    model = ModelNode(
+        type="model",
+        metadata_node={
+            "database": "awsdatacatalog",
+            "schema": "analytics",
+            "alias": "orders",
+        },
+    )
+
+    _, _, facets, _ = dbt_artifact_processor.extract_dataset_data(model, None)
+
+    assert facets["symlinks"].identifiers[0].namespace == "arn:aws:glue:us-east-1:123456789012"
+    assert facets["symlinks"].identifiers[0].name == "table/analytics/orders"
+    assert facets["symlinks"].identifiers[0].type == "TABLE"
+
+
+def test_athena_dataset_symlink_uses_source_name(dbt_artifact_processor):
+    dbt_artifact_processor.adapter_type = Adapter.ATHENA
+    dbt_artifact_processor.extract_dataset_namespace(
+        {"region_name": "us-east-1", "assume_role_arn": "arn:aws:iam::123456789012:role/dbt-athena"}
+    )
+
+    source = ModelNode(
+        type="source",
+        metadata_node={
+            "database": "awsdatacatalog",
+            "schema": "analytics",
+            "name": "raw_orders",
+        },
+    )
+
+    _, _, facets, _ = dbt_artifact_processor.extract_dataset_data(source, None)
+
+    assert facets["symlinks"].identifiers[0].name == "table/analytics/raw_orders"
+
+
+def test_athena_dataset_symlink_uses_effective_profile_credentials(monkeypatch, dbt_artifact_processor):
+    class FakeStsClient:
+        def get_caller_identity(self):
+            return {"Account": "123456789012"}
+
+    class FakeSession:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.instances.append(self)
+
+        def client(self, service_name):
+            assert service_name == "sts"
+            return FakeStsClient()
+
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.session = types.SimpleNamespace(Session=FakeSession)
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    dbt_artifact_processor.adapter_type = Adapter.ATHENA
+    dbt_artifact_processor.extract_dataset_namespace(
+        {"region_name": "us-east-1", "aws_profile_name": "production"}
+    )
+
+    assert dbt_artifact_processor.dataset_symlink_namespace == "arn:aws:glue:us-east-1:123456789012"
+    assert FakeSession.instances[0].kwargs["profile_name"] == "production"
+
+
+def test_athena_dataset_symlink_is_omitted_without_profile_account(monkeypatch, dbt_artifact_processor):
+    monkeypatch.setitem(sys.modules, "boto3", None)
+    dbt_artifact_processor.adapter_type = Adapter.ATHENA
+    dbt_artifact_processor.extract_dataset_namespace({"region_name": "us-east-1"})
+
+    model = ModelNode(
+        type="model",
+        metadata_node={
+            "database": "awsdatacatalog",
+            "schema": "analytics",
+            "alias": "orders",
+        },
+    )
+
+    _, _, facets, _ = dbt_artifact_processor.extract_dataset_data(model, None)
+
+    assert "symlinks" not in facets
 
 
 class TestGetDbtProfilesDir:


### PR DESCRIPTION
This change adds a Glue table symlink to datasets emitted by the dbt Athena integration. AWS Glue is used as data catalog for Athena datasets, which is the canonical identity for those datasets.

The existing Athena dataset identity remains primary, and the new `SymlinksDatasetFacet` identifies the same table with the namespace `arn:aws:glue:<region>:<account>` and the name `table/<database>/<table>`. The integration uses the manifest’s `schema` and the model’s `alias` or source’s `name`. It reads the account from the supported `assume_role_arn` when available; otherwise, it performs a best-effort STS `GetCallerIdentity` lookup using the dbt profile’s AWS credential settings.

The account lookup uses a lazy optional boto3 import and catches import, credential, role-assumption, and network errors, so failed AWS enrichment does not fail dbt processing. The symlink is omitted when the account cannot be resolved. The change covers model and source inputs and outputs, including test datasets, and adds tests for role ARN parsing, STS-based resolution, missing boto3, and missing account data.

### Checklist
- [x] AI was used in creating this PR
