### PR TITLE
spark: preserve Delta identity during session teardown

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -12,12 +12,14 @@ import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -56,11 +58,114 @@ public class DeltaHandler implements CatalogHandler {
   }
 
   @Override
+  @SneakyThrows
   public DatasetIdentifier getDatasetIdentifier(
       SparkSession session,
       TableCatalog tableCatalog,
       Identifier identifier,
       Map<String, String> properties) {
+    boolean setActiveSession = !SparkSession.getActiveSession().isDefined();
+    if (setActiveSession) {
+      // Delta catalog loading resolves the global active session, which may be absent on listener
+      // threads, most visibly while the final events are processed during application teardown.
+      SparkSession.setActiveSession(session);
+    }
+
+    try {
+      return getDatasetIdentifierFromCatalog(session, tableCatalog, identifier);
+    } catch (Exception e) {
+      if (!isMissingActiveSessionError(e)) {
+        throw e;
+      }
+      // The session is no longer usable (e.g. SparkContext already stopped during application
+      // teardown; Spark 4 rejects stopped sessions even when set as active), so the table cannot
+      // be loaded from the Delta catalog anymore. Derive a best-effort location-based identifier
+      // instead of dropping the dataset.
+      log.warn(
+          "Delta catalog lookup failed because no usable Spark session is available; "
+              + "falling back to a location-based dataset identifier",
+          e);
+      return fallbackDatasetIdentifier(session, identifier, properties, e);
+    } finally {
+      if (setActiveSession) {
+        SparkSession.clearActiveSession();
+      }
+    }
+  }
+
+  private static boolean isMissingActiveSessionError(Throwable e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      String message = t.getMessage();
+      if (message != null && message.contains("No active or default Spark session found")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Builds a dataset identifier without touching the Delta catalog, used when the catalog cannot be
+   * queried anymore (no usable Spark session). Falls back to the table location from the plan
+   * properties, or the default warehouse location; rethrows the original failure when neither is
+   * available.
+   */
+  @SneakyThrows
+  private DatasetIdentifier fallbackDatasetIdentifier(
+      SparkSession session,
+      Identifier identifier,
+      Map<String, String> properties,
+      Exception cause) {
+    // Path identifier (e.g. delta.`/some/path`): the identifier name is the location itself.
+    if (new Path(identifier.name()).isAbsolute()) {
+      return PathUtils.fromPath(new Path(identifier.name()));
+    }
+
+    Optional<String> location = location(properties);
+    if (location.isPresent()) {
+      return PathUtils.fromTableIdentifier(
+          toTableIdentifier(identifier), session.sparkContext(), new Path(location.get()).toUri());
+    }
+
+    Optional<URI> warehouseLocation =
+        PathUtils.getWarehouseLocation(
+            session.sparkContext().getConf(), session.sparkContext().hadoopConfiguration());
+    if (warehouseLocation.isPresent()) {
+      Path defaultLocation =
+          PathUtils.reconstructDefaultLocation(
+              warehouseLocation.get().toString(), identifier.namespace(), identifier.name());
+      return PathUtils.fromTableIdentifier(
+          toTableIdentifier(identifier), session.sparkContext(), defaultLocation.toUri());
+    }
+
+    throw cause;
+  }
+
+  private static Optional<String> location(Map<String, String> properties) {
+    return properties.entrySet().stream()
+        .filter(
+            entry ->
+                TableCatalog.PROP_LOCATION.equalsIgnoreCase(entry.getKey())
+                    || "path".equalsIgnoreCase(entry.getKey()))
+        .map(Map.Entry::getValue)
+        .filter(value -> value != null && !value.isEmpty())
+        .findFirst();
+  }
+
+  private static TableIdentifier toTableIdentifier(Identifier identifier) {
+    String[] namespace = identifier.namespace();
+    String database = null;
+    if (namespace.length == 1) {
+      // {"database"}
+      database = namespace[0];
+    } else if (namespace.length > 1) {
+      // {"spark_catalog", "database"}
+      database = namespace[1];
+    }
+    return new TableIdentifier(identifier.name(), Option.apply(database));
+  }
+
+  private DatasetIdentifier getDatasetIdentifierFromCatalog(
+      SparkSession session, TableCatalog tableCatalog, Identifier identifier) {
     DeltaCatalog catalog = (DeltaCatalog) tableCatalog;
 
     Table table = catalog.loadTable(identifier);
@@ -126,8 +231,18 @@ public class DeltaHandler implements CatalogHandler {
   @Override
   public Optional<String> getDatasetVersion(
       TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
-    DeltaCatalog deltaCatalog = (DeltaCatalog) tableCatalog;
-    return DeltaVersionUtils.getDatasetVersion(deltaCatalog.loadTable(identifier));
+    try {
+      DeltaCatalog deltaCatalog = (DeltaCatalog) tableCatalog;
+      return DeltaVersionUtils.getDatasetVersion(deltaCatalog.loadTable(identifier));
+    } catch (Exception e) {
+      if (isMissingActiveSessionError(e)) {
+        log.warn(
+            "Unable to resolve Delta dataset version without a usable Spark session; "
+                + "omitting the version");
+        return Optional.empty();
+      }
+      throw e;
+    }
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -32,6 +32,7 @@ import scala.Option;
 @Slf4j
 public class DeltaHandler implements CatalogHandler {
   private static final String DELTA = "delta";
+  private static final String PATH_PROPERTY = "path";
   private final OpenLineageContext context;
 
   public DeltaHandler(OpenLineageContext context) {
@@ -141,11 +142,13 @@ public class DeltaHandler implements CatalogHandler {
   }
 
   private static Optional<String> location(Map<String, String> properties) {
+    Optional<String> tableLocation = property(properties, TableCatalog.PROP_LOCATION);
+    return tableLocation.isPresent() ? tableLocation : property(properties, PATH_PROPERTY);
+  }
+
+  private static Optional<String> property(Map<String, String> properties, String name) {
     return properties.entrySet().stream()
-        .filter(
-            entry ->
-                TableCatalog.PROP_LOCATION.equalsIgnoreCase(entry.getKey())
-                    || "path".equalsIgnoreCase(entry.getKey()))
+        .filter(entry -> name.equalsIgnoreCase(entry.getKey()))
         .map(Map.Entry::getValue)
         .filter(value -> value != null && !value.isEmpty())
         .findFirst();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/V2CreateTablePlanUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/V2CreateTablePlanUtils.java
@@ -63,14 +63,19 @@ public class V2CreateTablePlanUtils {
    */
   public static Map<String, String> properties(LogicalPlan plan) {
     Map<String, String> properties = new LinkedHashMap<>();
-    Optional<Object> specProperties =
-        invoke(plan, "tableSpec").flatMap(spec -> invoke(spec, "properties"));
+    Optional<Object> tableSpec = invoke(plan, "tableSpec");
+    Optional<Object> specProperties = tableSpec.flatMap(spec -> invoke(spec, "properties"));
 
     if (specProperties.isPresent()) {
       properties.putAll(toJavaMap(specProperties.get()));
     } else {
       invoke(plan, "properties").ifPresent(p -> properties.putAll(toJavaMap(p)));
     }
+
+    tableSpec
+        .flatMap(spec -> invoke(spec, "location"))
+        .flatMap(V2CreateTablePlanUtils::stringValue)
+        .ifPresent(location -> properties.put(TableCatalog.PROP_LOCATION, location));
 
     invoke(plan, "writeOptions").ifPresent(options -> properties.putAll(toJavaMap(options)));
     return properties;
@@ -104,6 +109,22 @@ public class V2CreateTablePlanUtils {
 
   private static <T> Optional<T> cast(Optional<Object> value, Class<T> type) {
     return value.filter(type::isInstance).map(type::cast);
+  }
+
+  private static Optional<String> stringValue(Object value) {
+    if (value instanceof String) {
+      return Optional.of((String) value);
+    }
+    if (value instanceof scala.Option) {
+      scala.Option<?> option = (scala.Option<?>) value;
+      return option.isDefined() && option.get() instanceof String
+          ? Optional.of((String) option.get())
+          : Optional.empty();
+    }
+    if (value instanceof Optional) {
+      return ((Optional<?>) value).filter(String.class::isInstance).map(String.class::cast);
+    }
+    return Optional.empty();
   }
 
   @SafeVarargs

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.V1Table;
 import org.apache.spark.sql.delta.catalog.DeltaCatalog;
 import org.apache.spark.sql.delta.catalog.DeltaTableV2;
@@ -88,6 +90,156 @@ class DeltaHandlerTest {
         .hasFieldOrPropertyWithValue("name", "/some/location");
 
     assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
+  }
+
+  @Test
+  void testGetIdentifierSetsAndClearsActiveSessionForCatalogLookup() {
+    SparkSession.clearActiveSession();
+    Identifier identifier = Identifier.of(new String[] {}, "/some/location");
+    DeltaTableV2 deltaTable = mock(DeltaTableV2.class);
+    when(deltaCatalog.loadTable(identifier))
+        .thenAnswer(
+            invocation -> {
+              assertThat(SparkSession.getActiveSession().isDefined()).isTrue();
+              return deltaTable;
+            });
+    when(deltaCatalog.isPathIdentifier(identifier)).thenReturn(true);
+
+    deltaHandler.getDatasetIdentifier(
+        sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(SparkSession.getActiveSession().isEmpty()).isTrue();
+  }
+
+  @Test
+  void testGetIdentifierPreservesPreExistingActiveSession() {
+    Identifier identifier = Identifier.of(new String[] {}, "/some/location");
+    DeltaTableV2 deltaTable = mock(DeltaTableV2.class);
+    when(deltaCatalog.loadTable(identifier)).thenReturn(deltaTable);
+    when(deltaCatalog.isPathIdentifier(identifier)).thenReturn(true);
+    SparkSession.setActiveSession(sparkSession);
+
+    try {
+      deltaHandler.getDatasetIdentifier(
+          sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+      assertThat(SparkSession.getActiveSession().isDefined()).isTrue();
+      assertThat(SparkSession.getActiveSession().get()).isSameAs(sparkSession);
+    } finally {
+      SparkSession.clearActiveSession();
+    }
+  }
+
+  @Test
+  void testGetIdentifierFallsBackToLocationPropertyWhenSessionIsUnusable() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(
+            new IllegalStateException(
+                "[INTERNAL_ERROR] No active or default Spark session found SQLSTATE: XX000"));
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession,
+            deltaCatalog,
+            identifier,
+            Collections.singletonMap(TableCatalog.PROP_LOCATION, "/some/location"));
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/some/location");
+  }
+
+  @Test
+  void testGetIdentifierFallsBackToPathWriteOptionWhenSessionIsUnusable() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(
+            new IllegalStateException(
+                "[INTERNAL_ERROR] No active or default Spark session found SQLSTATE: XX000"));
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession,
+            deltaCatalog,
+            identifier,
+            Collections.singletonMap("PaTh", "/some/custom/location"));
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/some/custom/location");
+  }
+
+  @Test
+  void testGetIdentifierFallsBackToDefaultWarehouseLocationWhenSessionIsUnusable() {
+    Identifier identifier = Identifier.of(new String[] {"schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(new IllegalStateException("No active or default Spark session found"));
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "file:/tmp/warehouse")
+        .hasFieldOrPropertyWithValue("name", "schema.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  void testGetIdentifierFallsBackToPathForPathIdentifierWhenSessionIsUnusable() {
+    Identifier identifier = Identifier.of(new String[] {"delta"}, "/some/location");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(new IllegalStateException("No active or default Spark session found"));
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/some/location");
+  }
+
+  @Test
+  void testGetDatasetVersionOmitsVersionWhenSessionIsUnusable() {
+    Identifier identifier = Identifier.of(new String[] {"schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(new IllegalStateException("No active or default Spark session found"));
+
+    Optional<String> version =
+        deltaHandler.getDatasetVersion(deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(version).isEmpty();
+  }
+
+  @Test
+  void testGetDatasetVersionRethrowsUnrelatedCatalogFailures() {
+    Identifier identifier = Identifier.of(new String[] {"schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(new IllegalStateException("some other failure"));
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> deltaHandler.getDatasetVersion(deltaCatalog, identifier, Collections.emptyMap()));
+  }
+
+  @Test
+  void testGetIdentifierRethrowsUnrelatedCatalogFailures() {
+    Identifier identifier = Identifier.of(new String[] {"schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(new IllegalStateException("some other failure"));
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            deltaHandler.getDatasetIdentifier(
+                sparkSession, deltaCatalog, identifier, Collections.emptyMap()));
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -18,6 +18,8 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.hadoop.conf.Configuration;
@@ -148,6 +150,23 @@ class DeltaHandlerTest {
     assertThat(datasetIdentifier)
         .hasFieldOrPropertyWithValue("namespace", "file")
         .hasFieldOrPropertyWithValue("name", "/some/location");
+  }
+
+  @Test
+  void testGetIdentifierPrefersTableLocationOverPathWriteOption() {
+    Identifier identifier = Identifier.of(new String[] {"schema"}, "table");
+    when(deltaCatalog.loadTable(identifier))
+        .thenThrow(new IllegalStateException("No active or default Spark session found"));
+    Map<String, String> properties = new LinkedHashMap<>();
+    properties.put("path", "/write/option/path");
+    properties.put(TableCatalog.PROP_LOCATION, "/table/location");
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(sparkSession, deltaCatalog, identifier, properties);
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/table/location");
   }
 
   @Test

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -151,6 +151,32 @@ class CreateReplaceDatasetBuilderTest {
   }
 
   @Test
+  void testApplyIncludesTableSpecLocationInCatalogProperties() {
+    String location = "/some/custom/location";
+    CreateTable logicalPlan = mock(CreateTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(tableSpec.location()).thenReturn(Option.apply(location));
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+
+    DatasetIdentifier di = new DatasetIdentifier(location, "file");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalog,
+              tableName,
+              Collections.singletonMap(TableCatalog.PROP_LOCATION, location)))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+      assertThat(outputDatasets).singleElement().hasFieldOrPropertyWithValue("name", location);
+    }
+  }
+
+  @Test
   void testApplyDatasetVersionIncluded() {
     ReplaceTable logicalPlan = mock(ReplaceTable.class);
     when(logicalPlan.name()).thenReturn(namePlan);


### PR DESCRIPTION
### One-line summary for changelog:

Spark: Delta create/replace events preserve their output identity when asynchronous processing races Spark session teardown.

### Meaningful description

`DeltaHandler.getDatasetIdentifier` calls `DeltaCatalog.loadTable`. Delta resolves the global active/default Spark session internally, even though the handler receives the query's `SparkSession`. OpenLineage callbacks run on an asynchronous listener thread; when a final create/replace event races `spark.stop()`, the global session can already be cleared. The catalog lookup then fails with `No active or default Spark session found`, and the output dataset is dropped.

This change:

1. temporarily sets the passed session as the thread-local active session when the listener thread has none, preserving any pre-existing active session;
2. if Spark 4 has already stopped that session and the lookup fails with this specific error, derives the identifier from the plan-carried table `location`, or the case-insensitive `path` value when no location is present;
3. copies reflective `TableSpec.location` into the catalog properties so create/replace plans retain custom locations across Spark and Databricks API shapes;
4. falls back to the normal managed-table warehouse layout only when the plan has no explicit location;
5. omits the version facet for the same teardown error instead of losing the recovered dataset;
6. rethrows unrelated catalog failures unchanged.

Validation:

- 18 `DeltaHandlerTest` tests and 14 create/replace builder tests pass with both Scala 2.12 and Scala 2.13.
- Spark 3 and Spark 3.5 Spotless and PMD checks pass for both Scala source sets, as does `git diff --check`.
- A Spark 4.1 + Delta job whose final action writes a named, custom-location Delta table and then immediately calls `spark.stop()` reproduces the bug on current `main`: the application exits cleanly but emits no output and logs the failed `DeltaHandler` lookup. With this patch the event contains the custom path along with the Delta catalog, storage, schema, and overwrite lifecycle facets.

Once the session is stopped the Delta version can no longer be read, so the version facet is left out on purpose — the dataset itself is still emitted.

Closes #4888

### Checklist

- [x] AI was used in creating this PR
