### PR TITLE
spark: extract Delta output from V1 micro-batch writes

### DIFF
--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
@@ -6,15 +6,19 @@
 package io.openlineage.spark34.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
-import org.apache.spark.sql.execution.streaming.FileStreamSink;
 import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 
@@ -52,20 +56,47 @@ public class WriteToMicroBatchDataSourceV1DatasetBuilder
   @Override
   protected List<OpenLineage.OutputDataset> apply(
       SparkListenerEvent event, WriteToMicroBatchDataSourceV1 writeToMicroBatchV1) {
-    // Currently, only FileStreamSink is supported
-    if (writeToMicroBatchV1.sink() instanceof FileStreamSink) {
-      if (writeToMicroBatchV1.catalogTable().isDefined()) {
+    // Prefer catalog metadata for every sink when it is available.
+    if (writeToMicroBatchV1.catalogTable().isDefined()) {
+      return Collections.singletonList(
+          factory
+              .sparkDatasetBuilder()
+              .dataset(writeToMicroBatchV1.catalogTable().get())
+              .schema(writeToMicroBatchV1.schema())
+              .build());
+    }
+
+    if (isDeltaSink(writeToMicroBatchV1.sink())) {
+      Optional<String> path = pathWriteOption(writeToMicroBatchV1);
+      if (path.isPresent()) {
         return Collections.singletonList(
             factory
                 .sparkDatasetBuilder()
-                .dataset(writeToMicroBatchV1.catalogTable().get())
+                .dataset(PathUtils.fromPath(new Path(path.get())))
                 .schema(writeToMicroBatchV1.schema())
                 .build());
-      } else {
-        return Collections.emptyList();
       }
+      log.warn("Delta sink write has no path option; cannot extract output dataset");
+      return Collections.emptyList();
     }
+
     log.debug("Unsupported Sink type: {}", writeToMicroBatchV1.sink().getClass().getName());
     return Collections.emptyList();
+  }
+
+  private static Optional<String> pathWriteOption(WriteToMicroBatchDataSourceV1 write) {
+    return ScalaConversionUtils.<String, String>fromMap(write.writeOptions()).entrySet().stream()
+        .filter(entry -> "path".equalsIgnoreCase(entry.getKey()))
+        .map(Map.Entry::getValue)
+        .findFirst();
+  }
+
+  private static boolean isDeltaSink(Object sink) {
+    for (Class<?> clazz = sink.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+      if ("org.apache.spark.sql.delta.sources.DeltaSink".equals(clazz.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
@@ -31,6 +31,10 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 public class WriteToMicroBatchDataSourceV1DatasetBuilder
     extends AbstractQueryPlanOutputDatasetBuilder<WriteToMicroBatchDataSourceV1> {
 
+  private static final String DELTA_SINK_CLASS_NAME =
+      "org.apache.spark.sql.delta.sources.DeltaSink";
+  private static final String PATH_OPTION = "path";
+
   private final DatasetFactory<OpenLineage.OutputDataset> factory;
 
   public WriteToMicroBatchDataSourceV1DatasetBuilder(
@@ -86,14 +90,15 @@ public class WriteToMicroBatchDataSourceV1DatasetBuilder
 
   private static Optional<String> pathWriteOption(WriteToMicroBatchDataSourceV1 write) {
     return ScalaConversionUtils.<String, String>fromMap(write.writeOptions()).entrySet().stream()
-        .filter(entry -> "path".equalsIgnoreCase(entry.getKey()))
+        .filter(entry -> PATH_OPTION.equalsIgnoreCase(entry.getKey()))
         .map(Map.Entry::getValue)
+        .filter(path -> path != null && !path.isEmpty())
         .findFirst();
   }
 
   private static boolean isDeltaSink(Object sink) {
     for (Class<?> clazz = sink.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
-      if ("org.apache.spark.sql.delta.sources.DeltaSink".equals(clazz.getName())) {
+      if (DELTA_SINK_CLASS_NAME.equals(clazz.getName())) {
         return true;
       }
     }

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
@@ -25,6 +25,7 @@ import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.SparkSession;
@@ -32,7 +33,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.delta.sources.DeltaSink;
 import org.apache.spark.sql.execution.QueryExecution;
-import org.apache.spark.sql.execution.streaming.FileStreamSink;
 import org.apache.spark.sql.execution.streaming.Sink;
 import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
@@ -46,10 +46,11 @@ import scala.Option;
 
 class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
 
+  private static final String DELTA_PATH = "/tmp/delta_target";
+
   private DatasetFactory<OpenLineage.OutputDataset> factory;
   private WriteToMicroBatchDataSourceV1DatasetBuilder builder;
   private WriteToMicroBatchDataSourceV1 writeToMicroBatchV1;
-  private FileStreamSink fileStreamSink;
   private Sink unsupportedSink;
   private SparkListenerSQLExecutionEnd event;
   private StructType schema;
@@ -69,13 +70,10 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
             .openLineageConfig(new SparkOpenLineageConfig())
             .build();
 
-    @SuppressWarnings("unchecked")
-    DatasetFactory<OpenLineage.OutputDataset> typedFactory = mock(DatasetFactory.class);
-    factory = typedFactory;
+    factory = mockDatasetFactory();
     builder = new WriteToMicroBatchDataSourceV1DatasetBuilder(openLineageContext, factory);
 
     writeToMicroBatchV1 = mock(WriteToMicroBatchDataSourceV1.class);
-    fileStreamSink = mock(FileStreamSink.class);
     unsupportedSink = mock(Sink.class);
 
     QueryExecution queryExecution = mock(QueryExecution.class);
@@ -130,15 +128,6 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
   }
 
   @Test
-  void testApply_WithFileStreamSink_NoCatalogTable() {
-    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
-    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
-
-    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
   void testApply_WithCatalogTableRegardlessOfSink() {
     OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
     CatalogTable catalogTable = mock(CatalogTable.class);
@@ -147,8 +136,7 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     when(writeToMicroBatchV1.schema()).thenReturn(schema);
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.apply(catalogTable));
 
-    @SuppressWarnings("unchecked")
-    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mock(SparkDatasetBuilder.class);
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mockSparkDatasetBuilder();
     when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
     when(sparkBuilder.dataset(catalogTable)).thenReturn(sparkBuilder);
     when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);
@@ -171,12 +159,9 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     when(writeToMicroBatchV1.schema()).thenReturn(schema);
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
     when(writeToMicroBatchV1.writeOptions())
-        .thenReturn(
-            ScalaConversionUtils.fromJavaMap(
-                Collections.singletonMap("path", "/tmp/delta_target")));
+        .thenReturn(ScalaConversionUtils.fromJavaMap(Collections.singletonMap("path", DELTA_PATH)));
 
-    @SuppressWarnings("unchecked")
-    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mock(SparkDatasetBuilder.class);
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mockSparkDatasetBuilder();
     when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
     when(sparkBuilder.dataset(any(DatasetIdentifier.class))).thenReturn(sparkBuilder);
     when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);
@@ -189,7 +174,7 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     ArgumentCaptor<DatasetIdentifier> identifierCaptor =
         ArgumentCaptor.forClass(DatasetIdentifier.class);
     verify(sparkBuilder).dataset(identifierCaptor.capture());
-    assertEquals("/tmp/delta_target", identifierCaptor.getValue().getName());
+    assertEquals(DELTA_PATH, identifierCaptor.getValue().getName());
     assertEquals("file", identifierCaptor.getValue().getNamespace());
     verify(sparkBuilder).schema(schema);
   }
@@ -203,12 +188,9 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     when(writeToMicroBatchV1.schema()).thenReturn(schema);
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
     when(writeToMicroBatchV1.writeOptions())
-        .thenReturn(
-            ScalaConversionUtils.fromJavaMap(
-                Collections.singletonMap("PaTh", "/tmp/delta_target")));
+        .thenReturn(ScalaConversionUtils.fromJavaMap(Collections.singletonMap("PaTh", DELTA_PATH)));
 
-    @SuppressWarnings("unchecked")
-    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mock(SparkDatasetBuilder.class);
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mockSparkDatasetBuilder();
     when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
     when(sparkBuilder.dataset(any(DatasetIdentifier.class))).thenReturn(sparkBuilder);
     when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);
@@ -220,20 +202,36 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     ArgumentCaptor<DatasetIdentifier> identifierCaptor =
         ArgumentCaptor.forClass(DatasetIdentifier.class);
     verify(sparkBuilder).dataset(identifierCaptor.capture());
-    assertEquals("/tmp/delta_target", identifierCaptor.getValue().getName());
+    assertEquals(DELTA_PATH, identifierCaptor.getValue().getName());
   }
 
   @Test
   void testApply_WithDeltaSinkAndNoPathWriteOption() {
-    DeltaSink deltaSink = mock(DeltaSink.class);
+    assertDeltaSinkWithoutOutput(Collections.emptyMap());
+  }
 
-    when(writeToMicroBatchV1.sink()).thenReturn(deltaSink);
+  @Test
+  void testApply_WithDeltaSinkAndBlankPathWriteOption() {
+    assertDeltaSinkWithoutOutput(Collections.singletonMap("path", ""));
+  }
+
+  private void assertDeltaSinkWithoutOutput(Map<String, String> writeOptions) {
+    when(writeToMicroBatchV1.sink()).thenReturn(mock(DeltaSink.class));
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
-    when(writeToMicroBatchV1.writeOptions()).thenReturn(ScalaConversionUtils.asScalaMapEmpty());
+    when(writeToMicroBatchV1.writeOptions())
+        .thenReturn(ScalaConversionUtils.fromJavaMap(writeOptions));
 
-    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
-
-    assertTrue(result.isEmpty());
+    assertTrue(builder.apply(event, writeToMicroBatchV1).isEmpty());
     verify(factory, never()).sparkDatasetBuilder();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static DatasetFactory<OpenLineage.OutputDataset> mockDatasetFactory() {
+    return mock(DatasetFactory.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static SparkDatasetBuilder<OpenLineage.OutputDataset> mockSparkDatasetBuilder() {
+    return mock(SparkDatasetBuilder.class);
   }
 }

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
@@ -8,6 +8,7 @@ package io.openlineage.spark34.agent.lifecycle.plan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -15,17 +16,21 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkDatasetBuilder;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.Collections;
 import java.util.List;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.delta.sources.DeltaSink;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.execution.streaming.FileStreamSink;
 import org.apache.spark.sql.execution.streaming.Sink;
@@ -36,6 +41,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import scala.Option;
 
 class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
@@ -113,8 +119,9 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
   }
 
   @Test
-  void testApply_WithUnsupportedSink() {
+  void testApply_WithUnknownSinkAndNoCatalogTable() {
     when(writeToMicroBatchV1.sink()).thenReturn(unsupportedSink);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
 
     List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
 
@@ -132,11 +139,11 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
   }
 
   @Test
-  void testApply_WithFileStreamSink_ValidPath_WithCatalogTable() {
+  void testApply_WithCatalogTableRegardlessOfSink() {
     OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
     CatalogTable catalogTable = mock(CatalogTable.class);
 
-    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.sink()).thenReturn(unsupportedSink);
     when(writeToMicroBatchV1.schema()).thenReturn(schema);
     when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.apply(catalogTable));
 
@@ -153,5 +160,80 @@ class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
     assertEquals(expectedDataset, result.get(0));
     verify(sparkBuilder).dataset(catalogTable);
     verify(sparkBuilder).schema(schema);
+  }
+
+  @Test
+  void testApply_WithDeltaSinkPathWriteOptionAndNoCatalogTable() {
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+    DeltaSink deltaSink = mock(DeltaSink.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(deltaSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(writeToMicroBatchV1.writeOptions())
+        .thenReturn(
+            ScalaConversionUtils.fromJavaMap(
+                Collections.singletonMap("path", "/tmp/delta_target")));
+
+    @SuppressWarnings("unchecked")
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mock(SparkDatasetBuilder.class);
+    when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
+    when(sparkBuilder.dataset(any(DatasetIdentifier.class))).thenReturn(sparkBuilder);
+    when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);
+    when(sparkBuilder.build()).thenReturn(expectedDataset);
+
+    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+    assertEquals(1, result.size());
+    assertEquals(expectedDataset, result.get(0));
+    ArgumentCaptor<DatasetIdentifier> identifierCaptor =
+        ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(sparkBuilder).dataset(identifierCaptor.capture());
+    assertEquals("/tmp/delta_target", identifierCaptor.getValue().getName());
+    assertEquals("file", identifierCaptor.getValue().getNamespace());
+    verify(sparkBuilder).schema(schema);
+  }
+
+  @Test
+  void testApply_WithDeltaSinkPathWriteOptionIsCaseInsensitive() {
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+    DeltaSink deltaSink = mock(DeltaSink.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(deltaSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(writeToMicroBatchV1.writeOptions())
+        .thenReturn(
+            ScalaConversionUtils.fromJavaMap(
+                Collections.singletonMap("PaTh", "/tmp/delta_target")));
+
+    @SuppressWarnings("unchecked")
+    SparkDatasetBuilder<OpenLineage.OutputDataset> sparkBuilder = mock(SparkDatasetBuilder.class);
+    when(factory.sparkDatasetBuilder()).thenReturn(sparkBuilder);
+    when(sparkBuilder.dataset(any(DatasetIdentifier.class))).thenReturn(sparkBuilder);
+    when(sparkBuilder.schema(schema)).thenReturn(sparkBuilder);
+    when(sparkBuilder.build()).thenReturn(expectedDataset);
+
+    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+    assertEquals(1, result.size());
+    ArgumentCaptor<DatasetIdentifier> identifierCaptor =
+        ArgumentCaptor.forClass(DatasetIdentifier.class);
+    verify(sparkBuilder).dataset(identifierCaptor.capture());
+    assertEquals("/tmp/delta_target", identifierCaptor.getValue().getName());
+  }
+
+  @Test
+  void testApply_WithDeltaSinkAndNoPathWriteOption() {
+    DeltaSink deltaSink = mock(DeltaSink.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(deltaSink);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(writeToMicroBatchV1.writeOptions()).thenReturn(ScalaConversionUtils.asScalaMapEmpty());
+
+    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+    assertTrue(result.isEmpty());
+    verify(factory, never()).sparkDatasetBuilder();
   }
 }


### PR DESCRIPTION
### One-line summary for changelog:

Spark: V1 structured-streaming writes to Delta now include their output dataset on Spark 4.

### Meaningful description

Spark 4 + Delta plans streaming writes as `WriteToMicroBatchDataSourceV1` with a `org.apache.spark.sql.delta.sources.DeltaSink`. The existing builder only entered its output path for Spark 3's `FileStreamSink`. As a result, Delta streaming COMPLETE events had no output; on Spark 4 the `instanceof FileStreamSink` check could also raise `NoClassDefFoundError` because Spark moved that class to a different package.

This change:

1. uses the logical node's catalog table whenever it is defined, regardless of sink type;
2. for a Delta sink without catalog metadata, falls back to the case-insensitive `path` entry in `writeOptions`;
3. detects Delta by walking the sink class hierarchy, avoiding a Delta runtime dependency;
4. keeps the existing empty behavior for unsupported sinks without catalog metadata.

The `writeOptions` API is present on this logical node in Spark 3.4 and Spark 4, and `DataStreamWriter.start(path)` places its target there.

Validation:

- 10 focused `WriteToMicroBatchDataSourceV1DatasetBuilderTest` tests pass.
- Spark 3.4 Spotless and PMD checks pass, as does `git diff --check`.
- On Spark 4.1 + Delta, an AvailableNow Kafka replay on current `main` emits the Kafka input but no streaming output and logs two `FileStreamSink` linkage errors. With this patch both streaming COMPLETE events also carry the Delta target and the linkage errors disappear.
- A two-topic Kafka-to-Delta job much closer to our production setup shows the same result: the target output appears while both topic inputs are preserved.

Closes #4887

Related to #4110

### Checklist

- [x] AI was used in creating this PR
