### PR TITLE
spark: add ClickHouse V2 catalog handler

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -81,6 +81,7 @@ addDependenciesToConfiguration(testSourceSet.implementationConfigurationName, sp
 addDependenciesToConfiguration(testSourceSet.implementationConfigurationName, spark, scala, this.&gcsDependencies)
 addDependenciesToConfiguration(testSourceSet.implementationConfigurationName, spark, scala, this.&hadoopClientDependencies)
 addDependenciesToConfiguration(testSourceSet.implementationConfigurationName, spark, scala, this.&icebergDependencies)
+addDependenciesToConfiguration(testSourceSet.implementationConfigurationName, spark, scala, this.&clickhouseDependencies)
 addDependenciesToConfiguration(testSourceSet.runtimeOnlyConfigurationName, spark, scala, this.&runtimeOnlyDependencies)
 addDependenciesToConfiguration(additionalJarsConfigurationName, spark, scala, this.&additionalJars)
 
@@ -130,6 +131,7 @@ dependencies {
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:mockserver")
     testImplementation("org.testcontainers:kafka")
+    testImplementation("org.testcontainers:clickhouse")
     testImplementation("commons-beanutils:commons-beanutils:1.11.0")
     testImplementation("org.awaitility:awaitility:4.3.0")
     testImplementation("org.assertj:assertj-core:${assertjVersion}")
@@ -234,6 +236,9 @@ tasks.named("test", Test.class) {
         }
         if (!hasIcebergDependencies(spark, scala)) {
             excludeTags "iceberg"
+        }
+        if (!hasClickHouseDependencies(spark, scala)) {
+            excludeTags "clickhouse"
         }
     }
     systemProperties = testSystemProperties(spark, scala)
@@ -431,6 +436,11 @@ tasks.register("integrationTest", Test.class) {
             logger.warn("[IntegrationTest] Excluding iceberg tests")
             excludeTags("iceberg")
         }
+        logger.warn("[IntegrationTest] hasClickHouseDependencies: ${hasClickHouseDependencies(spark, scala)}")
+        if (!hasClickHouseDependencies(spark, scala)) {
+            logger.warn("[IntegrationTest] Excluding clickhouse tests")
+            excludeTags("clickhouse")
+        }
     }
     systemProperties.put("test.output.dir", buildDirectory.dir("test-output/${name}").get().asFile.toString())
     systemProperties.put("test.results.dir", buildDirectory.dir("test-results/${name}/o").get().asFile.toString())
@@ -601,6 +611,27 @@ List<Dependency> deltaDependencies(String spark, String scala) {
     }
 }
 
+List<Dependency> clickhouseDependencies(String spark, String scala) {
+    // ClickHouse Spark connector runtime artifacts exist for Spark 3.3+ only,
+    // and for Spark 4.x with Scala 2.13 only; tests are tagged with `clickhouse`
+    // and excluded where no artifact is available.
+    final def registry = [
+            "3.3.4": "0.10.0",
+            "3.4.4": "0.10.0",
+            "3.5.6": "0.10.0",
+            "4.0.0": "0.10.0",
+    ]
+
+    def clickhouse = registry.get(spark)
+    if (clickhouse == null || (spark.startsWith("4.") && scala != "2.13")) {
+        return []
+    }
+    def shortSpark = spark.substring(0, spark.lastIndexOf('.'))
+    return [
+            dependencies.create("com.clickhouse.spark:clickhouse-spark-runtime-${shortSpark}_${scala}:${clickhouse}")
+    ]
+}
+
 List<Dependency> gcsDependencies(String spark, String scala) {
     final def registry = [
             "2.4.8": "hadoop2-2.2.9",
@@ -717,6 +748,10 @@ boolean hasDeltaDependencies(String spark, String scala) {
 
 boolean hasIcebergDependencies(String spark, String scala) {
     return !icebergDependencies(spark, scala).isEmpty()
+}
+
+boolean hasClickHouseDependencies(String spark, String scala) {
+    return !clickhouseDependencies(spark, scala).isEmpty()
 }
 
 static List<String> map(List<SourceSet> sourceSets, Function<SourceSet, String> func) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DefaultCatalogHandlers.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DefaultCatalogHandlers.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.agent.lifecycle;
 import com.google.common.collect.ImmutableList;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.ClickHouseHandler;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.DatabricksDeltaHandler;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.DatabricksUnityV2Handler;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.DeltaHandler;
@@ -24,6 +25,7 @@ final class DefaultCatalogHandlers {
     return ImmutableList.of(
         new IcebergHandler(context),
         new DeltaHandler(context),
+        new ClickHouseHandler(context),
         new DatabricksDeltaHandler(context),
         new DatabricksUnityV2Handler(context),
         new JdbcHandler(context),

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkClickHouseIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkClickHouseIntegrationTest.java
@@ -17,12 +17,12 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.clickhouse.ClickHouseContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -33,29 +33,55 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Tag("integration-test")
 @Tag("clickhouse")
-@Testcontainers
-@Slf4j
 class SparkClickHouseIntegrationTest {
-  private static final OpenLineageEndpointHandler handler = new OpenLineageEndpointHandler();
   private static final int CLICKHOUSE_HTTP_PORT = 8123;
+  private static final String CLICKHOUSE = "clickhouse";
+  private static final String CLICKHOUSE_NAMESPACE_PREFIX = "clickhouse://localhost:";
+  private static final String TABLE_NAME = "mydb.people";
+  private static final String QUALIFIED_TABLE_NAME = CLICKHOUSE + "." + TABLE_NAME;
+
+  private final OpenLineageEndpointHandler handler = new OpenLineageEndpointHandler();
+  private HttpServer server;
+  private ClickHouseContainer clickhouse;
+  private SparkSession spark;
+
+  @BeforeEach
+  void beforeEach() throws IOException, InterruptedException {
+    server = createHttpServer(handler);
+    clickhouse =
+        new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.8"));
+    clickhouse.start();
+
+    exec("CREATE DATABASE IF NOT EXISTS mydb");
+    exec("CREATE TABLE " + TABLE_NAME + " (id Int32, name String) ENGINE = MergeTree ORDER BY id");
+    exec("INSERT INTO " + TABLE_NAME + " VALUES (1, 'John'), (2, 'Jane')");
+  }
+
+  @AfterEach
+  void afterEach() {
+    try {
+      stopSpark();
+    } finally {
+      try {
+        if (clickhouse != null) {
+          clickhouse.stop();
+        }
+      } finally {
+        if (server != null) {
+          server.stop(0);
+        }
+      }
+    }
+  }
 
   @Test
-  void testClickHouseCatalogDatasetIdentifierWhenTableIsRead()
-      throws IOException, InterruptedException {
-    HttpServer server = createHttpServer(handler);
-    ClickHouseContainer clickhouse = startClickHouseContainer();
+  void testClickHouseCatalogDatasetIdentifierWhenTableIsRead() {
     int httpPort = clickhouse.getMappedPort(CLICKHOUSE_HTTP_PORT);
 
-    SparkSession spark =
-        createSparkSession(
-            server.getAddress().getPort(),
-            clickhouse,
-            "testClickHouseCatalogDatasetIdentifierWhenTableIsRead");
+    spark = createSparkSession("testClickHouseCatalogDatasetIdentifierWhenTableIsRead");
 
-    spark.sql("SELECT * FROM clickhouse.mydb.people").show();
-
-    clickhouse.stop();
-    spark.stop();
+    spark.sql("SELECT * FROM " + QUALIFIED_TABLE_NAME).show();
+    stopSpark();
 
     List<OpenLineage.InputDataset> inputs =
         readInputs("test_click_house_catalog_dataset_identifier_when_table_is_read");
@@ -63,27 +89,17 @@ class SparkClickHouseIntegrationTest {
     assertThat(inputs).isNotEmpty();
     inputs.forEach(
         input -> {
-          assertThat(input.getNamespace()).isEqualTo("clickhouse://localhost:" + httpPort);
-          assertThat(input.getName()).isEqualTo("mydb.people");
+          assertThat(input.getNamespace()).isEqualTo(CLICKHOUSE_NAMESPACE_PREFIX + httpPort);
+          assertThat(input.getName()).isEqualTo(TABLE_NAME);
         });
   }
 
   @Test
-  void testClickHouseCatalogDatasetFacetsWhenTableIsRead()
-      throws IOException, InterruptedException {
-    HttpServer server = createHttpServer(handler);
-    ClickHouseContainer clickhouse = startClickHouseContainer();
+  void testClickHouseCatalogDatasetFacetsWhenTableIsRead() {
+    spark = createSparkSession("testClickHouseCatalogDatasetFacetsWhenTableIsRead");
 
-    SparkSession spark =
-        createSparkSession(
-            server.getAddress().getPort(),
-            clickhouse,
-            "testClickHouseCatalogDatasetFacetsWhenTableIsRead");
-
-    spark.sql("SELECT * FROM clickhouse.mydb.people").show();
-
-    clickhouse.stop();
-    spark.stop();
+    spark.sql("SELECT * FROM " + QUALIFIED_TABLE_NAME).show();
+    stopSpark();
 
     List<OpenLineage.InputDataset> inputs =
         readInputs("test_click_house_catalog_dataset_facets_when_table_is_read");
@@ -97,7 +113,7 @@ class SparkClickHouseIntegrationTest {
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
     assertThat(storageFacets).isNotEmpty();
-    assertThat(storageFacets.get(0).getStorageLayer()).isEqualTo("clickhouse");
+    assertThat(storageFacets.get(0).getStorageLayer()).isEqualTo(CLICKHOUSE);
     assertThat(storageFacets.get(0).getFileFormat()).isEqualTo("MergeTree");
 
     List<OpenLineage.CatalogDatasetFacet> catalogFacets =
@@ -107,10 +123,36 @@ class SparkClickHouseIntegrationTest {
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
     assertThat(catalogFacets).isNotEmpty();
-    assertThat(catalogFacets.get(0).getName()).isEqualTo("clickhouse");
-    assertThat(catalogFacets.get(0).getFramework()).isEqualTo("clickhouse");
-    assertThat(catalogFacets.get(0).getType()).isEqualTo("clickhouse");
+    assertThat(catalogFacets.get(0).getName()).isEqualTo(CLICKHOUSE);
+    assertThat(catalogFacets.get(0).getFramework()).isEqualTo(CLICKHOUSE);
+    assertThat(catalogFacets.get(0).getType()).isEqualTo(CLICKHOUSE);
     assertThat(catalogFacets.get(0).getSource()).isEqualTo("spark");
+  }
+
+  @Test
+  void testClickHouseCatalogDatasetIdentifierWhenTableIsWritten() {
+    int httpPort = clickhouse.getMappedPort(CLICKHOUSE_HTTP_PORT);
+    spark = createSparkSession("testClickHouseCatalogDatasetIdentifierWhenTableIsWritten");
+
+    spark.sql(
+        "INSERT INTO " + QUALIFIED_TABLE_NAME + " SELECT CAST(3 AS INT) AS id, 'Ada' AS name");
+    stopSpark();
+
+    List<OpenLineage.OutputDataset> outputs =
+        readOutputs("test_click_house_catalog_dataset_identifier_when_table_is_written");
+
+    assertThat(outputs).isNotEmpty();
+    outputs.forEach(
+        output -> {
+          assertThat(output.getNamespace()).isEqualTo(CLICKHOUSE_NAMESPACE_PREFIX + httpPort);
+          assertThat(output.getName()).isEqualTo(TABLE_NAME);
+          OpenLineage.CatalogDatasetFacet catalogFacet = output.getFacets().getCatalog();
+          assertThat(catalogFacet).isNotNull();
+          assertThat(catalogFacet.getName()).isEqualTo(CLICKHOUSE);
+          assertThat(catalogFacet.getFramework()).isEqualTo(CLICKHOUSE);
+          assertThat(catalogFacet.getType()).isEqualTo(CLICKHOUSE);
+          assertThat(catalogFacet.getSource()).isEqualTo("spark");
+        });
   }
 
   private List<OpenLineage.InputDataset> readInputs(String jobName) {
@@ -120,26 +162,24 @@ class SparkClickHouseIntegrationTest {
         .collect(Collectors.toList());
   }
 
-  private ClickHouseContainer startClickHouseContainer() throws IOException, InterruptedException {
-    ClickHouseContainer clickhouse =
-        new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.8"));
-    clickhouse.start();
-
-    exec(clickhouse, "CREATE DATABASE IF NOT EXISTS mydb");
-    exec(
-        clickhouse,
-        "CREATE TABLE mydb.people (id Int32, name String) ENGINE = MergeTree ORDER BY id");
-    exec(clickhouse, "INSERT INTO mydb.people VALUES (1, 'John'), (2, 'Jane')");
-    return clickhouse;
+  private List<OpenLineage.OutputDataset> readOutputs(String jobName) {
+    return handler.getEvents(jobName).stream()
+        .filter(event -> !event.getOutputs().isEmpty())
+        .flatMap(event -> event.getOutputs().stream())
+        .collect(Collectors.toList());
   }
 
-  private void exec(ClickHouseContainer clickhouse, String sql)
-      throws IOException, InterruptedException {
+  private void exec(String sql) throws IOException, InterruptedException {
     clickhouse.execInContainer("clickhouse-client", "--query", sql);
   }
 
-  private SparkSession createSparkSession(
-      Integer httpServerPort, ClickHouseContainer clickhouse, String appName) {
+  private void stopSpark() {
+    if (spark != null && !spark.sparkContext().isStopped()) {
+      spark.stop();
+    }
+  }
+
+  private SparkSession createSparkSession(String appName) {
     Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
     String testId = TestIds.randomHex();
     Path derbySystemHome = tmpDir.resolve("derby").resolve(testId);
@@ -154,8 +194,10 @@ class SparkClickHouseIntegrationTest {
         .config("spark.sql.warehouse.dir", sparkSqlWarehouse.toString())
         .config("spark.ui.enabled", false)
         .config("spark.openlineage.transport.type", "http")
-        .config("spark.openlineage.transport.url", "http://localhost:" + httpServerPort)
+        .config(
+            "spark.openlineage.transport.url", "http://localhost:" + server.getAddress().getPort())
         .config("spark.openlineage.facets.spark_unknown.disabled", "true")
+        .config("spark.clickhouse.write.format", "json")
         .config("spark.sql.catalog.clickhouse", "com.clickhouse.spark.ClickHouseCatalog")
         .config("spark.sql.catalog.clickhouse.host", clickhouse.getHost())
         .config("spark.sql.catalog.clickhouse.protocol", "http")

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkClickHouseIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkClickHouseIntegrationTest.java
@@ -1,0 +1,169 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static io.openlineage.spark.agent.SparkTestUtils.createHttpServer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkTestUtils.OpenLineageEndpointHandler;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Verifies lineage extraction for reads through the official ClickHouse Spark connector
+ * (com.clickhouse.spark.ClickHouseCatalog) against a real ClickHouse server. The connector is added
+ * to the test classpath by {@code clickhouseDependencies} in app/build.gradle; cells of the test
+ * matrix without a connector artifact exclude tests tagged `clickhouse`.
+ */
+@Tag("integration-test")
+@Tag("clickhouse")
+@Testcontainers
+@Slf4j
+class SparkClickHouseIntegrationTest {
+  private static final OpenLineageEndpointHandler handler = new OpenLineageEndpointHandler();
+  private static final int CLICKHOUSE_HTTP_PORT = 8123;
+
+  @Test
+  void testClickHouseCatalogDatasetIdentifierWhenTableIsRead()
+      throws IOException, InterruptedException {
+    HttpServer server = createHttpServer(handler);
+    ClickHouseContainer clickhouse = startClickHouseContainer();
+    int httpPort = clickhouse.getMappedPort(CLICKHOUSE_HTTP_PORT);
+
+    SparkSession spark =
+        createSparkSession(
+            server.getAddress().getPort(),
+            clickhouse,
+            "testClickHouseCatalogDatasetIdentifierWhenTableIsRead");
+
+    spark.sql("SELECT * FROM clickhouse.mydb.people").show();
+
+    clickhouse.stop();
+    spark.stop();
+
+    List<OpenLineage.InputDataset> inputs =
+        readInputs("test_click_house_catalog_dataset_identifier_when_table_is_read");
+
+    assertThat(inputs).isNotEmpty();
+    inputs.forEach(
+        input -> {
+          assertThat(input.getNamespace()).isEqualTo("clickhouse://localhost:" + httpPort);
+          assertThat(input.getName()).isEqualTo("mydb.people");
+        });
+  }
+
+  @Test
+  void testClickHouseCatalogDatasetFacetsWhenTableIsRead()
+      throws IOException, InterruptedException {
+    HttpServer server = createHttpServer(handler);
+    ClickHouseContainer clickhouse = startClickHouseContainer();
+
+    SparkSession spark =
+        createSparkSession(
+            server.getAddress().getPort(),
+            clickhouse,
+            "testClickHouseCatalogDatasetFacetsWhenTableIsRead");
+
+    spark.sql("SELECT * FROM clickhouse.mydb.people").show();
+
+    clickhouse.stop();
+    spark.stop();
+
+    List<OpenLineage.InputDataset> inputs =
+        readInputs("test_click_house_catalog_dataset_facets_when_table_is_read");
+
+    assertThat(inputs).isNotEmpty();
+
+    List<OpenLineage.StorageDatasetFacet> storageFacets =
+        inputs.stream()
+            .map(OpenLineage.Dataset::getFacets)
+            .map(OpenLineage.DatasetFacets::getStorage)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    assertThat(storageFacets).isNotEmpty();
+    assertThat(storageFacets.get(0).getStorageLayer()).isEqualTo("clickhouse");
+    assertThat(storageFacets.get(0).getFileFormat()).isEqualTo("MergeTree");
+
+    List<OpenLineage.CatalogDatasetFacet> catalogFacets =
+        inputs.stream()
+            .map(OpenLineage.Dataset::getFacets)
+            .map(OpenLineage.DatasetFacets::getCatalog)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    assertThat(catalogFacets).isNotEmpty();
+    assertThat(catalogFacets.get(0).getName()).isEqualTo("clickhouse");
+    assertThat(catalogFacets.get(0).getFramework()).isEqualTo("clickhouse");
+    assertThat(catalogFacets.get(0).getType()).isEqualTo("clickhouse");
+    assertThat(catalogFacets.get(0).getSource()).isEqualTo("spark");
+  }
+
+  private List<OpenLineage.InputDataset> readInputs(String jobName) {
+    return handler.getEvents(jobName).stream()
+        .filter(event -> !event.getInputs().isEmpty())
+        .flatMap(event -> event.getInputs().stream())
+        .collect(Collectors.toList());
+  }
+
+  private ClickHouseContainer startClickHouseContainer() throws IOException, InterruptedException {
+    ClickHouseContainer clickhouse =
+        new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.8"));
+    clickhouse.start();
+
+    exec(clickhouse, "CREATE DATABASE IF NOT EXISTS mydb");
+    exec(
+        clickhouse,
+        "CREATE TABLE mydb.people (id Int32, name String) ENGINE = MergeTree ORDER BY id");
+    exec(clickhouse, "INSERT INTO mydb.people VALUES (1, 'John'), (2, 'Jane')");
+    return clickhouse;
+  }
+
+  private void exec(ClickHouseContainer clickhouse, String sql)
+      throws IOException, InterruptedException {
+    clickhouse.execInContainer("clickhouse-client", "--query", sql);
+  }
+
+  private SparkSession createSparkSession(
+      Integer httpServerPort, ClickHouseContainer clickhouse, String appName) {
+    Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+    String testId = TestIds.randomHex();
+    Path derbySystemHome = tmpDir.resolve("derby").resolve(testId);
+    Path sparkSqlWarehouse = tmpDir.resolve("spark-sql-warehouse").resolve(testId);
+
+    return SparkSession.builder()
+        .appName(appName)
+        .master("local[*]")
+        .config("spark.extraListeners", OpenLineageSparkListener.class.getCanonicalName())
+        .config("spark.driver.host", "localhost")
+        .config("spark.driver.extraJavaOptions", "-Dderby.system.home=" + derbySystemHome)
+        .config("spark.sql.warehouse.dir", sparkSqlWarehouse.toString())
+        .config("spark.ui.enabled", false)
+        .config("spark.openlineage.transport.type", "http")
+        .config("spark.openlineage.transport.url", "http://localhost:" + httpServerPort)
+        .config("spark.openlineage.facets.spark_unknown.disabled", "true")
+        .config("spark.sql.catalog.clickhouse", "com.clickhouse.spark.ClickHouseCatalog")
+        .config("spark.sql.catalog.clickhouse.host", clickhouse.getHost())
+        .config("spark.sql.catalog.clickhouse.protocol", "http")
+        .config(
+            "spark.sql.catalog.clickhouse.http_port",
+            String.valueOf(clickhouse.getMappedPort(CLICKHOUSE_HTTP_PORT)))
+        .config("spark.sql.catalog.clickhouse.user", clickhouse.getUsername())
+        .config("spark.sql.catalog.clickhouse.password", clickhouse.getPassword())
+        .getOrCreate();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandler.java
@@ -19,9 +19,27 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 
+/**
+ * The ClickHouseHandler supports the official ClickHouse Spark connector
+ * (com.clickhouse:clickhouse-spark), whose catalog class is com.clickhouse.spark.ClickHouseCatalog.
+ * The connector is detected by class name, so there is no compile-time dependency on it.
+ *
+ * <p>Dataset identifiers use the same convention as {@code JdbcDatasetUtils} for {@code
+ * jdbc:clickhouse://} URLs - a {@code clickhouse://host:port} namespace with a database-qualified
+ * table name - so a table reached through this catalog and the same table reached through Spark
+ * JDBC produce the same dataset.
+ */
 public class ClickHouseHandler implements CatalogHandler {
   private static final String CATALOG_CLASS_NAME = "com.clickhouse.spark.ClickHouseCatalog";
   private static final String CLICKHOUSE = "clickhouse";
+  private static final String CATALOG_CONF_PREFIX = "spark.sql.catalog.";
+  private static final String PROTOCOL_NATIVE = "native";
+  private static final String PROTOCOL_TCP = "tcp";
+  private static final String DEFAULT_HOST = "localhost";
+  private static final String DEFAULT_HTTP_PORT = "8123";
+  private static final String DEFAULT_TCP_PORT = "9000";
+  private static final String ENGINE_PROPERTY = "engine";
+  private static final String UNKNOWN_ENGINE = "unknown";
 
   private final OpenLineageContext context;
 
@@ -62,14 +80,27 @@ public class ClickHouseHandler implements CatalogHandler {
       Identifier identifier,
       Map<String, String> properties) {
     RuntimeConfig conf = session.conf();
-    String prefix = "spark.sql.catalog." + catalog.name();
-    String host = conf.get(prefix + ".host", "localhost");
-    String port = conf.get(prefix + ".http_port", "8123");
+    String prefix = CATALOG_CONF_PREFIX + catalog.name();
+    String host = conf.get(prefix + ".host", DEFAULT_HOST);
+    String port = resolvePort(conf, prefix);
     String name =
         Stream.concat(Arrays.stream(identifier.namespace()), Stream.of(identifier.name()))
             .collect(Collectors.joining("."));
 
-    return new DatasetIdentifier(name, "clickhouse://" + host + ":" + port);
+    return new DatasetIdentifier(name, CLICKHOUSE + "://" + host + ":" + port);
+  }
+
+  /**
+   * The connector serves queries over http ({@code http_port}, 8123 by default) or the native tcp
+   * protocol ({@code tcp_port}, 9000 by default), selected by the {@code protocol} option. Any
+   * other value - including the connector's http default - falls back to the http port.
+   */
+  private String resolvePort(RuntimeConfig conf, String prefix) {
+    String protocol = conf.get(prefix + ".protocol", "http");
+    if (PROTOCOL_NATIVE.equalsIgnoreCase(protocol) || PROTOCOL_TCP.equalsIgnoreCase(protocol)) {
+      return conf.get(prefix + ".tcp_port", DEFAULT_TCP_PORT);
+    }
+    return conf.get(prefix + ".http_port", DEFAULT_HTTP_PORT);
   }
 
   @Override
@@ -85,6 +116,19 @@ public class ClickHouseHandler implements CatalogHandler {
             .source("spark");
 
     return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
+  }
+
+  @Override
+  public Optional<OpenLineage.StorageDatasetFacet> getStorageDatasetFacet(
+      Map<String, String> properties) {
+    // ClickHouseTable.properties() exposes the table spec, including the table engine
+    // (MergeTree, ReplacingMergeTree, ...); fall back when no engine is known, e.g. when
+    // extracting from a CREATE TABLE command.
+    return Optional.of(
+        context
+            .getOpenLineage()
+            .newStorageDatasetFacet(
+                CLICKHOUSE, properties.getOrDefault(ENGINE_PROPERTY, UNKNOWN_ENGINE)));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandler.java
@@ -1,0 +1,94 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.spark.sql.RuntimeConfig;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+public class ClickHouseHandler implements CatalogHandler {
+  private static final String CATALOG_CLASS_NAME = "com.clickhouse.spark.ClickHouseCatalog";
+  private static final String CLICKHOUSE = "clickhouse";
+
+  private final OpenLineageContext context;
+
+  public ClickHouseHandler(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean hasClasses() {
+    try {
+      ClickHouseHandler.class.getClassLoader().loadClass(CATALOG_CLASS_NAME);
+      return true;
+    } catch (NoClassDefFoundError | Exception e) {
+      // If the class does not exist or loading it fails, this handler is not available.
+    }
+
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    if (contextClassLoader != null) {
+      try {
+        contextClassLoader.loadClass(CATALOG_CLASS_NAME);
+        return true;
+      } catch (NoClassDefFoundError | Exception e) {
+        // If the class does not exist or loading it fails, this handler is not available.
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isClass(TableCatalog tableCatalog) {
+    return CATALOG_CLASS_NAME.equals(tableCatalog.getClass().getName());
+  }
+
+  @Override
+  public DatasetIdentifier getDatasetIdentifier(
+      SparkSession session,
+      TableCatalog catalog,
+      Identifier identifier,
+      Map<String, String> properties) {
+    RuntimeConfig conf = session.conf();
+    String prefix = "spark.sql.catalog." + catalog.name();
+    String host = conf.get(prefix + ".host", "localhost");
+    String port = conf.get(prefix + ".http_port", "8123");
+    String name =
+        Stream.concat(Arrays.stream(identifier.namespace()), Stream.of(identifier.name()))
+            .collect(Collectors.joining("."));
+
+    return new DatasetIdentifier(name, "clickhouse://" + host + ":" + port);
+  }
+
+  @Override
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
+      TableCatalog catalog, Map<String, String> properties) {
+    OpenLineage.CatalogDatasetFacetBuilder builder =
+        context
+            .getOpenLineage()
+            .newCatalogDatasetFacetBuilder()
+            .name(catalog.name())
+            .framework(CLICKHOUSE)
+            .type(CLICKHOUSE)
+            .source("spark");
+
+    return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
+  }
+
+  @Override
+  public String getName() {
+    return CLICKHOUSE;
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandler.java
@@ -35,6 +35,7 @@ public class ClickHouseHandler implements CatalogHandler {
   private static final String CATALOG_CONF_PREFIX = "spark.sql.catalog.";
   private static final String PROTOCOL_NATIVE = "native";
   private static final String PROTOCOL_TCP = "tcp";
+  private static final String PROTOCOL_TCPS = "tcps";
   private static final String DEFAULT_HOST = "localhost";
   private static final String DEFAULT_HTTP_PORT = "8123";
   private static final String DEFAULT_TCP_PORT = "9000";
@@ -92,12 +93,15 @@ public class ClickHouseHandler implements CatalogHandler {
 
   /**
    * The connector serves queries over http ({@code http_port}, 8123 by default) or the native tcp
-   * protocol ({@code tcp_port}, 9000 by default), selected by the {@code protocol} option. Any
-   * other value - including the connector's http default - falls back to the http port.
+   * protocol ({@code tcp_port}, 9000 by default), selected by the {@code protocol} option. The
+   * secure native {@code tcps} alias also uses the tcp port. Any other value - including the
+   * connector's http default - falls back to the http port.
    */
   private String resolvePort(RuntimeConfig conf, String prefix) {
     String protocol = conf.get(prefix + ".protocol", "http");
-    if (PROTOCOL_NATIVE.equalsIgnoreCase(protocol) || PROTOCOL_TCP.equalsIgnoreCase(protocol)) {
+    if (PROTOCOL_NATIVE.equalsIgnoreCase(protocol)
+        || PROTOCOL_TCP.equalsIgnoreCase(protocol)
+        || PROTOCOL_TCPS.equalsIgnoreCase(protocol)) {
       return conf.get(prefix + ".tcp_port", DEFAULT_TCP_PORT);
     }
     return conf.get(prefix + ".http_port", DEFAULT_HTTP_PORT);

--- a/integration/spark/spark3/src/test/java/com/clickhouse/spark/ClickHouseCatalog.java
+++ b/integration/spark/spark3/src/test/java/com/clickhouse/spark/ClickHouseCatalog.java
@@ -1,0 +1,63 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package com.clickhouse.spark;
+
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+public class ClickHouseCatalog implements TableCatalog {
+  private String catalogName;
+
+  @Override
+  public void initialize(String name, CaseInsensitiveStringMap options) {
+    this.catalogName = name;
+  }
+
+  @Override
+  public String name() {
+    return catalogName;
+  }
+
+  @Override
+  public Identifier[] listTables(String[] namespace) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Table loadTable(Identifier identifier) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Table createTable(
+      Identifier identifier,
+      StructType schema,
+      Transform[] partitions,
+      Map<String, String> properties) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Table alterTable(Identifier identifier, TableChange... changes) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean dropTable(Identifier identifier) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void renameTable(Identifier oldIdentifier, Identifier newIdentifier) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/integration/spark/spark3/src/test/java/com/clickhouse/spark/ClickHouseCatalog.java
+++ b/integration/spark/spark3/src/test/java/com/clickhouse/spark/ClickHouseCatalog.java
@@ -14,6 +14,13 @@ import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
+/**
+ * Minimal stand-in for the connector's {@code com.clickhouse.spark.ClickHouseCatalog}, which is
+ * deliberately not a test dependency of this project. The fully-qualified name must stay identical
+ * to the real catalog, because {@code ClickHouseHandler#isClass} matches on the class name. Should
+ * the real connector ever be added to the test classpath, this stub would shadow it and must be
+ * removed.
+ */
 public class ClickHouseCatalog implements TableCatalog {
   private String catalogName;
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
@@ -28,6 +28,10 @@ import org.junit.jupiter.api.Test;
 
 class ClickHouseHandlerTest {
   private static final String CLICKHOUSE = "clickhouse";
+  private static final String DATABASE = "mydb";
+  private static final String DEFAULT_HOST = "localhost";
+  private static final String HTTP = "http";
+  private static final String TABLE = "mytable";
 
   private final OpenLineageContext context = mock(OpenLineageContext.class);
   private final ClickHouseHandler handler = new ClickHouseHandler(context);
@@ -54,14 +58,14 @@ class ClickHouseHandlerTest {
 
   @Test
   void testGetDatasetIdentifier() {
-    when(conf.get("spark.sql.catalog.clickhouse.host", "localhost")).thenReturn("ch.example.com");
+    when(conf.get("spark.sql.catalog.clickhouse.host", DEFAULT_HOST)).thenReturn("ch.example.com");
     when(conf.get("spark.sql.catalog.clickhouse.http_port", "8123")).thenReturn("8123");
 
     DatasetIdentifier identifier =
         handler.getDatasetIdentifier(
             session,
             catalog,
-            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Identifier.of(new String[] {DATABASE}, TABLE),
             Collections.emptyMap());
 
     assertThat(identifier)
@@ -73,14 +77,14 @@ class ClickHouseHandlerTest {
   void testGetDatasetIdentifierWithNonDefaultCatalogName() {
     ClickHouseCatalog otherCatalog = new ClickHouseCatalog();
     otherCatalog.initialize("ch2", new CaseInsensitiveStringMap(Collections.emptyMap()));
-    when(conf.get("spark.sql.catalog.ch2.host", "localhost")).thenReturn("other.example.com");
+    when(conf.get("spark.sql.catalog.ch2.host", DEFAULT_HOST)).thenReturn("other.example.com");
     when(conf.get("spark.sql.catalog.ch2.http_port", "8123")).thenReturn("8124");
 
     DatasetIdentifier identifier =
         handler.getDatasetIdentifier(
             session,
             otherCatalog,
-            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Identifier.of(new String[] {DATABASE}, TABLE),
             Collections.emptyMap());
 
     assertThat(identifier)
@@ -90,15 +94,15 @@ class ClickHouseHandlerTest {
 
   @Test
   void testGetDatasetIdentifierWithNativeProtocol() {
-    when(conf.get("spark.sql.catalog.clickhouse.protocol", "http")).thenReturn("native");
-    when(conf.get("spark.sql.catalog.clickhouse.host", "localhost")).thenReturn("ch.example.com");
+    when(conf.get("spark.sql.catalog.clickhouse.protocol", HTTP)).thenReturn("native");
+    when(conf.get("spark.sql.catalog.clickhouse.host", DEFAULT_HOST)).thenReturn("ch.example.com");
     when(conf.get("spark.sql.catalog.clickhouse.tcp_port", "9000")).thenReturn("9440");
 
     DatasetIdentifier identifier =
         handler.getDatasetIdentifier(
             session,
             catalog,
-            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Identifier.of(new String[] {DATABASE}, TABLE),
             Collections.emptyMap());
 
     assertThat(identifier)
@@ -109,13 +113,13 @@ class ClickHouseHandlerTest {
   @Test
   void testGetDatasetIdentifierWithTcpProtocolDefaults() {
     when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
-    when(conf.get("spark.sql.catalog.clickhouse.protocol", "http")).thenReturn("TCP");
+    when(conf.get("spark.sql.catalog.clickhouse.protocol", HTTP)).thenReturn("TCP");
 
     DatasetIdentifier identifier =
         handler.getDatasetIdentifier(
             session,
             catalog,
-            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Identifier.of(new String[] {DATABASE}, TABLE),
             Collections.emptyMap());
 
     assertThat(identifier.getNamespace()).isEqualTo("clickhouse://localhost:9000");
@@ -124,14 +128,14 @@ class ClickHouseHandlerTest {
   @Test
   void testGetDatasetIdentifierWithHttpProtocolPrefix() {
     when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
-    when(conf.get("spark.sql.catalog.clickhouse.protocol", "http")).thenReturn("http");
-    when(conf.get("spark.sql.catalog.clickhouse.host", "localhost")).thenReturn("ch.example.com");
+    when(conf.get("spark.sql.catalog.clickhouse.protocol", HTTP)).thenReturn(HTTP);
+    when(conf.get("spark.sql.catalog.clickhouse.host", DEFAULT_HOST)).thenReturn("ch.example.com");
 
     DatasetIdentifier identifier =
         handler.getDatasetIdentifier(
             session,
             catalog,
-            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Identifier.of(new String[] {DATABASE}, TABLE),
             Collections.emptyMap());
 
     assertThat(identifier.getNamespace()).isEqualTo("clickhouse://ch.example.com:8123");
@@ -145,7 +149,7 @@ class ClickHouseHandlerTest {
         handler.getDatasetIdentifier(
             session,
             catalog,
-            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Identifier.of(new String[] {DATABASE}, TABLE),
             Collections.emptyMap());
 
     assertThat(identifier.getNamespace()).isEqualTo("clickhouse://localhost:8123");

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
@@ -31,6 +31,7 @@ class ClickHouseHandlerTest {
   private static final String DATABASE = "mydb";
   private static final String DEFAULT_HOST = "localhost";
   private static final String HTTP = "http";
+  private static final String PROTOCOL_CONF = "spark.sql.catalog.clickhouse.protocol";
   private static final String TABLE = "mytable";
 
   private final OpenLineageContext context = mock(OpenLineageContext.class);
@@ -94,7 +95,7 @@ class ClickHouseHandlerTest {
 
   @Test
   void testGetDatasetIdentifierWithNativeProtocol() {
-    when(conf.get("spark.sql.catalog.clickhouse.protocol", HTTP)).thenReturn("native");
+    when(conf.get(PROTOCOL_CONF, HTTP)).thenReturn("native");
     when(conf.get("spark.sql.catalog.clickhouse.host", DEFAULT_HOST)).thenReturn("ch.example.com");
     when(conf.get("spark.sql.catalog.clickhouse.tcp_port", "9000")).thenReturn("9440");
 
@@ -113,7 +114,7 @@ class ClickHouseHandlerTest {
   @Test
   void testGetDatasetIdentifierWithTcpProtocolDefaults() {
     when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
-    when(conf.get("spark.sql.catalog.clickhouse.protocol", HTTP)).thenReturn("TCP");
+    when(conf.get(PROTOCOL_CONF, HTTP)).thenReturn("TCP");
 
     DatasetIdentifier identifier =
         handler.getDatasetIdentifier(
@@ -126,9 +127,25 @@ class ClickHouseHandlerTest {
   }
 
   @Test
+  void testGetDatasetIdentifierWithSecureTcpProtocol() {
+    when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+    when(conf.get(PROTOCOL_CONF, HTTP)).thenReturn("tcps");
+    when(conf.get("spark.sql.catalog.clickhouse.tcp_port", "9000")).thenReturn("9440");
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            catalog,
+            Identifier.of(new String[] {DATABASE}, TABLE),
+            Collections.emptyMap());
+
+    assertThat(identifier.getNamespace()).isEqualTo("clickhouse://localhost:9440");
+  }
+
+  @Test
   void testGetDatasetIdentifierWithHttpProtocolPrefix() {
     when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
-    when(conf.get("spark.sql.catalog.clickhouse.protocol", HTTP)).thenReturn(HTTP);
+    when(conf.get(PROTOCOL_CONF, HTTP)).thenReturn(HTTP);
     when(conf.get("spark.sql.catalog.clickhouse.host", DEFAULT_HOST)).thenReturn("ch.example.com");
 
     DatasetIdentifier identifier =

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ClickHouseHandlerTest {
+  private static final String CLICKHOUSE = "clickhouse";
+
   private final OpenLineageContext context = mock(OpenLineageContext.class);
   private final ClickHouseHandler handler = new ClickHouseHandler(context);
   private final SparkSession session = mock(SparkSession.class);
@@ -35,7 +37,7 @@ class ClickHouseHandlerTest {
 
   @BeforeEach
   void beforeEach() {
-    catalog.initialize("clickhouse", new CaseInsensitiveStringMap(Collections.emptyMap()));
+    catalog.initialize(CLICKHOUSE, new CaseInsensitiveStringMap(Collections.emptyMap()));
     when(session.conf()).thenReturn(conf);
   }
 
@@ -110,9 +112,9 @@ class ClickHouseHandlerTest {
     assertThat(catalogDatasetFacet).isPresent();
     OpenLineage.CatalogDatasetFacet facet =
         catalogDatasetFacet.orElseThrow(AssertionError::new).getCatalogDatasetFacet();
-    assertThat(facet.getName()).isEqualTo("clickhouse");
-    assertThat(facet.getFramework()).isEqualTo("clickhouse");
-    assertThat(facet.getType()).isEqualTo("clickhouse");
+    assertThat(facet.getName()).isEqualTo(CLICKHOUSE);
+    assertThat(facet.getFramework()).isEqualTo(CLICKHOUSE);
+    assertThat(facet.getType()).isEqualTo(CLICKHOUSE);
     assertThat(facet.getSource()).isEqualTo("spark");
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
@@ -89,6 +89,55 @@ class ClickHouseHandlerTest {
   }
 
   @Test
+  void testGetDatasetIdentifierWithNativeProtocol() {
+    when(conf.get("spark.sql.catalog.clickhouse.protocol", "http")).thenReturn("native");
+    when(conf.get("spark.sql.catalog.clickhouse.host", "localhost")).thenReturn("ch.example.com");
+    when(conf.get("spark.sql.catalog.clickhouse.tcp_port", "9000")).thenReturn("9440");
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            catalog,
+            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Collections.emptyMap());
+
+    assertThat(identifier)
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://ch.example.com:9440")
+        .hasFieldOrPropertyWithValue("name", "mydb.mytable");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithTcpProtocolDefaults() {
+    when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+    when(conf.get("spark.sql.catalog.clickhouse.protocol", "http")).thenReturn("TCP");
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            catalog,
+            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Collections.emptyMap());
+
+    assertThat(identifier.getNamespace()).isEqualTo("clickhouse://localhost:9000");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithHttpProtocolPrefix() {
+    when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+    when(conf.get("spark.sql.catalog.clickhouse.protocol", "http")).thenReturn("http");
+    when(conf.get("spark.sql.catalog.clickhouse.host", "localhost")).thenReturn("ch.example.com");
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            catalog,
+            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Collections.emptyMap());
+
+    assertThat(identifier.getNamespace()).isEqualTo("clickhouse://ch.example.com:8123");
+  }
+
+  @Test
   void testGetDatasetIdentifierDefaults() {
     when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
 
@@ -105,16 +154,44 @@ class ClickHouseHandlerTest {
   @Test
   void testGetCatalogDatasetFacet() {
     when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+    ClickHouseCatalog namedCatalog = new ClickHouseCatalog();
+    namedCatalog.initialize("prod_ch", new CaseInsensitiveStringMap(Collections.emptyMap()));
 
     Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
-        handler.getCatalogDatasetFacet(catalog, Collections.emptyMap());
+        handler.getCatalogDatasetFacet(namedCatalog, Collections.emptyMap());
 
     assertThat(catalogDatasetFacet).isPresent();
     OpenLineage.CatalogDatasetFacet facet =
         catalogDatasetFacet.orElseThrow(AssertionError::new).getCatalogDatasetFacet();
-    assertThat(facet.getName()).isEqualTo(CLICKHOUSE);
+    assertThat(facet.getName()).isEqualTo("prod_ch");
     assertThat(facet.getFramework()).isEqualTo(CLICKHOUSE);
     assertThat(facet.getType()).isEqualTo(CLICKHOUSE);
     assertThat(facet.getSource()).isEqualTo("spark");
+  }
+
+  @Test
+  void testGetStorageDatasetFacet() {
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+
+    Optional<OpenLineage.StorageDatasetFacet> storageDatasetFacet =
+        handler.getStorageDatasetFacet(Collections.singletonMap("engine", "MergeTree"));
+
+    assertThat(storageDatasetFacet).isPresent();
+    OpenLineage.StorageDatasetFacet facet = storageDatasetFacet.orElseThrow(AssertionError::new);
+    assertThat(facet.getStorageLayer()).isEqualTo(CLICKHOUSE);
+    assertThat(facet.getFileFormat()).isEqualTo("MergeTree");
+  }
+
+  @Test
+  void testGetStorageDatasetFacetWithoutEngine() {
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+
+    Optional<OpenLineage.StorageDatasetFacet> storageDatasetFacet =
+        handler.getStorageDatasetFacet(Collections.emptyMap());
+
+    assertThat(storageDatasetFacet).isPresent();
+    OpenLineage.StorageDatasetFacet facet = storageDatasetFacet.orElseThrow(AssertionError::new);
+    assertThat(facet.getStorageLayer()).isEqualTo(CLICKHOUSE);
+    assertThat(facet.getFileFormat()).isEqualTo("unknown");
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/ClickHouseHandlerTest.java
@@ -1,0 +1,118 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.clickhouse.spark.ClickHouseCatalog;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.spark.sql.RuntimeConfig;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClickHouseHandlerTest {
+  private final OpenLineageContext context = mock(OpenLineageContext.class);
+  private final ClickHouseHandler handler = new ClickHouseHandler(context);
+  private final SparkSession session = mock(SparkSession.class);
+  private final RuntimeConfig conf = mock(RuntimeConfig.class);
+  private final ClickHouseCatalog catalog = new ClickHouseCatalog();
+
+  @BeforeEach
+  void beforeEach() {
+    catalog.initialize("clickhouse", new CaseInsensitiveStringMap(Collections.emptyMap()));
+    when(session.conf()).thenReturn(conf);
+  }
+
+  @Test
+  void testHasClasses() {
+    assertThat(handler.hasClasses()).isTrue();
+  }
+
+  @Test
+  void testIsClass() {
+    assertThat(handler.isClass(catalog)).isTrue();
+    assertThat(handler.isClass(mock(TableCatalog.class))).isFalse();
+  }
+
+  @Test
+  void testGetDatasetIdentifier() {
+    when(conf.get("spark.sql.catalog.clickhouse.host", "localhost")).thenReturn("ch.example.com");
+    when(conf.get("spark.sql.catalog.clickhouse.http_port", "8123")).thenReturn("8123");
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            catalog,
+            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Collections.emptyMap());
+
+    assertThat(identifier)
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://ch.example.com:8123")
+        .hasFieldOrPropertyWithValue("name", "mydb.mytable");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithNonDefaultCatalogName() {
+    ClickHouseCatalog otherCatalog = new ClickHouseCatalog();
+    otherCatalog.initialize("ch2", new CaseInsensitiveStringMap(Collections.emptyMap()));
+    when(conf.get("spark.sql.catalog.ch2.host", "localhost")).thenReturn("other.example.com");
+    when(conf.get("spark.sql.catalog.ch2.http_port", "8123")).thenReturn("8124");
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            otherCatalog,
+            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Collections.emptyMap());
+
+    assertThat(identifier)
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://other.example.com:8124")
+        .hasFieldOrPropertyWithValue("name", "mydb.mytable");
+  }
+
+  @Test
+  void testGetDatasetIdentifierDefaults() {
+    when(conf.get(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+
+    DatasetIdentifier identifier =
+        handler.getDatasetIdentifier(
+            session,
+            catalog,
+            Identifier.of(new String[] {"mydb"}, "mytable"),
+            Collections.emptyMap());
+
+    assertThat(identifier.getNamespace()).isEqualTo("clickhouse://localhost:8123");
+  }
+
+  @Test
+  void testGetCatalogDatasetFacet() {
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
+        handler.getCatalogDatasetFacet(catalog, Collections.emptyMap());
+
+    assertThat(catalogDatasetFacet).isPresent();
+    OpenLineage.CatalogDatasetFacet facet =
+        catalogDatasetFacet.orElseThrow(AssertionError::new).getCatalogDatasetFacet();
+    assertThat(facet.getName()).isEqualTo("clickhouse");
+    assertThat(facet.getFramework()).isEqualTo("clickhouse");
+    assertThat(facet.getType()).isEqualTo("clickhouse");
+    assertThat(facet.getSource()).isEqualTo("spark");
+  }
+}


### PR DESCRIPTION
### One-line summary for changelog:

Adds Spark lineage support for the official ClickHouse V2 catalog.

### Meaningful description

Spark reads and writes through `com.clickhouse.spark.ClickHouseCatalog` currently have no matching catalog handler. Catalog resolution therefore raises `UnsupportedCatalogException`, and lineage extraction skips the affected ClickHouse dataset.

This change registers a ClickHouse handler for the shared Spark 3.x/4.x catalog-handler set. It detects the connector by class name to avoid a hard dependency, reads the selected catalog's `host`, `protocol`, `http_port` and `tcp_port` settings, and emits the established `clickhouse://host:port` namespace with a database-qualified table name. The namespace port follows the connector's `protocol` option: `tcp_port` (9000 by default) for the native/tcp/tcps protocol, `http_port` (8123 by default) otherwise. The identifier convention matches the client's `ClickHouseJdbcExtractor`, so the same table reached through Spark JDBC (`jdbc:clickhouse://host:port`) and through this catalog produces the same dataset.

The handler also emits the ClickHouse catalog dataset facet and a storage dataset facet that carries the ClickHouse table engine (MergeTree, ReplacingMergeTree, ...) as the file format, matching the Delta and Unity handlers.

Tests:

- Unit tests use a minimal catalog stub in the connector's package and cover class detection, configured and default endpoints, native/tcp/tcps protocol, non-default catalog names, dataset names, and catalog/storage facet fields.
- A container-based integration test (`SparkClickHouseIntegrationTest`) runs a real ClickHouse server with the real connector and verifies input and output dataset identifiers and catalog and storage facets end to end, with per-test cleanup for Spark, ClickHouse, and the HTTP collector. Connector runtime artifacts are wired per Spark/Scala matrix cell in `app/build.gradle`; cells without an artifact (Spark 3.2, Spark 4.2, Spark 4 with Scala 2.12) exclude the `clickhouse`-tagged tests.

Closes #4877

### Checklist

- [x] AI was used in creating this PR

