### PR TITLE
python: prevent async release queue deadlock

### DIFF
--- a/client/python/src/openlineage/client/transport/async_http.py
+++ b/client/python/src/openlineage/client/transport/async_http.py
@@ -9,6 +9,7 @@ import logging
 import queue
 import threading
 import time
+from collections import deque
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -56,7 +57,8 @@ The AsyncHttpTransport provides:
 - **Semaphore-controlled**: Uses asyncio.Semaphore to limit concurrent operations
 - **Task-based architecture**: Each event is processed as an independent asyncio task
 - **Race-condition-free**: Immediate task removal prevents double-processing of completed tasks
-- **Reserved queue capacity**: 2x configured queue size to accommodate released completion events
+- **Non-blocking event release**: Held events remain in a worker-owned backlog until request
+  capacity is available
 
 ### 3. Event Tracking and Statistics
 - **Simplified tracking**: Uses direct counters for pending, success, and failed events
@@ -206,7 +208,7 @@ class AsyncHttpTransport(Transport):
         self.compression = config.compression
 
         # Initialize async emitter components directly
-        # Create a queue with 2x the configured size to reserve space for released completion events
+        # Keep 2x actual capacity behind the producer-facing soft limit
         self.configured_queue_size = config.max_queue_size
         self.event_queue: queue.Queue[Request] = queue.Queue(maxsize=self.configured_queue_size * 2)
 
@@ -255,6 +257,7 @@ class AsyncHttpTransport(Transport):
         semaphore = asyncio.Semaphore(self.max_concurrent)
         # Keep track of active tasks
         active_tasks: set[asyncio.Task[list[Request]]] = set()
+        released_requests: deque[Request] = deque()
 
         # Httpx client for the worker
         limits = httpx.Limits(
@@ -265,7 +268,10 @@ class AsyncHttpTransport(Transport):
 
         def _should_exit() -> bool:
             return self.should_exit.is_set() or (
-                self.event_queue.empty() and not len(active_tasks) and self.may_exit.is_set()
+                self.event_queue.empty()
+                and not released_requests
+                and not len(active_tasks)
+                and self.may_exit.is_set()
             )
 
         async with httpx.AsyncClient(
@@ -279,22 +285,28 @@ class AsyncHttpTransport(Transport):
             max_idle_sleep = 1.0
             while not _should_exit():
                 processed_items = False
-                while not self.event_queue.empty() and len(active_tasks) < self.max_concurrent:
-                    try:
-                        request = self.event_queue.get_nowait()
-                        task = asyncio.create_task(
-                            self._process_event(
-                                client,
-                                semaphore,
-                                request,
-                                from_main_queue=True,
-                            ),
-                            name=request.event_id,
-                        )
-                        active_tasks.add(task)
-                        processed_items = True
-                    except queue.Empty:
-                        break
+                while len(active_tasks) < self.max_concurrent:
+                    if released_requests:
+                        request = released_requests.popleft()
+                        from_main_queue = False
+                    else:
+                        try:
+                            request = self.event_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        from_main_queue = True
+
+                    task = asyncio.create_task(
+                        self._process_event(
+                            client,
+                            semaphore,
+                            request,
+                            from_main_queue=from_main_queue,
+                        ),
+                        name=request.event_id,
+                    )
+                    active_tasks.add(task)
+                    processed_items = True
 
                 # Update last processed time if we processed items
                 if processed_items:
@@ -310,26 +322,7 @@ class AsyncHttpTransport(Transport):
                     for task in done:
                         try:
                             # Get any pending requests that can now be processed
-                            pending_requests = await task
-                            if pending_requests:
-                                # Add the released requests back to the queue - we can
-                                # process them now
-                                for request in pending_requests:
-                                    if len(active_tasks) < self.max_concurrent:
-                                        release_task = asyncio.create_task(
-                                            self._process_event(
-                                                client,
-                                                semaphore,
-                                                request,
-                                                from_main_queue=False,
-                                            ),
-                                            name=request.event_id,
-                                        )
-                                        active_tasks.add(release_task)
-                                    else:
-                                        # Put released completion events directly into the reserved queue
-                                        # space (we have 2x capacity, so these should always fit)
-                                        self.event_queue.put(request)
+                            released_requests.extend(await task)
                         except Exception:
                             log.exception("Error in event processing task")
                 # No tasks are active, didn't process any new items - sleep

--- a/client/python/tests/test_async_http.py
+++ b/client/python/tests/test_async_http.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import asyncio
 import datetime
 import gzip
 import hashlib
 import os
+import queue
 import threading
 import time
 from contextlib import contextmanager
@@ -306,6 +308,55 @@ class TestAsyncHttpTransport:
 
             mock_process.assert_awaited_once()
             assert transport.get_stats()["success"] == 1
+
+    def test_released_events_do_not_deadlock_full_queue(self):
+        config = AsyncHttpConfig(url="http://example.com", max_queue_size=1, max_concurrent_requests=1)
+        transport = AsyncHttpTransport(config)
+        start_processing = threading.Event()
+        finish_start = threading.Event()
+        completed = False
+
+        async def process_event(client, semaphore, request, from_main_queue=True):
+            if request.event_type == "START":
+                start_processing.set()
+                while not finish_start.is_set():
+                    await asyncio.sleep(0.01)
+
+            released = transport._mark_success(request)
+            if from_main_queue:
+                transport.event_queue.task_done()
+            return released
+
+        def event(state, second):
+            return RunEvent(
+                eventType=state,
+                eventTime=f"2026-08-20T00:00:{second:02d}Z",
+                run=Run(runId="00000000-0000-0000-0000-000000000001"),
+                job=Job(namespace="test", name="queue-release"),
+                producer="test",
+                schemaURL="test",
+            )
+
+        try:
+            with patch.object(transport, "_process_event", side_effect=process_event):
+                transport.emit(event(RunState.START, 0))
+                assert start_processing.wait(1)
+                for second in range(1, 5):
+                    transport.emit(event(RunState.RUNNING, second))
+
+                finish_start.set()
+                completed = transport.wait_for_completion(timeout=1)
+                assert completed
+                assert transport.get_stats() == {"pending": 0, "success": 5, "failed": 0}
+        finally:
+            finish_start.set()
+            if not completed:
+                while True:
+                    try:
+                        transport.event_queue.get_nowait()
+                    except queue.Empty:
+                        break
+            transport.close(timeout=1)
 
     def test_async_http_transport_get_stats(self):
         config = AsyncHttpConfig(url="http://example.com")


### PR DESCRIPTION
### One-line summary for changelog:

Prevent the Python async HTTP transport from deadlocking when a `START` completion releases more held events than its bounded queue can accept.

### Meaningful description

`AsyncHttpTransport` previously returned every event held behind an in-flight `START` request to its sole worker. Once request concurrency was full, the worker placed the remainder into `event_queue` with blocking `queue.Queue.put()`. If the released burst exceeded the queue's reserved capacity, the worker blocked waiting for itself to consume an item. All async delivery then stopped, `wait_for_completion()` timed out, and `close()` could hang while joining the blocked worker.

Keep released events in a worker-owned `deque` instead. The event loop drains that backlog as request slots become available, before taking more producer-queued work. The backlog is included in the graceful-exit condition, so shutdown still waits for every accepted event while bounded HTTP concurrency and `START` ordering remain unchanged.

The regression test uses `max_queue_size=1` and `max_concurrent_requests=1`, holds four `RUNNING` events behind an in-flight `START`, and verifies that all five events complete. Four held events are the smallest burst that deadlocked the previous implementation with an otherwise empty queue.

Closes #4881.

### Validation

- `.venv/bin/pytest tests/test_async_http.py -q` — 48 passed
- `.venv/bin/pytest tests --ignore=tests/test_http_integration.py -q` — 617 passed
- `.venv/bin/pytest tests/test_http_integration.py -q` — 34 passed
- `/private/tmp/openlineage-mypy-env/bin/mypy --explicit-package-bases src` — passed (80 source files)
- `.venv/bin/ruff check src/openlineage/client/transport/async_http.py tests/test_async_http.py` — passed
- `.venv/bin/ruff format --check src/openlineage/client/transport/async_http.py tests/test_async_http.py` — passed
- `uvx prek run --files client/python/src/openlineage/client/transport/async_http.py client/python/tests/test_async_http.py` — all applicable hooks passed
- Original local-server reproduction with four held events — completion changed from `False` (1/5 requests delivered) to `True` (5/5 delivered)

### Checklist

- [x] AI was used in creating this PR
