### PR TITLE
client-java: add lineage compatibility converters

### DIFF
--- a/client/java/openlineage.example.yml
+++ b/client/java/openlineage.example.yml
@@ -1,3 +1,5 @@
 transport:
   type: http
   url: http://localhost:5000
+lineage:
+  compatibility: none

--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -60,7 +60,9 @@ public final class Clients {
     // ...
     OpenLineageClient.Builder builder = OpenLineageClient.builder();
 
-    builder.lineageCompatibility(openLineageConfig.getLineageConfig().getCompatibility());
+    Optional.ofNullable(openLineageConfig.getLineageConfig())
+        .map(LineageConfig::getCompatibility)
+        .ifPresent(builder::lineageCompatibility);
 
     if (openLineageConfig.getFacetsConfig() != null) {
       builder.disableFacets(openLineageConfig.getFacetsConfig().getEffectiveDisabledFacets());

--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -60,6 +60,8 @@ public final class Clients {
     // ...
     OpenLineageClient.Builder builder = OpenLineageClient.builder();
 
+    builder.lineageCompatibility(openLineageConfig.getLineageConfig().getCompatibility());
+
     if (openLineageConfig.getFacetsConfig() != null) {
       builder.disableFacets(openLineageConfig.getFacetsConfig().getEffectiveDisabledFacets());
     }

--- a/client/java/src/main/java/io/openlineage/client/LineageCompatibility.java
+++ b/client/java/src/main/java/io/openlineage/client/LineageCompatibility.java
@@ -1,0 +1,22 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Locale;
+
+/** Controls automatic translation between explicit lineage facets and legacy lineage fields. */
+public enum LineageCompatibility {
+  NONE,
+  LEGACY,
+  MODERN,
+  BOTH;
+
+  @JsonCreator
+  public static LineageCompatibility fromString(String value) {
+    return value == null ? null : valueOf(value.toUpperCase(Locale.ROOT));
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/LineageCompatibilityConverter.java
+++ b/client/java/src/main/java/io/openlineage/client/LineageCompatibilityConverter.java
@@ -1,0 +1,580 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openlineage.client.OpenLineage.JobEvent;
+import io.openlineage.client.OpenLineage.RunEvent;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Translates between explicit lineage facets and legacy inputs, outputs and column lineage. */
+final class LineageCompatibilityConverter {
+  private static final String DATASET = "DATASET";
+  private static final String LINEAGE_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/1-0-0/LineageFacet.json#/$defs/LineageJobFacet";
+  private static final String COLUMN_LINEAGE_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/1-2-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet";
+  private static final ObjectMapper MAPPER = OpenLineageClientUtils.newObjectMapper();
+
+  private LineageCompatibilityConverter() {}
+
+  static RunEvent convert(RunEvent event, LineageCompatibility compatibility) {
+    return convert(event, compatibility, RunEvent.class);
+  }
+
+  static JobEvent convert(JobEvent event, LineageCompatibility compatibility) {
+    return convert(event, compatibility, JobEvent.class);
+  }
+
+  private static <T> T convert(
+      T event, LineageCompatibility configuredCompatibility, Class<T> eventClass) {
+    LineageCompatibility compatibility =
+        configuredCompatibility == null ? LineageCompatibility.NONE : configuredCompatibility;
+    if (compatibility == LineageCompatibility.NONE) {
+      return event;
+    }
+
+    ObjectNode eventNode = MAPPER.valueToTree(event);
+    ObjectNode facets = getJobFacets(eventNode, false);
+    boolean hasLineage = facets != null && hasValue(facets, "lineage");
+    boolean changed;
+    switch (compatibility) {
+      case LEGACY:
+        changed = hasLineage && addLegacyLineage(eventNode, facets.get("lineage"));
+        break;
+      case MODERN:
+        changed = !hasLineage && addModernLineage(eventNode);
+        break;
+      case BOTH:
+        changed =
+            hasLineage
+                ? addLegacyLineage(eventNode, facets.get("lineage"))
+                : addModernLineage(eventNode);
+        break;
+      default:
+        changed = false;
+        break;
+    }
+
+    if (!changed) {
+      return event;
+    }
+    try {
+      return MAPPER.treeToValue(eventNode, eventClass);
+    } catch (JsonProcessingException e) {
+      throw new OpenLineageClientException("Unable to translate lineage compatibility fields", e);
+    }
+  }
+
+  /** Adds inputs, outputs and representable column lineage from a LineageJobFacet. */
+  private static boolean addLegacyLineage(ObjectNode event, JsonNode lineage) {
+    JsonNode entriesNode = lineage.get("entries");
+    if (!entriesNodeIsUsable(entriesNode)) {
+      return false;
+    }
+
+    ArrayNode inputs = arrayOrEmpty(event.get("inputs"));
+    ArrayNode outputs = arrayOrEmpty(event.get("outputs"));
+    Map<DatasetIdentifier, JsonNode> knownInputs = indexDatasets(inputs);
+    Map<DatasetIdentifier, List<ObjectNode>> knownOutputs = indexObjectDatasets(outputs);
+    Map<DatasetIdentifier, ObjectNode> generatedColumnLineage = new LinkedHashMap<>();
+    boolean changed = false;
+
+    for (JsonNode entryNode : entriesNode) {
+      if (!entryNode.isObject()) {
+        continue;
+      }
+      ObjectNode entry = (ObjectNode) entryNode;
+      DatasetIdentifier target = isDataset(entry) ? DatasetIdentifier.from(entry) : null;
+      if (target != null && !knownOutputs.containsKey(target)) {
+        ObjectNode output = datasetIdentity(entry);
+        outputs.add(output);
+        knownOutputs.computeIfAbsent(target, unused -> new ArrayList<>()).add(output);
+        changed = true;
+      }
+
+      changed |=
+          collectLegacyInputsAndDatasetLineage(
+              entry.get("inputs"), target, lineage, inputs, knownInputs, generatedColumnLineage);
+      if (target != null) {
+        changed |=
+            collectLegacyFieldLineage(
+                entry.get("fields"), target, lineage, inputs, knownInputs, generatedColumnLineage);
+      }
+    }
+
+    if (inputs.size() > 0 && !inputs.equals(event.get("inputs"))) {
+      event.set("inputs", inputs);
+    }
+    if (outputs.size() > 0 && !outputs.equals(event.get("outputs"))) {
+      event.set("outputs", outputs);
+    }
+
+    for (Map.Entry<DatasetIdentifier, ObjectNode> generated : generatedColumnLineage.entrySet()) {
+      List<ObjectNode> targetOutputs = knownOutputs.get(generated.getKey());
+      if (targetOutputs != null) {
+        changed |= mergeColumnLineage(targetOutputs, generated.getValue());
+      }
+    }
+    return changed;
+  }
+
+  private static boolean entriesNodeIsUsable(JsonNode entries) {
+    return entries != null && entries.isArray() && entries.size() > 0;
+  }
+
+  private static boolean collectLegacyInputsAndDatasetLineage(
+      JsonNode lineageInputs,
+      DatasetIdentifier target,
+      JsonNode lineage,
+      ArrayNode eventInputs,
+      Map<DatasetIdentifier, JsonNode> knownInputs,
+      Map<DatasetIdentifier, ObjectNode> generatedColumnLineage) {
+    if (lineageInputs == null || !lineageInputs.isArray()) {
+      return false;
+    }
+    boolean changed = false;
+    for (JsonNode inputNode : lineageInputs) {
+      if (!inputNode.isObject() || !isDataset(inputNode)) {
+        continue;
+      }
+      ObjectNode input = (ObjectNode) inputNode;
+      changed |= addLegacyInput(input, eventInputs, knownInputs);
+      if (target != null && hasValue(input, "field")) {
+        ObjectNode columnLineage =
+            generatedColumnLineage.computeIfAbsent(
+                target, unused -> newColumnLineageFacet(lineage));
+        changed |= appendUnique(array(columnLineage, "dataset"), toLegacyInputField(input));
+      }
+    }
+    return changed;
+  }
+
+  private static boolean collectLegacyFieldLineage(
+      JsonNode fieldsNode,
+      DatasetIdentifier target,
+      JsonNode lineage,
+      ArrayNode eventInputs,
+      Map<DatasetIdentifier, JsonNode> knownInputs,
+      Map<DatasetIdentifier, ObjectNode> generatedColumnLineage) {
+    if (fieldsNode == null || !fieldsNode.isObject()) {
+      return false;
+    }
+    boolean changed = false;
+    Iterator<Map.Entry<String, JsonNode>> fields = fieldsNode.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> field = fields.next();
+      JsonNode lineageInputs = field.getValue().get("inputs");
+      if (lineageInputs == null || !lineageInputs.isArray()) {
+        continue;
+      }
+      for (JsonNode inputNode : lineageInputs) {
+        if (!inputNode.isObject() || !isDataset(inputNode)) {
+          continue;
+        }
+        ObjectNode input = (ObjectNode) inputNode;
+        changed |= addLegacyInput(input, eventInputs, knownInputs);
+        if (hasValue(input, "field")) {
+          ObjectNode columnLineage =
+              generatedColumnLineage.computeIfAbsent(
+                  target, unused -> newColumnLineageFacet(lineage));
+          ObjectNode legacyField = object(object(columnLineage, "fields"), field.getKey());
+          changed |= appendUnique(array(legacyField, "inputFields"), toLegacyInputField(input));
+        }
+      }
+    }
+    return changed;
+  }
+
+  private static boolean addLegacyInput(
+      ObjectNode input, ArrayNode eventInputs, Map<DatasetIdentifier, JsonNode> knownInputs) {
+    DatasetIdentifier identifier = DatasetIdentifier.from(input);
+    if (identifier == null || knownInputs.containsKey(identifier)) {
+      return false;
+    }
+    ObjectNode legacyInput = datasetIdentity(input);
+    eventInputs.add(legacyInput);
+    knownInputs.put(identifier, legacyInput);
+    return true;
+  }
+
+  private static ObjectNode toLegacyInputField(ObjectNode input) {
+    ObjectNode legacyInput = datasetIdentity(input);
+    copyIfPresent(input, legacyInput, "field");
+    copyIfPresent(input, legacyInput, "transformations");
+    return legacyInput;
+  }
+
+  private static ObjectNode newColumnLineageFacet(JsonNode lineage) {
+    ObjectNode columnLineage = MAPPER.createObjectNode();
+    copyIfPresent(lineage, columnLineage, "_producer");
+    columnLineage.put("_schemaURL", COLUMN_LINEAGE_SCHEMA_URL);
+    columnLineage.set("fields", MAPPER.createObjectNode());
+    return columnLineage;
+  }
+
+  /** Adds a LineageJobFacet from legacy inputs, outputs and column lineage. */
+  private static boolean addModernLineage(ObjectNode event) {
+    JsonNode outputsNode = event.get("outputs");
+    if (outputsNode == null || !outputsNode.isArray() || outputsNode.size() == 0) {
+      return false;
+    }
+
+    ArrayNode legacyInputs = arrayOrEmpty(event.get("inputs"));
+    ArrayNode commonInputs = MAPPER.createArrayNode();
+    for (JsonNode input : legacyInputs) {
+      if (input.isObject()) {
+        appendUnique(commonInputs, toModernDatasetInput((ObjectNode) input));
+      }
+    }
+
+    Map<DatasetIdentifier, ObjectNode> entriesByTarget = new LinkedHashMap<>();
+    for (JsonNode outputNode : outputsNode) {
+      if (!outputNode.isObject()) {
+        continue;
+      }
+      ObjectNode output = (ObjectNode) outputNode;
+      DatasetIdentifier target = DatasetIdentifier.from(output);
+      if (target == null) {
+        continue;
+      }
+      ObjectNode entry = entriesByTarget.computeIfAbsent(target, unused -> newLineageEntry(output));
+      ArrayNode entryInputs = array(entry, "inputs");
+      appendUnique(entryInputs, commonInputs);
+      addModernColumnLineage(entry, getColumnLineage(output));
+    }
+
+    if (entriesByTarget.isEmpty()) {
+      return false;
+    }
+    ObjectNode lineage = MAPPER.createObjectNode();
+    copyIfPresent(event, lineage, "producer", "_producer");
+    lineage.put("_schemaURL", LINEAGE_SCHEMA_URL);
+    ArrayNode entries = MAPPER.createArrayNode();
+    entriesByTarget.values().forEach(entries::add);
+    lineage.set("entries", entries);
+    ObjectNode jobFacets = getJobFacets(event, true);
+    if (jobFacets == null) {
+      return false;
+    }
+    jobFacets.set("lineage", lineage);
+    return true;
+  }
+
+  private static ObjectNode newLineageEntry(ObjectNode output) {
+    ObjectNode entry = datasetIdentity(output);
+    entry.put("type", DATASET);
+    entry.set("inputs", MAPPER.createArrayNode());
+    return entry;
+  }
+
+  private static JsonNode getColumnLineage(ObjectNode output) {
+    JsonNode facets = output.get("facets");
+    if (facets == null || !facets.isObject()) {
+      return null;
+    }
+    JsonNode columnLineage = facets.get("columnLineage");
+    return columnLineage != null && columnLineage.isObject() ? columnLineage : null;
+  }
+
+  private static void addModernColumnLineage(ObjectNode entry, JsonNode columnLineage) {
+    if (columnLineage == null) {
+      return;
+    }
+    JsonNode datasetInputs = columnLineage.get("dataset");
+    if (datasetInputs != null && datasetInputs.isArray()) {
+      ArrayNode entryInputs = array(entry, "inputs");
+      for (JsonNode input : datasetInputs) {
+        if (input.isObject()) {
+          appendUnique(entryInputs, toModernInputField((ObjectNode) input));
+        }
+      }
+    }
+
+    JsonNode fieldsNode = columnLineage.get("fields");
+    if (fieldsNode == null || !fieldsNode.isObject()) {
+      return;
+    }
+    Iterator<Map.Entry<String, JsonNode>> fields = fieldsNode.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> field = fields.next();
+      JsonNode inputFields = field.getValue().get("inputFields");
+      if (inputFields == null || !inputFields.isArray()) {
+        continue;
+      }
+      ObjectNode modernField = object(object(entry, "fields"), field.getKey());
+      ArrayNode modernInputs = array(modernField, "inputs");
+      for (JsonNode input : inputFields) {
+        if (input.isObject()) {
+          appendUnique(modernInputs, toModernInputField((ObjectNode) input));
+        }
+      }
+    }
+  }
+
+  private static ObjectNode toModernDatasetInput(ObjectNode input) {
+    ObjectNode modernInput = datasetIdentity(input);
+    modernInput.put("type", DATASET);
+    return modernInput;
+  }
+
+  private static ObjectNode toModernInputField(ObjectNode input) {
+    ObjectNode modernInput = toModernDatasetInput(input);
+    copyIfPresent(input, modernInput, "field");
+    copyIfPresent(input, modernInput, "transformations");
+    return modernInput;
+  }
+
+  private static boolean mergeColumnLineage(List<ObjectNode> outputs, ObjectNode generated) {
+    List<ObjectNode> existingFacets = new ArrayList<>();
+    for (ObjectNode output : outputs) {
+      JsonNode existing = getColumnLineage(output);
+      if (existing != null) {
+        existingFacets.add((ObjectNode) existing);
+      }
+    }
+    if (existingFacets.isEmpty()) {
+      object(outputs.get(0), "facets").set("columnLineage", generated);
+      return true;
+    }
+
+    ObjectNode destination = existingFacets.get(0);
+    boolean changed = false;
+    JsonNode generatedDataset = generated.get("dataset");
+    if (generatedDataset != null && generatedDataset.isArray()) {
+      for (JsonNode input : generatedDataset) {
+        if (!containsDatasetInput(existingFacets, input)) {
+          array(destination, "dataset").add(input);
+          changed = true;
+        }
+      }
+    }
+
+    Iterator<Map.Entry<String, JsonNode>> generatedFields = generated.get("fields").fields();
+    while (generatedFields.hasNext()) {
+      Map.Entry<String, JsonNode> field = generatedFields.next();
+      JsonNode generatedInputs = field.getValue().get("inputFields");
+      if (generatedInputs != null && generatedInputs.isArray()) {
+        ObjectNode destinationField = findField(existingFacets, field.getKey());
+        for (JsonNode input : generatedInputs) {
+          if (!containsFieldInput(existingFacets, field.getKey(), input)) {
+            if (destinationField == null) {
+              destinationField = object(object(destination, "fields"), field.getKey());
+            }
+            array(destinationField, "inputFields").add(input);
+            changed = true;
+          }
+        }
+      }
+    }
+    return changed;
+  }
+
+  private static boolean containsDatasetInput(List<ObjectNode> facets, JsonNode input) {
+    for (ObjectNode facet : facets) {
+      JsonNode dataset = facet.get("dataset");
+      if (dataset != null && dataset.isArray() && contains((ArrayNode) dataset, input)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsFieldInput(
+      List<ObjectNode> facets, String fieldName, JsonNode input) {
+    for (ObjectNode facet : facets) {
+      ObjectNode field = findField(facet, fieldName);
+      if (field != null) {
+        JsonNode inputs = field.get("inputFields");
+        if (inputs != null && inputs.isArray() && contains((ArrayNode) inputs, input)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static ObjectNode findField(List<ObjectNode> facets, String fieldName) {
+    for (ObjectNode facet : facets) {
+      ObjectNode field = findField(facet, fieldName);
+      if (field != null) {
+        return field;
+      }
+    }
+    return null;
+  }
+
+  private static ObjectNode findField(ObjectNode facet, String fieldName) {
+    JsonNode fields = facet.get("fields");
+    if (fields == null || !fields.isObject()) {
+      return null;
+    }
+    JsonNode field = fields.get(fieldName);
+    return field != null && field.isObject() ? (ObjectNode) field : null;
+  }
+
+  private static ObjectNode getJobFacets(ObjectNode event, boolean create) {
+    JsonNode jobNode = event.get("job");
+    if (jobNode == null || !jobNode.isObject()) {
+      return null;
+    }
+    JsonNode facetsNode = jobNode.get("facets");
+    if (facetsNode != null && facetsNode.isObject()) {
+      return (ObjectNode) facetsNode;
+    }
+    if (!create) {
+      return null;
+    }
+    ObjectNode facets = MAPPER.createObjectNode();
+    ((ObjectNode) jobNode).set("facets", facets);
+    return facets;
+  }
+
+  private static Map<DatasetIdentifier, JsonNode> indexDatasets(ArrayNode datasets) {
+    Map<DatasetIdentifier, JsonNode> indexed = new LinkedHashMap<>();
+    for (JsonNode dataset : datasets) {
+      DatasetIdentifier identifier = DatasetIdentifier.from(dataset);
+      if (identifier != null) {
+        indexed.putIfAbsent(identifier, dataset);
+      }
+    }
+    return indexed;
+  }
+
+  private static Map<DatasetIdentifier, List<ObjectNode>> indexObjectDatasets(ArrayNode datasets) {
+    Map<DatasetIdentifier, List<ObjectNode>> indexed = new LinkedHashMap<>();
+    for (JsonNode dataset : datasets) {
+      DatasetIdentifier identifier = DatasetIdentifier.from(dataset);
+      if (identifier != null && dataset.isObject()) {
+        indexed.computeIfAbsent(identifier, unused -> new ArrayList<>()).add((ObjectNode) dataset);
+      }
+    }
+    return indexed;
+  }
+
+  private static ObjectNode datasetIdentity(JsonNode dataset) {
+    ObjectNode identity = MAPPER.createObjectNode();
+    copyIfPresent(dataset, identity, "namespace");
+    copyIfPresent(dataset, identity, "name");
+    return identity;
+  }
+
+  private static boolean isDataset(JsonNode node) {
+    JsonNode type = node.get("type");
+    return type != null && DATASET.equals(type.asText());
+  }
+
+  private static boolean hasValue(JsonNode node, String field) {
+    JsonNode value = node.get(field);
+    return value != null && !value.isNull();
+  }
+
+  private static ArrayNode arrayOrEmpty(JsonNode node) {
+    return node != null && node.isArray() ? (ArrayNode) node : MAPPER.createArrayNode();
+  }
+
+  private static ArrayNode array(ObjectNode parent, String field) {
+    JsonNode value = parent.get(field);
+    if (value != null && value.isArray()) {
+      return (ArrayNode) value;
+    }
+    ArrayNode array = MAPPER.createArrayNode();
+    parent.set(field, array);
+    return array;
+  }
+
+  private static ObjectNode object(ObjectNode parent, String field) {
+    JsonNode value = parent.get(field);
+    if (value != null && value.isObject()) {
+      return (ObjectNode) value;
+    }
+    ObjectNode object = MAPPER.createObjectNode();
+    parent.set(field, object);
+    return object;
+  }
+
+  private static boolean appendUnique(ArrayNode target, ArrayNode values) {
+    boolean changed = false;
+    for (JsonNode value : values) {
+      changed |= appendUnique(target, value);
+    }
+    return changed;
+  }
+
+  private static boolean appendUnique(ArrayNode target, JsonNode value) {
+    if (contains(target, value)) {
+      return false;
+    }
+    target.add(value);
+    return true;
+  }
+
+  private static boolean contains(ArrayNode values, JsonNode candidate) {
+    for (JsonNode value : values) {
+      if (value.equals(candidate)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void copyIfPresent(JsonNode source, ObjectNode target, String field) {
+    copyIfPresent(source, target, field, field);
+  }
+
+  private static void copyIfPresent(
+      JsonNode source, ObjectNode target, String sourceField, String targetField) {
+    JsonNode value = source.get(sourceField);
+    if (value != null && !value.isNull()) {
+      target.set(targetField, value.deepCopy());
+    }
+  }
+
+  private static final class DatasetIdentifier {
+    private final String namespace;
+    private final String name;
+
+    private DatasetIdentifier(String namespace, String name) {
+      this.namespace = namespace;
+      this.name = name;
+    }
+
+    private static DatasetIdentifier from(JsonNode dataset) {
+      JsonNode namespace = dataset.get("namespace");
+      JsonNode name = dataset.get("name");
+      if (namespace == null || namespace.isNull() || name == null || name.isNull()) {
+        return null;
+      }
+      return new DatasetIdentifier(namespace.asText(), name.asText());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof DatasetIdentifier)) {
+        return false;
+      }
+      DatasetIdentifier that = (DatasetIdentifier) other;
+      return Objects.equals(namespace, that.namespace) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(namespace, name);
+    }
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/LineageCompatibilityConverter.java
+++ b/client/java/src/main/java/io/openlineage/client/LineageCompatibilityConverter.java
@@ -13,11 +13,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openlineage.client.OpenLineage.JobEvent;
 import io.openlineage.client.OpenLineage.RunEvent;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /** Translates between explicit lineage facets and legacy inputs, outputs and column lineage. */
 final class LineageCompatibilityConverter {
@@ -240,6 +242,16 @@ final class LineageCompatibilityConverter {
       }
     }
 
+    Set<DatasetIdentifier> targetsWithColumnLineage = new HashSet<>();
+    for (JsonNode outputNode : outputsNode) {
+      if (outputNode.isObject() && getColumnLineage((ObjectNode) outputNode) != null) {
+        DatasetIdentifier target = DatasetIdentifier.from(outputNode);
+        if (target != null) {
+          targetsWithColumnLineage.add(target);
+        }
+      }
+    }
+
     Map<DatasetIdentifier, ObjectNode> entriesByTarget = new LinkedHashMap<>();
     for (JsonNode outputNode : outputsNode) {
       if (!outputNode.isObject()) {
@@ -251,9 +263,12 @@ final class LineageCompatibilityConverter {
         continue;
       }
       ObjectNode entry = entriesByTarget.computeIfAbsent(target, unused -> newLineageEntry(output));
-      ArrayNode entryInputs = array(entry, "inputs");
-      appendUnique(entryInputs, commonInputs);
-      addModernColumnLineage(entry, getColumnLineage(output));
+      JsonNode columnLineage = getColumnLineage(output);
+      if (!targetsWithColumnLineage.contains(target)) {
+        ArrayNode entryInputs = array(entry, "inputs");
+        appendUnique(entryInputs, commonInputs);
+      }
+      addModernColumnLineage(entry, columnLineage);
     }
 
     if (entriesByTarget.isEmpty()) {

--- a/client/java/src/main/java/io/openlineage/client/LineageConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/LineageConfig.java
@@ -1,0 +1,35 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/** Configuration for automatic lineage compatibility translation. */
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class LineageConfig implements MergeConfig<LineageConfig> {
+  private LineageCompatibility compatibility;
+
+  /**
+   * Returns the configured translation mode, defaulting to {@link LineageCompatibility#NONE}.
+   *
+   * @return the effective translation mode
+   */
+  public LineageCompatibility getCompatibility() {
+    return Optional.ofNullable(compatibility).orElse(LineageCompatibility.NONE);
+  }
+
+  @Override
+  public LineageConfig mergeWithNonNull(LineageConfig other) {
+    return new LineageConfig(mergePropertyWith(compatibility, other.compatibility));
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -29,6 +29,7 @@ public final class OpenLineageClient implements AutoCloseable {
   final Optional<CircuitBreaker> circuitBreaker;
   final MeterRegistry meterRegistry;
   final String[] disabledFacets;
+  final LineageCompatibility lineageCompatibility;
 
   Counter emitStart;
   Counter emitComplete;
@@ -53,8 +54,19 @@ public final class OpenLineageClient implements AutoCloseable {
       CircuitBreaker circuitBreaker,
       MeterRegistry meterRegistry,
       String... disabledFacets) {
+    this(transport, circuitBreaker, meterRegistry, disabledFacets, LineageCompatibility.NONE);
+  }
+
+  private OpenLineageClient(
+      @NonNull final Transport transport,
+      CircuitBreaker circuitBreaker,
+      MeterRegistry meterRegistry,
+      String[] disabledFacets,
+      LineageCompatibility lineageCompatibility) {
     this.transport = transport;
     this.disabledFacets = Arrays.copyOf(disabledFacets, disabledFacets.length);
+    this.lineageCompatibility =
+        lineageCompatibility == null ? LineageCompatibility.NONE : lineageCompatibility;
     this.circuitBreaker = Optional.ofNullable(circuitBreaker);
     if (meterRegistry == null) {
       this.meterRegistry = MicrometerProvider.getMeterRegistry();
@@ -73,7 +85,9 @@ public final class OpenLineageClient implements AutoCloseable {
    * @param runEvent The run event to emit.
    */
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
-    emitRunEvent(runEvent, () -> transport.emit(runEvent));
+    OpenLineage.RunEvent translated =
+        LineageCompatibilityConverter.convert(runEvent, lineageCompatibility);
+    emitRunEvent(translated, () -> transport.emit(translated));
   }
 
   /**
@@ -86,7 +100,9 @@ public final class OpenLineageClient implements AutoCloseable {
    * @param timeout Maximum time to wait for transports that support bounded delivery.
    */
   public void emit(@NonNull OpenLineage.RunEvent runEvent, @NonNull Duration timeout) {
-    emitRunEvent(runEvent, () -> transport.emit(runEvent, timeout));
+    OpenLineage.RunEvent translated =
+        LineageCompatibilityConverter.convert(runEvent, lineageCompatibility);
+    emitRunEvent(translated, () -> transport.emit(translated, timeout));
   }
 
   private void emitRunEvent(@NonNull OpenLineage.RunEvent runEvent, Runnable emit) {
@@ -137,9 +153,12 @@ public final class OpenLineageClient implements AutoCloseable {
    * @param jobEvent The job event to emit.
    */
   public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
+    OpenLineage.JobEvent translated =
+        LineageCompatibilityConverter.convert(jobEvent, lineageCompatibility);
     if (log.isDebugEnabled()) {
       log.debug(
-          "OpenLineageClient will emit lineage event: {}", OpenLineageClientUtils.toJson(jobEvent));
+          "OpenLineageClient will emit lineage event: {}",
+          OpenLineageClientUtils.toJson(translated));
     }
     if (circuitBreaker.isPresent() && circuitBreaker.get().currentState().isClosed()) {
       engagedCircuitBreaker.set(1);
@@ -149,7 +168,7 @@ public final class OpenLineageClient implements AutoCloseable {
       engagedCircuitBreaker.set(0);
     }
     emitStart.increment();
-    emitTime.record(() -> transport.emit(jobEvent));
+    emitTime.record(() -> transport.emit(translated));
     emitComplete.increment();
   }
 
@@ -210,10 +229,12 @@ public final class OpenLineageClient implements AutoCloseable {
     private String[] disabledFacets;
     private CircuitBreaker circuitBreaker;
     private MeterRegistry meterRegistry;
+    private LineageCompatibility lineageCompatibility;
 
     private Builder() {
       this.transport = DEFAULT_TRANSPORT;
       disabledFacets = new String[] {};
+      lineageCompatibility = LineageCompatibility.NONE;
     }
 
     public Builder transport(@NonNull Transport transport) {
@@ -236,12 +257,18 @@ public final class OpenLineageClient implements AutoCloseable {
       return this;
     }
 
+    public Builder lineageCompatibility(@NonNull LineageCompatibility lineageCompatibility) {
+      this.lineageCompatibility = lineageCompatibility;
+      return this;
+    }
+
     /**
      * @return an {@link OpenLineageClient} object with the properties of this {@link
      *     OpenLineageClient.Builder}.
      */
     public OpenLineageClient build() {
-      return new OpenLineageClient(transport, circuitBreaker, meterRegistry, disabledFacets);
+      return new OpenLineageClient(
+          transport, circuitBreaker, meterRegistry, disabledFacets, lineageCompatibility);
     }
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
@@ -14,7 +14,6 @@ import io.openlineage.client.run.RunConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -29,7 +28,6 @@ import lombok.ToString;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @ToString
 public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConfig<T> {
   @JsonProperty("transport")
@@ -53,6 +51,55 @@ public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConf
   @JsonProperty("job")
   protected JobConfig jobConfig;
 
+  @JsonProperty("lineage")
+  protected LineageConfig lineageConfig;
+
+  /** Preserves the existing constructor used by integration-specific configuration classes. */
+  public OpenLineageConfig(
+      TransportConfig transportConfig,
+      FacetsConfig facetsConfig,
+      DatasetConfig datasetConfig,
+      CircuitBreakerConfig circuitBreaker,
+      Map<String, Object> metricsConfig,
+      RunConfig runConfig,
+      JobConfig jobConfig) {
+    this(
+        transportConfig,
+        facetsConfig,
+        datasetConfig,
+        circuitBreaker,
+        metricsConfig,
+        runConfig,
+        jobConfig,
+        null);
+  }
+
+  public OpenLineageConfig(
+      TransportConfig transportConfig,
+      FacetsConfig facetsConfig,
+      DatasetConfig datasetConfig,
+      CircuitBreakerConfig circuitBreaker,
+      Map<String, Object> metricsConfig,
+      RunConfig runConfig,
+      JobConfig jobConfig,
+      LineageConfig lineageConfig) {
+    this.transportConfig = transportConfig;
+    this.facetsConfig = facetsConfig;
+    this.datasetConfig = datasetConfig;
+    this.circuitBreaker = circuitBreaker;
+    this.metricsConfig = metricsConfig;
+    this.runConfig = runConfig;
+    this.jobConfig = jobConfig;
+    this.lineageConfig = lineageConfig;
+  }
+
+  public LineageConfig getLineageConfig() {
+    if (lineageConfig == null) {
+      lineageConfig = new LineageConfig();
+    }
+    return lineageConfig;
+  }
+
   /**
    * Overwrites existing object with properties of other config entries whenever they're present.
    *
@@ -68,6 +115,7 @@ public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConf
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
         mergePropertyWith(metricsConfig, other.metricsConfig),
         mergePropertyWith(runConfig, other.runConfig),
-        mergePropertyWith(jobConfig, other.jobConfig));
+        mergePropertyWith(jobConfig, other.jobConfig),
+        mergePropertyWith(lineageConfig, other.lineageConfig));
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -7,6 +7,7 @@ package io.openlineage.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -165,6 +166,16 @@ class ConfigTest {
     assertThat(OpenLineageClient.builder().build())
         .extracting("lineageCompatibility")
         .isEqualTo(LineageCompatibility.NONE);
+  }
+
+  @Test
+  void testMissingLineageConfigDefaultsToNone() {
+    OpenLineageConfig config = mock(OpenLineageConfig.class);
+    when(config.getTransportConfig()).thenReturn(new ConsoleConfig());
+
+    OpenLineageClient client = Clients.newClient(config);
+
+    assertThat(client.lineageCompatibility).isEqualTo(LineageCompatibility.NONE);
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -33,10 +33,12 @@ import io.openlineage.client.transports.NoopTransport;
 import io.openlineage.client.transports.TransformTransport;
 import io.openlineage.client.transports.Transport;
 import io.openlineage.client.utils.TagField;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -142,6 +144,56 @@ class ConfigTest {
       OpenLineageClient client = Clients.newClient();
       assertThat(client.transport).isInstanceOf(ConsoleTransport.class);
     }
+  }
+
+  @Test
+  void testLineageCompatibilityConfigFromYaml() {
+    OpenLineageConfig config =
+        OpenLineageClientUtils.loadOpenLineageConfigYaml(
+            new TestConfigPathProvider("config/lineage.yaml"),
+            new TypeReference<OpenLineageConfig>() {});
+    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider("config/lineage.yaml"));
+
+    assertThat(config.getLineageConfig().getCompatibility()).isEqualTo(LineageCompatibility.LEGACY);
+    assertThat(client.lineageCompatibility).isEqualTo(LineageCompatibility.LEGACY);
+  }
+
+  @Test
+  void testLineageCompatibilityDefaultsToNone() {
+    assertThat(new OpenLineageConfig().getLineageConfig().getCompatibility())
+        .isEqualTo(LineageCompatibility.NONE);
+    assertThat(OpenLineageClient.builder().build())
+        .extracting("lineageCompatibility")
+        .isEqualTo(LineageCompatibility.NONE);
+  }
+
+  @Test
+  void testLoadLineageCompatibilityFromEnvVars() {
+    try (MockedStatic mocked = mockStatic(Environment.class)) {
+      when(Environment.getAllEnvironmentVariables())
+          .thenReturn(
+              Map.of(
+                  "OPENLINEAGE__TRANSPORT__TYPE",
+                  "console",
+                  "OPENLINEAGE__LINEAGE__COMPATIBILITY",
+                  "modern"));
+
+      OpenLineageClient client = Clients.newClient();
+
+      assertThat(client.lineageCompatibility).isEqualTo(LineageCompatibility.MODERN);
+    }
+  }
+
+  @Test
+  void testRejectInvalidLineageCompatibility() {
+    String yaml = "lineage:\n  compatibility: invalid\n";
+
+    assertThrows(
+        OpenLineageClientException.class,
+        () ->
+            OpenLineageClientUtils.loadOpenLineageConfigYaml(
+                new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)),
+                new TypeReference<OpenLineageConfig>() {}));
   }
 
   @Test
@@ -301,6 +353,18 @@ class ConfigTest {
     OpenLineageConfig config = (OpenLineageConfig) base.mergeWith(overwrite);
     assertThat(config.getMetricsConfig()).hasSize(1);
     assertThat(config.getTransportConfig()).isInstanceOf(ConsoleConfig.class);
+  }
+
+  @Test
+  void testOverwriteLineageCompatibilityConfig() {
+    OpenLineageConfig base = new OpenLineageConfig();
+    OpenLineageConfig overwrite = new OpenLineageConfig();
+    base.setLineageConfig(new LineageConfig(LineageCompatibility.LEGACY));
+    overwrite.setLineageConfig(new LineageConfig(LineageCompatibility.MODERN));
+
+    OpenLineageConfig config = (OpenLineageConfig) base.mergeWith(overwrite);
+
+    assertThat(config.getLineageConfig().getCompatibility()).isEqualTo(LineageCompatibility.MODERN);
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/LineageCompatibilityConverterTest.java
+++ b/client/java/src/test/java/io/openlineage/client/LineageCompatibilityConverterTest.java
@@ -1,0 +1,244 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openlineage.client.OpenLineage.JobEvent;
+import io.openlineage.client.OpenLineage.RunEvent;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class LineageCompatibilityConverterTest {
+  private static final ObjectMapper MAPPER = OpenLineageClientUtils.newObjectMapper();
+
+  @Test
+  @SneakyThrows
+  void legacyModeCreatesLegacyDatasetsAndRepresentableColumnLineage() {
+    RunEvent original =
+        runEvent(
+            "{\"lineage\":{"
+                + "\"_producer\":\"https://lineage-producer.example\","
+                + "\"entries\":["
+                + "{\"namespace\":\"out\",\"name\":\"orders\",\"type\":\"DATASET\","
+                + "\"inputs\":["
+                + datasetInput("in", "raw", null)
+                + ","
+                + datasetInput("in", "raw", "filter_id")
+                + ","
+                + "{\"namespace\":\"jobs\",\"name\":\"source\",\"type\":\"JOB\"}],"
+                + "\"fields\":{\"id\":{\"inputs\":["
+                + transformedDatasetInput("in", "raw", "source_id")
+                + ","
+                + "{\"namespace\":\"jobs\",\"name\":\"source\",\"type\":\"JOB\"}]}}},"
+                + "{\"namespace\":\"out\",\"name\":\"orders\",\"type\":\"DATASET\","
+                + "\"inputs\":["
+                + datasetInput("in", "secondary", null)
+                + "]},"
+                + "{\"namespace\":\"jobs\",\"name\":\"target\",\"type\":\"JOB\","
+                + "\"inputs\":["
+                + datasetInput("in", "job-source", null)
+                + "]}]}}",
+            "[]",
+            "[{\"namespace\":\"out\",\"name\":\"orders\"}]");
+    JsonNode originalJson = MAPPER.valueToTree(original);
+
+    RunEvent converted =
+        LineageCompatibilityConverter.convert(original, LineageCompatibility.LEGACY);
+    JsonNode convertedJson = MAPPER.valueToTree(converted);
+
+    assertThat(convertedJson.get("inputs"))
+        .isEqualTo(
+            MAPPER.readTree(
+                "[{\"namespace\":\"in\",\"name\":\"raw\"},"
+                    + "{\"namespace\":\"in\",\"name\":\"secondary\"},"
+                    + "{\"namespace\":\"in\",\"name\":\"job-source\"}]"));
+    assertThat(convertedJson.get("outputs")).hasSize(1);
+
+    JsonNode columnLineage = convertedJson.at("/outputs/0/facets/columnLineage");
+    assertThat(columnLineage.get("_producer").asText())
+        .isEqualTo("https://lineage-producer.example");
+    assertThat(columnLineage.get("_schemaURL").asText()).contains("ColumnLineageDatasetFacet");
+    assertThat(columnLineage.get("dataset"))
+        .isEqualTo(
+            MAPPER.readTree("[{\"namespace\":\"in\",\"name\":\"raw\",\"field\":\"filter_id\"}]"));
+    assertThat(columnLineage.at("/fields/id/inputFields/0/field").asText()).isEqualTo("source_id");
+    assertThat(columnLineage.at("/fields/id/inputFields/0/transformations/0/subtype").asText())
+        .isEqualTo("IDENTITY");
+    assertThat(originalJson).isEqualTo(MAPPER.valueToTree(original));
+    JsonNode convertedAgain =
+        MAPPER.valueToTree(
+            LineageCompatibilityConverter.convert(converted, LineageCompatibility.LEGACY));
+    assertThat(convertedAgain).isEqualTo(convertedJson);
+  }
+
+  @Test
+  @SneakyThrows
+  void legacyModeMergesWithoutOverwritingProducerProvidedColumnLineage() {
+    String modernInput = datasetInput("in", "raw", "source_id");
+    String existingInput = "{\"namespace\":\"in\",\"name\":\"existing\",\"field\":\"existing_id\"}";
+    RunEvent event =
+        runEvent(
+            "{\"lineage\":{\"_producer\":\"https://lineage-producer.example\","
+                + "\"entries\":[{\"namespace\":\"out\",\"name\":\"orders\","
+                + "\"type\":\"DATASET\",\"inputs\":[],\"fields\":{\"id\":{\"inputs\":["
+                + modernInput
+                + "]}}}]}}",
+            "[]",
+            "[{\"namespace\":\"out\",\"name\":\"orders\",\"facets\":{"
+                + "\"columnLineage\":{\"_producer\":\"https://existing-producer.example\","
+                + "\"fields\":{\"id\":{\"inputFields\":["
+                + existingInput
+                + "]}}}}}]");
+
+    JsonNode converted =
+        MAPPER.valueToTree(
+            LineageCompatibilityConverter.convert(event, LineageCompatibility.LEGACY));
+    JsonNode columnLineage = converted.at("/outputs/0/facets/columnLineage");
+
+    assertThat(columnLineage.get("_producer").asText())
+        .isEqualTo("https://existing-producer.example");
+    assertThat(columnLineage.at("/fields/id/inputFields"))
+        .isEqualTo(MAPPER.readTree("[" + existingInput + "," + legacyInput(modernInput) + "]"));
+  }
+
+  @Test
+  @SneakyThrows
+  void modernModeCreatesAndMergesEntriesFromLegacyLineage() {
+    RunEvent original =
+        runEvent(
+            "{}",
+            "[{\"namespace\":\"in\",\"name\":\"raw\"},"
+                + "{\"namespace\":\"in\",\"name\":\"lookup\"}]",
+            "[{\"namespace\":\"out\",\"name\":\"orders\",\"facets\":{"
+                + "\"columnLineage\":{\"fields\":{\"id\":{\"inputFields\":["
+                + transformedLegacyInput("in", "raw", "source_id")
+                + "]}},\"dataset\":["
+                + transformedLegacyInput("in", "raw", "filter_id")
+                + "]}}},"
+                + "{\"namespace\":\"out\",\"name\":\"report\"},"
+                + "{\"namespace\":\"out\",\"name\":\"orders\",\"facets\":{"
+                + "\"columnLineage\":{\"fields\":{\"id\":{\"inputFields\":["
+                + legacyInputField("in", "lookup", "lookup_id")
+                + "]}}}}}]");
+    JsonNode originalJson = MAPPER.valueToTree(original);
+
+    RunEvent converted =
+        LineageCompatibilityConverter.convert(original, LineageCompatibility.MODERN);
+    JsonNode convertedJson = MAPPER.valueToTree(converted);
+    JsonNode lineage = convertedJson.at("/job/facets/lineage");
+
+    assertThat(lineage.get("_producer").asText()).isEqualTo("https://producer.example");
+    assertThat(lineage.get("entries")).hasSize(2);
+    assertThat(lineage.at("/entries/0/name").asText()).isEqualTo("orders");
+    assertThat(lineage.at("/entries/1/name").asText()).isEqualTo("report");
+    assertThat(lineage.at("/entries/0/inputs")).hasSize(3);
+    assertThat(lineage.at("/entries/0/inputs/0/field").isMissingNode()).isTrue();
+    assertThat(lineage.at("/entries/0/inputs/2/field").asText()).isEqualTo("filter_id");
+    assertThat(lineage.at("/entries/0/fields/id/inputs")).hasSize(2);
+    assertThat(lineage.at("/entries/0/fields/id/inputs/0/field").asText()).isEqualTo("source_id");
+    assertThat(lineage.at("/entries/0/fields/id/inputs/1/field").asText()).isEqualTo("lookup_id");
+    assertThat(lineage.at("/entries/0/fields/id/inputs/0/transformations/0/type").asText())
+        .isEqualTo("DIRECT");
+    assertThat(lineage.at("/entries/1/inputs")).hasSize(2);
+    assertThat(originalJson).isEqualTo(MAPPER.valueToTree(original));
+
+    RunEvent convertedAgain =
+        LineageCompatibilityConverter.convert(converted, LineageCompatibility.BOTH);
+    JsonNode convertedAgainJson = MAPPER.valueToTree(convertedAgain);
+    assertThat(convertedAgainJson).isEqualTo(convertedJson);
+  }
+
+  @Test
+  void modernModeSupportsJobEvents() {
+    JobEvent event =
+        jobEvent(
+            "{}",
+            "[{\"namespace\":\"in\",\"name\":\"raw\"}]",
+            "[{\"namespace\":\"out\",\"name\":\"orders\"}]");
+
+    JobEvent converted = LineageCompatibilityConverter.convert(event, LineageCompatibility.MODERN);
+
+    assertThat(MAPPER.valueToTree(converted).at("/job/facets/lineage/entries")).hasSize(1);
+  }
+
+  @Test
+  void translationModesDoNotReplaceProducerProvidedLineageOrCreateSinks() {
+    RunEvent modernEvent =
+        runEvent(
+            "{\"lineage\":{\"entries\":[]}}",
+            "[]",
+            "[{\"namespace\":\"out\",\"name\":\"orders\"}]");
+    RunEvent sinkEvent = runEvent("{}", "[]", "[]");
+
+    assertThat(LineageCompatibilityConverter.convert(modernEvent, LineageCompatibility.MODERN))
+        .isSameAs(modernEvent);
+    assertThat(LineageCompatibilityConverter.convert(sinkEvent, LineageCompatibility.MODERN))
+        .isSameAs(sinkEvent);
+    assertThat(LineageCompatibilityConverter.convert(modernEvent, LineageCompatibility.NONE))
+        .isSameAs(modernEvent);
+  }
+
+  @SneakyThrows
+  private static RunEvent runEvent(String jobFacets, String inputs, String outputs) {
+    return MAPPER.readValue(
+        "{\"eventTime\":\"2026-08-18T10:00:00Z\","
+            + "\"producer\":\"https://producer.example\",\"eventType\":\"COMPLETE\","
+            + "\"run\":{\"runId\":\"11111111-1111-1111-1111-111111111111\"},"
+            + "\"job\":{\"namespace\":\"jobs\",\"name\":\"example\",\"facets\":"
+            + jobFacets
+            + "},\"inputs\":"
+            + inputs
+            + ",\"outputs\":"
+            + outputs
+            + "}",
+        RunEvent.class);
+  }
+
+  @SneakyThrows
+  private static JobEvent jobEvent(String jobFacets, String inputs, String outputs) {
+    return MAPPER.readValue(
+        "{\"eventTime\":\"2026-08-18T10:00:00Z\","
+            + "\"producer\":\"https://producer.example\","
+            + "\"job\":{\"namespace\":\"jobs\",\"name\":\"example\",\"facets\":"
+            + jobFacets
+            + "},\"inputs\":"
+            + inputs
+            + ",\"outputs\":"
+            + outputs
+            + "}",
+        JobEvent.class);
+  }
+
+  private static String datasetInput(String namespace, String name, String field) {
+    return "{\"namespace\":\""
+        + namespace
+        + "\",\"name\":\""
+        + name
+        + "\",\"type\":\"DATASET\""
+        + (field == null ? "" : ",\"field\":\"" + field + "\"")
+        + "}";
+  }
+
+  private static String transformedDatasetInput(String namespace, String name, String field) {
+    return datasetInput(namespace, name, field)
+        .replace("}", ",\"transformations\":[{\"type\":\"DIRECT\",\"subtype\":\"IDENTITY\"}]}");
+  }
+
+  private static String legacyInput(String modernInput) {
+    return modernInput.replace(",\"type\":\"DATASET\"", "");
+  }
+
+  private static String legacyInputField(String namespace, String name, String field) {
+    return legacyInput(datasetInput(namespace, name, field));
+  }
+
+  private static String transformedLegacyInput(String namespace, String name, String field) {
+    return legacyInput(transformedDatasetInput(namespace, name, field));
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/LineageCompatibilityConverterTest.java
+++ b/client/java/src/test/java/io/openlineage/client/LineageCompatibilityConverterTest.java
@@ -137,9 +137,8 @@ class LineageCompatibilityConverterTest {
     assertThat(lineage.get("entries")).hasSize(2);
     assertThat(lineage.at("/entries/0/name").asText()).isEqualTo("orders");
     assertThat(lineage.at("/entries/1/name").asText()).isEqualTo("report");
-    assertThat(lineage.at("/entries/0/inputs")).hasSize(3);
-    assertThat(lineage.at("/entries/0/inputs/0/field").isMissingNode()).isTrue();
-    assertThat(lineage.at("/entries/0/inputs/2/field").asText()).isEqualTo("filter_id");
+    assertThat(lineage.at("/entries/0/inputs")).hasSize(1);
+    assertThat(lineage.at("/entries/0/inputs/0/field").asText()).isEqualTo("filter_id");
     assertThat(lineage.at("/entries/0/fields/id/inputs")).hasSize(2);
     assertThat(lineage.at("/entries/0/fields/id/inputs/0/field").asText()).isEqualTo("source_id");
     assertThat(lineage.at("/entries/0/fields/id/inputs/1/field").asText()).isEqualTo("lookup_id");
@@ -152,6 +151,34 @@ class LineageCompatibilityConverterTest {
         LineageCompatibilityConverter.convert(converted, LineageCompatibility.BOTH);
     JsonNode convertedAgainJson = MAPPER.valueToTree(convertedAgain);
     assertThat(convertedAgainJson).isEqualTo(convertedJson);
+  }
+
+  @Test
+  @SneakyThrows
+  void modernModeDoesNotAddCartesianInputsToOutputsWithColumnLineage() {
+    RunEvent event =
+        runEvent(
+            "{}",
+            "[{\"namespace\":\"in\",\"name\":\"a\"}," + "{\"namespace\":\"in\",\"name\":\"b\"}]",
+            "[{\"namespace\":\"out\",\"name\":\"c\",\"facets\":{"
+                + "\"columnLineage\":{\"fields\":{\"id\":{\"inputFields\":["
+                + legacyInputField("in", "a", "id")
+                + "]}}}}},"
+                + "{\"namespace\":\"out\",\"name\":\"d\",\"facets\":{"
+                + "\"columnLineage\":{\"fields\":{\"id\":{\"inputFields\":["
+                + legacyInputField("in", "b", "id")
+                + "]}}}}},"
+                + "{\"namespace\":\"out\",\"name\":\"c\"}]");
+
+    JsonNode lineage =
+        MAPPER
+            .valueToTree(LineageCompatibilityConverter.convert(event, LineageCompatibility.MODERN))
+            .at("/job/facets/lineage");
+
+    assertThat(lineage.at("/entries/0/inputs")).isEqualTo(MAPPER.createArrayNode());
+    assertThat(lineage.at("/entries/0/fields/id/inputs/0/name").asText()).isEqualTo("a");
+    assertThat(lineage.at("/entries/1/inputs")).isEqualTo(MAPPER.createArrayNode());
+    assertThat(lineage.at("/entries/1/fields/id/inputs/0/name").asText()).isEqualTo("b");
   }
 
   @Test

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageClientTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageClientTest.java
@@ -22,8 +22,13 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.circuitBreaker.CircuitBreaker;
 import io.openlineage.client.circuitBreaker.CircuitBreakerState;
 import io.openlineage.client.transports.Transport;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.UUID;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class OpenLineageClientTest {
 
@@ -47,6 +52,33 @@ class OpenLineageClientTest {
     OpenLineage.JobEvent jobEvent = mock(JobEvent.class);
     client.emit(jobEvent);
     verify(transport, times(1)).emit(jobEvent);
+  }
+
+  @Test
+  void testTranslatesBeforeEmittingWithoutMutatingOriginal() {
+    OpenLineage openLineage = new OpenLineage(URI.create("https://producer.example"));
+    OpenLineage.Job job =
+        openLineage.newJob("jobs", "example", openLineage.newJobFacetsBuilder().build());
+    OpenLineage.RunEvent event =
+        openLineage.newRunEvent(
+            ZonedDateTime.parse("2026-08-18T10:00:00Z"),
+            RunEvent.EventType.COMPLETE,
+            openLineage.newRun(UUID.randomUUID(), null),
+            job,
+            Collections.emptyList(),
+            Collections.singletonList(openLineage.newOutputDataset("out", "orders", null, null)));
+    OpenLineageClient translatingClient =
+        OpenLineageClient.builder()
+            .transport(transport)
+            .lineageCompatibility(LineageCompatibility.MODERN)
+            .build();
+    ArgumentCaptor<RunEvent> emitted = ArgumentCaptor.forClass(RunEvent.class);
+
+    translatingClient.emit(event);
+
+    verify(transport).emit(emitted.capture());
+    assertThat(event.getJob().getFacets().getLineage()).isNull();
+    assertThat(emitted.getValue().getJob().getFacets().getLineage()).isNotNull();
   }
 
   @SneakyThrows

--- a/client/java/src/test/resources/config/lineage.yaml
+++ b/client/java/src/test/resources/config/lineage.yaml
@@ -1,0 +1,7 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+transport:
+  type: console
+lineage:
+  compatibility: legacy

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
@@ -80,19 +80,23 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
 
   @Override
   public FlinkOpenLineageConfig mergeWithNonNull(FlinkOpenLineageConfig other) {
-    return new FlinkOpenLineageConfig(
-        mergePropertyWith(transportConfig, other.transportConfig),
-        mergePropertyWith(facetsConfig, other.facetsConfig),
-        mergePropertyWith(datasetConfig, other.datasetConfig),
-        mergePropertyWith(circuitBreaker, other.circuitBreaker),
-        mergePropertyWith(metricsConfig, other.metricsConfig),
-        mergePropertyWith(runConfig, other.runConfig),
-        mergePropertyWith(jobConfig, other.jobConfig),
-        mergePropertyWith(trackingIntervalInSeconds, other.trackingIntervalInSeconds),
-        mergePropertyWith(
-            detachedStartEventEmitTimeoutInSeconds, other.detachedStartEventEmitTimeoutInSeconds),
-        mergePropertyWith(enableDetachedJobTracking, other.enableDetachedJobTracking),
-        mergePropertyWith(disableCheckpointTracking, other.disableCheckpointTracking));
+    FlinkOpenLineageConfig merged =
+        new FlinkOpenLineageConfig(
+            mergePropertyWith(transportConfig, other.transportConfig),
+            mergePropertyWith(facetsConfig, other.facetsConfig),
+            mergePropertyWith(datasetConfig, other.datasetConfig),
+            mergePropertyWith(circuitBreaker, other.circuitBreaker),
+            mergePropertyWith(metricsConfig, other.metricsConfig),
+            mergePropertyWith(runConfig, other.runConfig),
+            mergePropertyWith(jobConfig, other.jobConfig),
+            mergePropertyWith(trackingIntervalInSeconds, other.trackingIntervalInSeconds),
+            mergePropertyWith(
+                detachedStartEventEmitTimeoutInSeconds,
+                other.detachedStartEventEmitTimeoutInSeconds),
+            mergePropertyWith(enableDetachedJobTracking, other.enableDetachedJobTracking),
+            mergePropertyWith(disableCheckpointTracking, other.disableCheckpointTracking));
+    merged.setLineageConfig(mergePropertyWith(lineageConfig, other.lineageConfig));
+    return merged;
   }
 
   public Integer getTrackingIntervalInSeconds() {

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.io.Resources;
+import io.openlineage.client.LineageCompatibility;
 import io.openlineage.client.transports.HttpConfig;
 import io.openlineage.flink.config.FlinkConfigParser;
 import io.openlineage.flink.config.FlinkDatasetConfig;
@@ -38,6 +39,8 @@ class FlinkConfigParserTest {
       ConfigOptions.key("openlineage.transport.headers.testHeader").stringType().noDefaultValue();
   ConfigOption testCompressionOption =
       ConfigOptions.key("openlineage.transport.compression").stringType().noDefaultValue();
+  ConfigOption lineageCompatibilityOption =
+      ConfigOptions.key("openlineage.lineage.compatibility").stringType().noDefaultValue();
 
   ConfigOption facetXDisabled =
       ConfigOptions.key("openlineage.facets.facetX.disabled").booleanType().noDefaultValue();
@@ -176,5 +179,14 @@ class FlinkConfigParserTest {
     configuration.set(disableCheckpointTrackingOption, true);
     config = FlinkConfigParser.parse(configuration);
     assertThat(config.getDisableCheckpointTracking()).isTrue();
+  }
+
+  @Test
+  void testLineageCompatibility() {
+    configuration.set(lineageCompatibilityOption, "modern");
+
+    FlinkOpenLineageConfig config = FlinkConfigParser.parse(configuration);
+
+    assertThat(config.getLineageConfig().getCompatibility()).isEqualTo(LineageCompatibility.MODERN);
   }
 }

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfig.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfig.java
@@ -48,16 +48,19 @@ public class HiveOpenLineageConfig extends OpenLineageConfig<HiveOpenLineageConf
 
   @Override
   public HiveOpenLineageConfig mergeWithNonNull(HiveOpenLineageConfig other) {
-    return new HiveOpenLineageConfig(
-        mergePropertyWith(parentRunId, other.parentRunId),
-        mergePropertyWith(parentJobName, other.parentJobName),
-        mergePropertyWith(parentJobNamespace, other.parentJobNamespace),
-        mergePropertyWith(transportConfig, other.transportConfig),
-        mergePropertyWith(facetsConfig, other.facetsConfig),
-        mergePropertyWith(datasetConfig, other.datasetConfig),
-        mergePropertyWith(circuitBreaker, other.circuitBreaker),
-        mergePropertyWith(metricsConfig, other.metricsConfig),
-        mergePropertyWith(runConfig, other.runConfig),
-        mergePropertyWith(jobConfig, other.jobConfig));
+    HiveOpenLineageConfig merged =
+        new HiveOpenLineageConfig(
+            mergePropertyWith(parentRunId, other.parentRunId),
+            mergePropertyWith(parentJobName, other.parentJobName),
+            mergePropertyWith(parentJobNamespace, other.parentJobNamespace),
+            mergePropertyWith(transportConfig, other.transportConfig),
+            mergePropertyWith(facetsConfig, other.facetsConfig),
+            mergePropertyWith(datasetConfig, other.datasetConfig),
+            mergePropertyWith(circuitBreaker, other.circuitBreaker),
+            mergePropertyWith(metricsConfig, other.metricsConfig),
+            mergePropertyWith(runConfig, other.runConfig),
+            mergePropertyWith(jobConfig, other.jobConfig));
+    merged.setLineageConfig(mergePropertyWith(lineageConfig, other.lineageConfig));
+    return merged;
   }
 }

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfigParser.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfigParser.java
@@ -51,7 +51,8 @@ public class HiveOpenLineageConfigParser {
                 key ->
                     key.startsWith("transport")
                         || key.startsWith("facets")
-                        || key.startsWith("circuitBreaker"))
+                        || key.startsWith("circuitBreaker")
+                        || key.startsWith("lineage"))
             .collect(Collectors.toSet());
     ObjectNode objectNode = JSON.createObjectNode();
     for (String key : configKeys) {

--- a/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/client/HiveOpenLineageConfigParserTest.java
+++ b/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/client/HiveOpenLineageConfigParserTest.java
@@ -7,6 +7,7 @@ package io.openlineage.hive.client;
 import static io.openlineage.hive.client.HiveOpenLineageConfigParser.extractFromHadoopConf;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.openlineage.client.LineageCompatibility;
 import io.openlineage.client.transports.ConsoleConfig;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
@@ -36,5 +37,15 @@ public class HiveOpenLineageConfigParserTest {
     assertThat(config.getCircuitBreaker()).isNull();
     assertThat(config.getMetricsConfig()).isNull();
     assertThat(config.getDatasetConfig()).isNull();
+  }
+
+  @Test
+  public void testLineageCompatibility() {
+    Configuration conf = new Configuration();
+    conf.set("hive.openlineage.lineage.compatibility", "modern");
+
+    HiveOpenLineageConfig config = extractFromHadoopConf(conf);
+
+    assertThat(config.getLineageConfig().getCompatibility()).isEqualTo(LineageCompatibility.MODERN);
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -81,6 +81,7 @@ public class EventEmitter {
         OpenLineageClient.builder()
             .transport(new TransportFactory(config.getTransportConfig()).build())
             .disableFacets(disabledFacets.toArray(new String[0]))
+            .lineageCompatibility(config.getLineageConfig().getCompatibility())
             .build();
     this.applicationJobName = this.overriddenAppName.orElse(applicationJobName);
     this.applicationRunId =

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/EventEmitterTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/EventEmitterTest.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.openlineage.client.LineageCompatibility;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import lombok.SneakyThrows;
 import org.apache.spark.SparkConf;
@@ -42,5 +43,20 @@ class EventEmitterTest {
     eventEmitter.setApplicationJobName(resolvedName);
 
     assertThat(eventEmitter.getApplicationJobName()).isEqualTo(resolvedName);
+  }
+
+  @SneakyThrows
+  @Test
+  void testLineageCompatibilityFromSparkConfigIsPassedToClient() {
+    SparkConf sparkConf = new SparkConf().set("spark.openlineage.lineage.compatibility", "legacy");
+
+    SparkOpenLineageConfig olConfig = ArgumentParser.parse(sparkConf);
+    EventEmitter eventEmitter = new EventEmitter(olConfig, "test-app");
+
+    assertThat(olConfig.getLineageConfig().getCompatibility())
+        .isEqualTo(LineageCompatibility.LEGACY);
+    assertThat(eventEmitter.getClient())
+        .extracting("lineageCompatibility")
+        .isEqualTo(LineageCompatibility.LEGACY);
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -186,31 +186,34 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
 
   @Override
   public SparkOpenLineageConfig mergeWithNonNull(SparkOpenLineageConfig other) {
-    return new SparkOpenLineageConfig(
-        mergeWithDefaultValue(namespace, other.namespace, DEFAULT_NAMESPACE),
-        mergePropertyWith(parentJobName, other.parentJobName),
-        mergePropertyWith(parentJobNamespace, other.parentJobNamespace),
-        mergePropertyWith(parentRunId, other.parentRunId),
-        mergePropertyWith(rootParentJobName, other.rootParentJobName),
-        mergePropertyWith(rootParentJobNamespace, other.rootParentJobNamespace),
-        mergePropertyWith(rootParentRunId, other.rootParentRunId),
-        mergePropertyWith(parentJobFacets, other.parentJobFacets),
-        mergePropertyWith(parentRunFacets, other.parentRunFacets),
-        mergePropertyWith(rootParentJobFacets, other.rootParentJobFacets),
-        mergePropertyWith(rootParentRunFacets, other.rootParentRunFacets),
-        mergePropertyWith(overriddenAppName, other.overriddenAppName),
-        mergePropertyWith(overriddenApplicationRunId, other.overriddenApplicationRunId),
-        mergePropertyWith(testExtensionProvider, other.testExtensionProvider),
-        mergePropertyWith(jobName, other.jobName),
-        mergePropertyWith(jobConfig, other.jobConfig),
-        mergePropertyWith(transportConfig, other.transportConfig),
-        mergePropertyWith(facetsConfig, other.facetsConfig),
-        mergePropertyWith(datasetConfig, other.datasetConfig),
-        mergePropertyWith(circuitBreaker, other.circuitBreaker),
-        mergePropertyWith(metricsConfig, other.metricsConfig),
-        mergePropertyWith(columnLineageConfig, other.columnLineageConfig),
-        mergePropertyWith(vendors, other.vendors),
-        mergePropertyWith(filterConfig, other.filterConfig),
-        mergePropertyWith(runConfig, other.runConfig));
+    SparkOpenLineageConfig merged =
+        new SparkOpenLineageConfig(
+            mergeWithDefaultValue(namespace, other.namespace, DEFAULT_NAMESPACE),
+            mergePropertyWith(parentJobName, other.parentJobName),
+            mergePropertyWith(parentJobNamespace, other.parentJobNamespace),
+            mergePropertyWith(parentRunId, other.parentRunId),
+            mergePropertyWith(rootParentJobName, other.rootParentJobName),
+            mergePropertyWith(rootParentJobNamespace, other.rootParentJobNamespace),
+            mergePropertyWith(rootParentRunId, other.rootParentRunId),
+            mergePropertyWith(parentJobFacets, other.parentJobFacets),
+            mergePropertyWith(parentRunFacets, other.parentRunFacets),
+            mergePropertyWith(rootParentJobFacets, other.rootParentJobFacets),
+            mergePropertyWith(rootParentRunFacets, other.rootParentRunFacets),
+            mergePropertyWith(overriddenAppName, other.overriddenAppName),
+            mergePropertyWith(overriddenApplicationRunId, other.overriddenApplicationRunId),
+            mergePropertyWith(testExtensionProvider, other.testExtensionProvider),
+            mergePropertyWith(jobName, other.jobName),
+            mergePropertyWith(jobConfig, other.jobConfig),
+            mergePropertyWith(transportConfig, other.transportConfig),
+            mergePropertyWith(facetsConfig, other.facetsConfig),
+            mergePropertyWith(datasetConfig, other.datasetConfig),
+            mergePropertyWith(circuitBreaker, other.circuitBreaker),
+            mergePropertyWith(metricsConfig, other.metricsConfig),
+            mergePropertyWith(columnLineageConfig, other.columnLineageConfig),
+            mergePropertyWith(vendors, other.vendors),
+            mergePropertyWith(filterConfig, other.filterConfig),
+            mergePropertyWith(runConfig, other.runConfig));
+    merged.setLineageConfig(mergePropertyWith(lineageConfig, other.lineageConfig));
+    return merged;
   }
 }

--- a/website/docs/client/java/configuration.md
+++ b/website/docs/client/java/configuration.md
@@ -58,6 +58,36 @@ facets:
 
 Please be aware that this syntax is not working anymore.
 
+## Lineage compatibility
+
+The client can translate automatically between explicit lineage facets and the legacy
+`inputs`, `outputs` and `ColumnLineageDatasetFacet` representation. The default mode is `none`.
+
+Enable translation in both directions with:
+
+```yaml
+lineage:
+  compatibility: both
+```
+
+The available modes are:
+
+| Mode | Behaviour |
+|------|-----------|
+| `none` | Do not translate lineage. |
+| `legacy` | Generate missing legacy lineage from an explicit lineage facet. |
+| `modern` | Generate an explicit lineage facet from legacy lineage when outputs exist. |
+| `both` | Generate the missing representation without replacing producer-provided data. |
+
+Set the same option with `OPENLINEAGE__LINEAGE__COMPATIBILITY`, or override it when building a
+client:
+
+```java
+OpenLineageClient client = OpenLineageClient.builder()
+    .lineageCompatibility(LineageCompatibility.LEGACY)
+    .build();
+```
+
 ## Transports
 
 import Transports from './partials/java_transport.md';


### PR DESCRIPTION
### One-line summary for changelog:

Add opt-in Java client translation between explicit lineage facets and legacy dataset lineage.

### Meaningful description

The new `LineageJobFacet` can describe an output such as `warehouse.orders` as depending on `raw.orders.customer_id`, including field mappings and transformations. Older consumers only inspect the event-level `inputs` and `outputs` arrays and `ColumnLineageDatasetFacet`, so they cannot read that lineage unless the producer emits both representations. The reverse applies to newer consumers receiving events from legacy producers.

This adds a compatibility layer to the Java client which translates immutable event copies immediately before logging and transport:

- `legacy` generates missing event-level datasets and representable column lineage from `LineageJobFacet`
- `modern` generates `LineageJobFacet` from legacy inputs, outputs and column lineage
- `both` selects the missing representation without running both passes or creating cycles
- `none` disables translation and remains the default while the feature is evaluated

Translation applies to `RunEvent` and `JobEvent`, preserves producer-provided data, and is deterministic, stable-order and idempotent. `DatasetEvent` is unchanged.

The mode can be set through YAML, `OPENLINEAGE__LINEAGE__COMPATIBILITY`, or the Java client builder. Configuration is also propagated through Spark, Flink and Hive.

Validation:

- 478 Java client tests
- focused Spark, Flink and Hive configuration tests
- Java PMD and Spotless
- repository pre-commit hooks

### Checklist

- [x] AI was used in creating this PR
