### PR TITLE
integrations: add Temporal integration

### DIFF
--- a/integration/temporalio/adapter.py
+++ b/integration/temporalio/adapter.py
@@ -61,23 +61,17 @@ class TemporalOpenLineageAdapter:
             "producer": self.producer,
         }
 
-        try:
-            inputs = [
-                Dataset(namespace=dataset["uri"], name=dataset["table"])
-                for dataset in input_datasets
-            ]
-            kwargs["inputs"] = inputs
-        except KeyError:
-            logger.info(f"No input datasets will be included in {taskname} event.")
+        inputs = [
+            Dataset(namespace=dataset["uri"], name=dataset["table"])
+            for dataset in input_datasets
+        ]
+        kwargs["inputs"] = inputs
 
-        try:
-            outputs = [
-                Dataset(namespace=dataset["uri"], name=dataset["table"])
-                for dataset in output_datasets
-            ]
-            kwargs["outputs"] = outputs
-        except KeyError:
-            logger.info(f"No output datasets will be included in {taskname} event.")
+        outputs = [
+            Dataset(namespace=dataset["uri"], name=dataset["table"])
+            for dataset in output_datasets
+        ]
+        kwargs["outputs"] = outputs
 
         run_event = RunEvent(**kwargs)
         self.client.emit(run_event)

--- a/integration/temporalio/adapter.py
+++ b/integration/temporalio/adapter.py
@@ -1,11 +1,17 @@
 # Copyright 2018-2026 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+# Warning: this integration is experimental and in active development.
+
 import datetime
+import logging
 import os
 
 from openlineage.client import OpenLineageClient
-from openlineage.client.facet import ( JobTypeJobFacet )
+from openlineage.client.event_v2 import Dataset
+from openlineage.client.facet import (
+    JobTypeJobFacet
+)
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.uuid import generate_static_uuid
 
@@ -15,9 +21,13 @@ PRODUCER: str = (
 
 NAMESPACE = os.environ.get("TEMPORAL_OPENLINEAGE_NAMESPACE", "default")
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 class TemporalOpenLineageAdapter:
     def __init__(self, client: OpenLineageClient | None = None):
         self.client = client or OpenLineageClient()
+        self.namespace = NAMESPACE
+        self.producer = PRODUCER
 
     def build_run_id(
         self, execution_time: datetime, run_name: str
@@ -27,7 +37,7 @@ class TemporalOpenLineageAdapter:
         return str(
             generate_static_uuid(
                 instant=execution_time,
-                data=f"{NAMESPACE}.{run_name}".encode("utf-8"),
+                data=f"{self.namespace}.{run_name}".encode("utf-8"),
             )
         )
 
@@ -36,7 +46,9 @@ class TemporalOpenLineageAdapter:
         runId: str,
         eventType: str,
         eventTime: datetime,
-        taskName: str
+        taskName: str,
+        input_datasets: list = [],
+        output_datasets: list = []
     ) -> RunEvent:
         """Create and emit an OpenLineage task event."""
 
@@ -46,11 +58,31 @@ class TemporalOpenLineageAdapter:
             )
         }
 
-        run_event = RunEvent(
-            eventType=eventType,
-            eventTime=eventTime.isoformat(),
-            run=Run(runId),
-            job=Job(NAMESPACE, taskName, job_facets),
-            producer=PRODUCER,
-        )
+        kwargs = {
+            "eventType": eventType,
+            "eventTime": eventTime.isoformat(),
+            "run": Run(runId),
+            "job": Job(self.namespace, taskName, job_facets),
+            "producer": self.producer,
+        }
+
+        try:
+            inputs = [
+                Dataset(namespace=dataset["uri"], name=dataset["table"])
+                for dataset in input_datasets
+            ]
+            kwargs["inputs"] = inputs
+        except:
+            logger.info(f"No input datasets will be included in {taskname} event.")
+
+        try:
+            outputs = [
+                Dataset(namespace=dataset["uri"], name=dataset["table"])
+                for dataset in output_datasets
+            ]
+            kwargs["outputs"] = outputs
+        except:
+            logger.info(f"No output datasets will be included in {taskname} event.")
+
+        run_event = RunEvent(**kwargs)
         self.client.emit(run_event)

--- a/integration/temporalio/adapter.py
+++ b/integration/temporalio/adapter.py
@@ -1,0 +1,56 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+import os
+
+from openlineage.client import OpenLineageClient
+from openlineage.client.facet import ( JobTypeJobFacet )
+from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_static_uuid
+
+PRODUCER: str = (
+    "https://github.com/OpenLineage/openlineage/integration/temporal"
+)
+
+NAMESPACE = os.environ.get("TEMPORAL_OPENLINEAGE_NAMESPACE", "default")
+
+class TemporalOpenLineageAdapter:
+    def __init__(self, client: OpenLineageClient | None = None):
+        self.client = client or OpenLineageClient()
+
+    def build_run_id(
+        self, execution_time: datetime, run_name: str
+    ) -> str:
+        """Build a deterministic UUID for the OpenLineage run based on the execution time, run name, and namespace."""
+
+        return str(
+            generate_static_uuid(
+                instant=execution_time,
+                data=f"{NAMESPACE}.{run_name}".encode("utf-8"),
+            )
+        )
+
+    def create_and_emit_task_event(
+        self,
+        runId: str,
+        eventType: str,
+        eventTime: datetime,
+        taskName: str
+    ) -> RunEvent:
+        """Create and emit an OpenLineage task event."""
+
+        job_facets = {
+            "jobType": JobTypeJobFacet(
+                processingType="BATCH", integration="Temporal", jobType="TASK"
+            )
+        }
+
+        run_event = RunEvent(
+            eventType=eventType,
+            eventTime=eventTime.isoformat(),
+            run=Run(runId),
+            job=Job(NAMESPACE, taskName, job_facets),
+            producer=PRODUCER,
+        )
+        self.client.emit(run_event)

--- a/integration/temporalio/adapter.py
+++ b/integration/temporalio/adapter.py
@@ -15,7 +15,7 @@ from openlineage.client.uuid import generate_static_uuid
 
 PRODUCER: str = "https://github.com/OpenLineage/openlineage/integration/temporal"
 
-NAMESPACE = os.environ.get("TEMPORAL_OPENLINEAGE_NAMESPACE", "default")
+NAMESPACE = os.environ.get("OPENLINEAGE_NAMESPACE", "default")
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/integration/temporalio/adapter.py
+++ b/integration/temporalio/adapter.py
@@ -9,19 +9,16 @@ import os
 
 from openlineage.client import OpenLineageClient
 from openlineage.client.event_v2 import Dataset
-from openlineage.client.facet import (
-    JobTypeJobFacet
-)
+from openlineage.client.facet import JobTypeJobFacet
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.uuid import generate_static_uuid
 
-PRODUCER: str = (
-    "https://github.com/OpenLineage/openlineage/integration/temporal"
-)
+PRODUCER: str = "https://github.com/OpenLineage/openlineage/integration/temporal"
 
 NAMESPACE = os.environ.get("TEMPORAL_OPENLINEAGE_NAMESPACE", "default")
 
 logger: logging.Logger = logging.getLogger(__name__)
+
 
 class TemporalOpenLineageAdapter:
     def __init__(self, client: OpenLineageClient | None = None):
@@ -29,9 +26,7 @@ class TemporalOpenLineageAdapter:
         self.namespace = NAMESPACE
         self.producer = PRODUCER
 
-    def build_run_id(
-        self, execution_time: datetime, run_name: str
-    ) -> str:
+    def build_run_id(self, execution_time: datetime, run_name: str) -> str:
         """Build a deterministic UUID for the OpenLineage run based on the execution time, run name, and namespace."""
 
         return str(
@@ -48,7 +43,7 @@ class TemporalOpenLineageAdapter:
         eventTime: datetime,
         taskName: str,
         input_datasets: list = [],
-        output_datasets: list = []
+        output_datasets: list = [],
     ) -> RunEvent:
         """Create and emit an OpenLineage task event."""
 
@@ -72,7 +67,7 @@ class TemporalOpenLineageAdapter:
                 for dataset in input_datasets
             ]
             kwargs["inputs"] = inputs
-        except:
+        except KeyError:
             logger.info(f"No input datasets will be included in {taskname} event.")
 
         try:
@@ -81,7 +76,7 @@ class TemporalOpenLineageAdapter:
                 for dataset in output_datasets
             ]
             kwargs["outputs"] = outputs
-        except:
+        except KeyError:
             logger.info(f"No output datasets will be included in {taskname} event.")
 
         run_event = RunEvent(**kwargs)

--- a/integration/temporalio/adapter.py
+++ b/integration/temporalio/adapter.py
@@ -10,7 +10,7 @@ import os
 from openlineage.client import OpenLineageClient
 from openlineage.client.event_v2 import Dataset
 from openlineage.client.facet import JobTypeJobFacet
-from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.run import Job, Run, RunEvent
 from openlineage.client.uuid import generate_static_uuid
 
 PRODUCER: str = "https://github.com/OpenLineage/openlineage/integration/temporal"
@@ -27,23 +27,26 @@ class TemporalOpenLineageAdapter:
         self.producer = PRODUCER
 
     def build_run_id(self, execution_time: datetime, run_name: str) -> str:
-        """Build a deterministic UUID for the OpenLineage run based on the execution time, run name, and namespace."""
+        """
+        Build a deterministic UUID for the OpenLineage run based on the
+        execution time, run name, and namespace.
+        """
 
         return str(
             generate_static_uuid(
                 instant=execution_time,
-                data=f"{self.namespace}.{run_name}".encode("utf-8"),
+                data=f"{self.namespace}.{run_name}".encode(),
             )
         )
 
     def create_and_emit_task_event(
         self,
-        runId: str,
-        eventType: str,
-        eventTime: datetime,
-        taskName: str,
-        input_datasets: list = [],
-        output_datasets: list = [],
+        run_id: str,
+        event_type: str,
+        event_time: datetime,
+        task_name: str,
+        input_datasets: list | None = None,
+        output_datasets: list | None = None,
     ) -> RunEvent:
         """Create and emit an OpenLineage task event."""
 
@@ -54,10 +57,10 @@ class TemporalOpenLineageAdapter:
         }
 
         kwargs = {
-            "eventType": eventType,
-            "eventTime": eventTime.isoformat(),
-            "run": Run(runId),
-            "job": Job(self.namespace, taskName, job_facets),
+            "event_type": event_type,
+            "event_time": event_time.isoformat(),
+            "run": Run(run_id),
+            "job": Job(self.namespace, task_name, job_facets),
             "producer": self.producer,
         }
 

--- a/integration/temporalio/harvester.py
+++ b/integration/temporalio/harvester.py
@@ -1,52 +1,69 @@
 # Copyright 2018-2026 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+# Warning: this integration is experimental and in active development.
+
+import json
+import logging
 import os
 
+from openlineage.client import OpenLineageClient
+from openlineage.client.event_v2 import Dataset
+from openlineage.client.facet import (
+    JobTypeJobFacet
+)
+from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_static_uuid
 from temporalio.client import Client
 from temporalio.service import ( RPCError )
 
 from adapter import TemporalOpenLineageAdapter
 
+logger: logging.Logger = logging.getLogger(__name__)
 
-async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
-    """Get events from the Temporal API, process them, and pass them to the adapter."""
+
+async def get_temporal_events(event_data: list, t_client: Client) -> None:
     adapter = TemporalOpenLineageAdapter()
-
+    input_datasets = []
+    output_datasets = []
     temporal_events = []
-    for workflow_id in workflow_ids:
+
+    for workflow in event_data:
+
         try:
-            description = await t_client.get_workflow_handle(workflow_id).describe()
+            description = await t_client.get_workflow_handle(workflow["id"]).describe()
         except RPCError:
-            print(f"Description not found for workflow with id {workflow_id}")
+            print(f"Description not found for workflow with id {workflow["id"]}")
             continue
+
         start_event_name = description.id
         start_event_time = description.start_time
         start_event_run_id = adapter.build_run_id(start_event_time, start_event_name)
 
-        adapter.create_and_emit_task_event(
-                                            start_event_run_id, 
-                                            RunState.START, 
-                                            start_event_time, 
-                                            start_event_name
-                                            )
+        try:
+            input_datasets = [dataset for dataset in workflow["datasets"] if dataset["type"] == "input"]
+        except:
+            logger.info(f"No input datasets found for workflow {workflow["id"]}.")
 
+        try:
+            output_datasets = [dataset for dataset in workflow["datasets"] if dataset["type"] == "output"]
+        except:
+            logger.info(f"No output datasets found for workflow {workflow["id"]}.")
+
+        # Start event
+        adapter.create_and_emit_task_event(start_event_run_id, RunState.START, start_event_time, start_event_name)
+
+        # Complete event
         if description.raw_info.status == 2:
             complete_event_name = description.id
             complete_event_time = description.close_time
-            adapter.create_and_emit_task_event(
-                                                start_event_run_id, 
-                                                RunState.COMPLETE, 
-                                                complete_event_time, 
-                                                complete_event_name
-                                                )
 
+            adapter.create_and_emit_task_event(start_event_run_id, RunState.COMPLETE, complete_event_time, complete_event_name, input_datasets, output_datasets)
+
+        # Fail event
         elif description.raw_info.status == 3:
+
             complete_event_name = description.id
             complete_event_time = description.close_time
-            adapter.create_and_emit_task_event(
-                                                start_event_run_id, 
-                                                RunState.FAIL, 
-                                                complete_event_time, 
-                                                complete_event_name
-                                                )
+
+            adapter.create_and_emit_task_event(start_event_run_id, RunState.FAIL, complete_event_time, complete_event_name)

--- a/integration/temporalio/harvester.py
+++ b/integration/temporalio/harvester.py
@@ -3,35 +3,28 @@
 
 # Warning: this integration is experimental and in active development.
 
-import json
 import logging
-import os
 
-from openlineage.client import OpenLineageClient
-from openlineage.client.event_v2 import Dataset
-from openlineage.client.facet import JobTypeJobFacet
-from openlineage.client.run import Job, Run, RunEvent, RunState
-from openlineage.client.uuid import generate_static_uuid
+from adapter import TemporalOpenLineageAdapter
+from openlineage.client.run import RunState
 from temporalio.client import Client
 from temporalio.service import RPCError
 
-from adapter import TemporalOpenLineageAdapter
-
 logger: logging.Logger = logging.getLogger(__name__)
-
+COMPLETE_STATUS_VALUE = 2
+FAIL_STATUS_VALUE = 3
 
 async def get_temporal_events(event_data: list, t_client: Client) -> None:
     adapter = TemporalOpenLineageAdapter()
     input_datasets = []
     output_datasets = []
-    temporal_events = []
 
     for workflow in event_data:
 
         try:
             description = await t_client.get_workflow_handle(workflow["id"]).describe()
         except RPCError:
-            print(f"Description not found for workflow with id {workflow["id"]}")
+            print("Description not found for workflow with id %", workflow["id"])
             continue
 
         start_event_name = description.id
@@ -45,7 +38,7 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
                 if dataset["type"] == "input"
             ]
         except KeyError:
-            logger.info(f"No input datasets found for workflow {workflow["id"]}.")
+            logger.info("No input datasets found for workflow %", workflow["id"])
 
         try:
             output_datasets = [
@@ -54,7 +47,7 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
                 if dataset["type"] == "output"
             ]
         except KeyError:
-            logger.info(f"No output datasets found for workflow {workflow["id"]}.")
+            logger.info("No output datasets found for workflow %", workflow["id"])
 
         # Start event
         adapter.create_and_emit_task_event(
@@ -62,7 +55,7 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
         )
 
         # Complete event
-        if description.raw_info.status == 2:
+        if description.raw_info.status == COMPLETE_STATUS_VALUE:
             complete_event_name = description.id
             complete_event_time = description.close_time
 
@@ -76,8 +69,7 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
             )
 
         # Fail event
-        elif description.raw_info.status == 3:
-
+        elif description.raw_info.status == FAIL_STATUS_VALUE:
             complete_event_name = description.id
             complete_event_time = description.close_time
 

--- a/integration/temporalio/harvester.py
+++ b/integration/temporalio/harvester.py
@@ -9,13 +9,11 @@ import os
 
 from openlineage.client import OpenLineageClient
 from openlineage.client.event_v2 import Dataset
-from openlineage.client.facet import (
-    JobTypeJobFacet
-)
+from openlineage.client.facet import JobTypeJobFacet
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.uuid import generate_static_uuid
 from temporalio.client import Client
-from temporalio.service import ( RPCError )
+from temporalio.service import RPCError
 
 from adapter import TemporalOpenLineageAdapter
 
@@ -41,24 +39,41 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
         start_event_run_id = adapter.build_run_id(start_event_time, start_event_name)
 
         try:
-            input_datasets = [dataset for dataset in workflow["datasets"] if dataset["type"] == "input"]
-        except:
+            input_datasets = [
+                dataset
+                for dataset in workflow["datasets"]
+                if dataset["type"] == "input"
+            ]
+        except KeyError:
             logger.info(f"No input datasets found for workflow {workflow["id"]}.")
 
         try:
-            output_datasets = [dataset for dataset in workflow["datasets"] if dataset["type"] == "output"]
-        except:
+            output_datasets = [
+                dataset
+                for dataset in workflow["datasets"]
+                if dataset["type"] == "output"
+            ]
+        except KeyError:
             logger.info(f"No output datasets found for workflow {workflow["id"]}.")
 
         # Start event
-        adapter.create_and_emit_task_event(start_event_run_id, RunState.START, start_event_time, start_event_name)
+        adapter.create_and_emit_task_event(
+            start_event_run_id, RunState.START, start_event_time, start_event_name
+        )
 
         # Complete event
         if description.raw_info.status == 2:
             complete_event_name = description.id
             complete_event_time = description.close_time
 
-            adapter.create_and_emit_task_event(start_event_run_id, RunState.COMPLETE, complete_event_time, complete_event_name, input_datasets, output_datasets)
+            adapter.create_and_emit_task_event(
+                start_event_run_id,
+                RunState.COMPLETE,
+                complete_event_time,
+                complete_event_name,
+                input_datasets,
+                output_datasets,
+            )
 
         # Fail event
         elif description.raw_info.status == 3:
@@ -66,4 +81,9 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
             complete_event_name = description.id
             complete_event_time = description.close_time
 
-            adapter.create_and_emit_task_event(start_event_run_id, RunState.FAIL, complete_event_time, complete_event_name)
+            adapter.create_and_emit_task_event(
+                start_event_run_id,
+                RunState.FAIL,
+                complete_event_time,
+                complete_event_name,
+            )

--- a/integration/temporalio/harvester.py
+++ b/integration/temporalio/harvester.py
@@ -48,6 +48,7 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
             ]
         except KeyError:
             logger.info("No output datasets found for workflow %", workflow["id"])
+            output_datasets = []
 
         # Start event
         adapter.create_and_emit_task_event(

--- a/integration/temporalio/harvester.py
+++ b/integration/temporalio/harvester.py
@@ -24,7 +24,7 @@ async def get_temporal_events(event_data: list, t_client: Client) -> None:
         try:
             description = await t_client.get_workflow_handle(workflow["id"]).describe()
         except RPCError:
-            print("Description not found for workflow with id %", workflow["id"])
+            logger.info("Description not found for workflow with id %", workflow["id"])
             continue
 
         start_event_name = description.id

--- a/integration/temporalio/harvester.py
+++ b/integration/temporalio/harvester.py
@@ -2,66 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import datetime
-from datetime import timezone
-import logging
 
-from openlineage.client import OpenLineageClient
-from openlineage.client.facet import (
-    JobTypeJobFacet
-)
-from openlineage.client.run import Job, Run, RunEvent, RunState
-from openlineage.client.uuid import generate_static_uuid
 from temporalio.client import Client
 from temporalio.service import ( RPCError )
 
-PRODUCER: str = (
-    "https://github.com/OpenLineage/openlineage/integration/temporal"
-)
-
-NAMESPACE = os.environ.get("TEMPORAL_OPENLINEAGE_NAMESPACE", "default")
-
-logger: logging.Logger = logging.getLogger(__name__)
-
-class TemporalOpenLineageAdapter:
-    def __init__(self, client: OpenLineageClient | None = None):
-        self.client = client or OpenLineageClient()
-
-    def build_run_id(
-        self, execution_time: datetime, run_name: str
-    ) -> str:
-        """Build a deterministic UUID for the OpenLineage run based on the execution time, run name, and namespace."""
-
-        return str(
-            generate_static_uuid(
-                instant=execution_time,
-                data=f"{NAMESPACE}.{run_name}".encode("utf-8"),
-            )
-        )
-
-    def create_and_emit_task_event(
-        self,
-        runId: str,
-        eventType: str,
-        eventTime: datetime,
-        taskName: str
-    ) -> RunEvent:
-        """Create and emit an OpenLineage task event."""
-
-        job_facets = {
-            "jobType": JobTypeJobFacet(
-                processingType="BATCH", integration="Temporal", jobType="TASK"
-            )
-        }
-
-        run_event = RunEvent(
-            eventType=eventType,
-            eventTime=eventTime.isoformat(),
-            run=Run(runId),
-            job=Job(NAMESPACE, taskName, job_facets),
-            producer=PRODUCER,
-        )
-        self.client.emit(run_event)
+from adapter import TemporalOpenLineageAdapter
 
 
 async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:

--- a/integration/temporalio/temporal_harvester.py
+++ b/integration/temporalio/temporal_harvester.py
@@ -65,51 +65,43 @@ class TemporalOpenLineageAdapter:
 
 
 async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
-    """"""
+    """Get events from the Temporal API, process them, and pass them to the adapter."""
     adapter = TemporalOpenLineageAdapter()
 
     temporal_events = []
     for workflow_id in workflow_ids:
         try:
             description = await t_client.get_workflow_handle(workflow_id).describe()
-        except RPCError as e:
-            print("Description not found for workflow with ID %s", workflow_id)
+        except RPCError:
+            print(f"Description not found for workflow with id {workflow_id}")
             continue
-        start_event_name = description.raw_info.type.name
-        start_event_time = description.raw_info.start_time
-        base_dt = datetime.datetime.fromtimestamp(start_event_time.seconds, tz=timezone.utc)
-        start_final_dt = base_dt + datetime.timedelta(microseconds=start_event_time.nanos // 1000)
-        start_event_run_id = adapter.build_run_id(start_final_dt, start_event_name)
+        start_event_name = description.id
+        start_event_time = description.start_time
+        start_event_run_id = adapter.build_run_id(start_event_time, start_event_name)
 
         adapter.create_and_emit_task_event(
                                             start_event_run_id, 
                                             RunState.START, 
-                                            start_final_dt, 
+                                            start_event_time, 
                                             start_event_name
                                             )
 
         if description.raw_info.status == 2:
-            complete_event_name = description.raw_info.type.name
-            complete_event_time = description.raw_info.close_time
-            base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
-            complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
-
+            complete_event_name = description.id
+            complete_event_time = description.close_time
             adapter.create_and_emit_task_event(
                                                 start_event_run_id, 
                                                 RunState.COMPLETE, 
-                                                complete_final_dt, 
+                                                complete_event_time, 
                                                 complete_event_name
                                                 )
 
         elif description.raw_info.status == 3:
-            complete_event_name = description.raw_info.type.name
-            complete_event_time = description.raw_info.close_time
-            base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
-            complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
-
+            complete_event_name = description.id
+            complete_event_time = description.close_time
             adapter.create_and_emit_task_event(
                                                 start_event_run_id, 
                                                 RunState.FAIL, 
-                                                complete_final_dt, 
+                                                complete_event_time, 
                                                 complete_event_name
                                                 )

--- a/integration/temporalio/temporal_harvester.py
+++ b/integration/temporalio/temporal_harvester.py
@@ -69,7 +69,6 @@ async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
     temporal_events = []
     for workflow_id in workflow_ids:
         description = await t_client.get_workflow_handle(workflow_id).describe()
-        
         start_event_name = description.raw_info.type.name
         start_event_time = description.raw_info.start_time
         base_dt = datetime.datetime.fromtimestamp(start_event_time.seconds, tz=timezone.utc)
@@ -78,9 +77,19 @@ async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
 
         adapter.create_and_emit_task_event(start_event_run_id, RunState.START, start_final_dt, start_event_name)
 
-        complete_event_name = description.raw_info.type.name
-        complete_event_time = description.raw_info.close_time
-        base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
-        complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
+        if description.raw_info.status == 2:
+            complete_event_name = description.raw_info.type.name
+            complete_event_time = description.raw_info.close_time
+            base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
+            complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
 
-        adapter.create_and_emit_task_event(start_event_run_id, RunState.COMPLETE, complete_final_dt, complete_event_name)
+            adapter.create_and_emit_task_event(start_event_run_id, RunState.COMPLETE, complete_final_dt, complete_event_name)
+
+        elif description.raw_info.status == 3:
+
+            complete_event_name = description.raw_info.type.name
+            complete_event_time = description.raw_info.close_time
+            base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
+            complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
+
+            adapter.create_and_emit_task_event(start_event_run_id, RunState.FAIL, complete_final_dt, complete_event_name)

--- a/integration/temporalio/temporal_harvester.py
+++ b/integration/temporalio/temporal_harvester.py
@@ -13,6 +13,7 @@ from openlineage.client.facet import (
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.uuid import generate_static_uuid
 from temporalio.client import Client
+from temporalio.service import ( RPCError )
 
 PRODUCER: str = (
     "https://github.com/OpenLineage/openlineage/integration/temporal"
@@ -64,18 +65,28 @@ class TemporalOpenLineageAdapter:
 
 
 async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
+    """"""
     adapter = TemporalOpenLineageAdapter()
 
     temporal_events = []
     for workflow_id in workflow_ids:
-        description = await t_client.get_workflow_handle(workflow_id).describe()
+        try:
+            description = await t_client.get_workflow_handle(workflow_id).describe()
+        except RPCError as e:
+            print("Description not found for workflow with ID %s", workflow_id)
+            continue
         start_event_name = description.raw_info.type.name
         start_event_time = description.raw_info.start_time
         base_dt = datetime.datetime.fromtimestamp(start_event_time.seconds, tz=timezone.utc)
         start_final_dt = base_dt + datetime.timedelta(microseconds=start_event_time.nanos // 1000)
         start_event_run_id = adapter.build_run_id(start_final_dt, start_event_name)
 
-        adapter.create_and_emit_task_event(start_event_run_id, RunState.START, start_final_dt, start_event_name)
+        adapter.create_and_emit_task_event(
+                                            start_event_run_id, 
+                                            RunState.START, 
+                                            start_final_dt, 
+                                            start_event_name
+                                            )
 
         if description.raw_info.status == 2:
             complete_event_name = description.raw_info.type.name
@@ -83,13 +94,22 @@ async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
             base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
             complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
 
-            adapter.create_and_emit_task_event(start_event_run_id, RunState.COMPLETE, complete_final_dt, complete_event_name)
+            adapter.create_and_emit_task_event(
+                                                start_event_run_id, 
+                                                RunState.COMPLETE, 
+                                                complete_final_dt, 
+                                                complete_event_name
+                                                )
 
         elif description.raw_info.status == 3:
-
             complete_event_name = description.raw_info.type.name
             complete_event_time = description.raw_info.close_time
             base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
             complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
 
-            adapter.create_and_emit_task_event(start_event_run_id, RunState.FAIL, complete_final_dt, complete_event_name)
+            adapter.create_and_emit_task_event(
+                                                start_event_run_id, 
+                                                RunState.FAIL, 
+                                                complete_final_dt, 
+                                                complete_event_name
+                                                )

--- a/integration/temporalio/temporal_harvester.py
+++ b/integration/temporalio/temporal_harvester.py
@@ -1,0 +1,86 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import datetime
+from datetime import timezone
+import logging
+
+from openlineage.client import OpenLineageClient
+from openlineage.client.facet import (
+    JobTypeJobFacet
+)
+from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_static_uuid
+from temporalio.client import Client
+
+PRODUCER: str = (
+    "https://github.com/OpenLineage/openlineage/integration/temporal"
+)
+
+NAMESPACE = os.environ.get("TEMPORAL_OPENLINEAGE_NAMESPACE", "default")
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+class TemporalOpenLineageAdapter:
+    def __init__(self, client: OpenLineageClient | None = None):
+        self.client = client or OpenLineageClient()
+
+    def build_run_id(
+        self, execution_time: datetime, run_name: str
+    ) -> str:
+        """Build a deterministic UUID for the OpenLineage run based on the execution time, run name, and namespace."""
+
+        return str(
+            generate_static_uuid(
+                instant=execution_time,
+                data=f"{NAMESPACE}.{run_name}".encode("utf-8"),
+            )
+        )
+
+    def create_and_emit_task_event(
+        self,
+        runId: str,
+        eventType: str,
+        eventTime: datetime,
+        taskName: str
+    ) -> RunEvent:
+        """Create and emit an OpenLineage task event."""
+
+        job_facets = {
+            "jobType": JobTypeJobFacet(
+                processingType="BATCH", integration="Temporal", jobType="TASK"
+            )
+        }
+
+        run_event = RunEvent(
+            eventType=eventType,
+            eventTime=eventTime.isoformat(),
+            run=Run(runId),
+            job=Job(NAMESPACE, taskName, job_facets),
+            producer=PRODUCER,
+        )
+        self.client.emit(run_event)
+
+
+async def get_temporal_events(workflow_ids: list, t_client: Client) -> None:
+    adapter = TemporalOpenLineageAdapter()
+
+    temporal_events = []
+    for workflow_id in workflow_ids:
+        description = await t_client.get_workflow_handle(workflow_id).describe()
+        
+        start_event_name = description.raw_info.type.name
+        start_event_time = description.raw_info.start_time
+        base_dt = datetime.datetime.fromtimestamp(start_event_time.seconds, tz=timezone.utc)
+        start_final_dt = base_dt + datetime.timedelta(microseconds=start_event_time.nanos // 1000)
+        start_event_run_id = adapter.build_run_id(start_final_dt, start_event_name)
+
+        adapter.create_and_emit_task_event(start_event_run_id, RunState.START, start_final_dt, start_event_name)
+
+        complete_event_name = description.raw_info.type.name
+        complete_event_time = description.raw_info.close_time
+        base_dt = datetime.datetime.fromtimestamp(complete_event_time.seconds, tz=timezone.utc)
+        complete_final_dt = base_dt + datetime.timedelta(microseconds=complete_event_time.nanos // 1000)
+
+        adapter.create_and_emit_task_event(start_event_run_id, RunState.COMPLETE, complete_final_dt, complete_event_name)


### PR DESCRIPTION
### One-line summary for changelog:
Adds a Temporal integration

### Meaningful description
Temporal's orchestration system does not offer streaming analytics. Therefore, instead of using a listener, this approach runs a harvester and adapter on the existing Temporal worker in a separate task queue, obtaining events for explicit workflows using a handle offered by the Temporal Python client. The user would be responsible for providing the harvester to the worker, for example in a workflow, and for specifying workflows to be monitored.

Currently this is a simple POC for getting input on the general approach.

Example Temporal workflow:
```py
@workflow.defn
class GetEvents:
    @workflow.run
    async def run(self, workflow_info: list) -> None:
        return await workflow.execute_activity(
            check_workflow_activity,
            workflow_info,
            schedule_to_close_timeout=timedelta(seconds=10),
        )
```

Example Temporal worker:
```py
  events_worker = Worker(
      client,
      task_queue="my-other-task-queue",
      workflows=[GetEvents],
      activities=[check_workflow_activity],
  )
  print("Worker started.")
  await events_worker.run()
```

Example Temporal activity leveraging imported harvester:
```py
@activity.defn
async def check_workflow_activity(workflow_info) -> None:
    client = await Client.connect("localhost:7233")
    await get_temporal_events(workflow_info, client)
```

Workflow ids and datasets are to be provided via the Temporal starter:
```py
events = await client.execute_workflow(
  "GetEvents",
  [
      {"id":"say-hello-workflow","datasets":[{"uri":"duckdb:///database","table":"table","type":"input"}]}, 
      {"id":"say-bye-workflow","datasets":[{"uri":"duckdb:///database","table":"table","type":"output"}]}
  ],
  id="get-events",
  task_queue="my-other-task-queue"
)
```


### Checklist
- [ ] AI was used in creating this PR
