### PR TITLE
spark: clean up retained lifecycle state

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/JobMetricsLifecycleManager.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/JobMetricsLifecycleManager.java
@@ -1,0 +1,124 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import io.openlineage.spark.agent.JobMetricsHolder.Metric;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/** Owns compact job metrics while SQL executions in the same root execution are still active. */
+class JobMetricsLifecycleManager {
+  private final JobMetricsHolder jobMetrics;
+  private final Map<Long, Long> executionRoots = new HashMap<>();
+  private final Map<Long, Set<Long>> activeExecutionsByRoot = new HashMap<>();
+  private final Map<Integer, Long> jobRoots = new HashMap<>();
+  private final Map<Long, Set<Integer>> jobsByRoot = new HashMap<>();
+  private final Set<Integer> completedJobs = new HashSet<>();
+
+  JobMetricsLifecycleManager(JobMetricsHolder jobMetrics) {
+    this.jobMetrics = jobMetrics;
+  }
+
+  synchronized void registerExecution(long executionId, long rootExecutionId) {
+    long rootId = executionRoots.getOrDefault(executionId, rootExecutionId);
+    executionRoots.put(executionId, rootId);
+    activeExecutionsByRoot.computeIfAbsent(rootId, ignored -> new HashSet<>()).add(executionId);
+  }
+
+  synchronized void registerJob(int jobId, long executionId, Optional<Long> rootExecutionId) {
+    long rootId = executionRoots.getOrDefault(executionId, rootExecutionId.orElse(executionId));
+    registerExecution(executionId, rootId);
+
+    Long previousRootId = jobRoots.put(jobId, rootId);
+    if (previousRootId != null && previousRootId != rootId) {
+      removeJobFromRoot(jobId, previousRootId);
+    }
+    jobsByRoot.computeIfAbsent(rootId, ignored -> new HashSet<>()).add(jobId);
+  }
+
+  synchronized void completeJob(int jobId) {
+    Map<Metric, Number> metrics = jobMetrics.completeJob(jobId);
+    Long rootId = jobRoots.get(jobId);
+    if (metrics.isEmpty()
+        || rootId == null
+        || activeExecutionsByRoot
+            .getOrDefault(rootId, java.util.Collections.emptySet())
+            .isEmpty()) {
+      cleanUpJob(jobId);
+    } else {
+      completedJobs.add(jobId);
+    }
+  }
+
+  synchronized void endExecution(long executionId) {
+    Long rootId = executionRoots.remove(executionId);
+    if (rootId == null) {
+      return;
+    }
+
+    Set<Long> activeExecutions = activeExecutionsByRoot.get(rootId);
+    if (activeExecutions == null) {
+      return;
+    }
+    activeExecutions.remove(executionId);
+    if (!activeExecutions.isEmpty()) {
+      return;
+    }
+
+    activeExecutionsByRoot.remove(rootId);
+    Set<Integer> jobs = jobsByRoot.remove(rootId);
+    if (jobs != null) {
+      new HashSet<>(jobs)
+          .forEach(
+              jobId -> {
+                if (completedJobs.contains(jobId)) {
+                  cleanUpJob(jobId);
+                } else {
+                  jobRoots.remove(jobId);
+                }
+              });
+    }
+  }
+
+  synchronized void cleanUpJob(int jobId) {
+    jobMetrics.cleanUp(jobId);
+    completedJobs.remove(jobId);
+    Long rootId = jobRoots.remove(jobId);
+    if (rootId != null) {
+      removeJobFromRoot(jobId, rootId);
+    }
+  }
+
+  synchronized void cleanUpAll() {
+    executionRoots.clear();
+    activeExecutionsByRoot.clear();
+    jobRoots.clear();
+    jobsByRoot.clear();
+    completedJobs.clear();
+    jobMetrics.cleanUpAll();
+  }
+
+  synchronized int getExecutionGroupCount() {
+    return activeExecutionsByRoot.size();
+  }
+
+  synchronized int getPendingJobCount() {
+    return jobRoots.size();
+  }
+
+  private void removeJobFromRoot(int jobId, long rootId) {
+    Set<Integer> jobs = jobsByRoot.get(rootId);
+    if (jobs != null) {
+      jobs.remove(jobId);
+      if (jobs.isEmpty()) {
+        jobsByRoot.remove(rootId);
+      }
+    }
+  }
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -24,6 +24,7 @@ import io.openlineage.spark.agent.lifecycle.ExecutionContext;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.agent.util.SparkVersionUtils;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,6 +64,13 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   static final String RDD_REGISTRY_GAUGE = "openlineage.spark.state.rdd_execution_registry";
   static final String BUILDER_JOBS_GAUGE = "openlineage.spark.state.builder.jobs";
   static final String BUILDER_STAGES_GAUGE = "openlineage.spark.state.builder.stages";
+  static final String METRICS_EXECUTION_GROUPS_GAUGE =
+      "openlineage.spark.state.job_metrics.execution_groups";
+  static final String METRICS_PENDING_JOBS_GAUGE =
+      "openlineage.spark.state.job_metrics.pending_jobs";
+
+  private static final String SQL_EXECUTION_ID_KEY = "spark.sql.execution.id";
+  private static final String SQL_EXECUTION_ROOT_ID_KEY = "spark.sql.execution.root.id";
 
   // These are used only in integration tests to override default factory,
   // before SparkSession creates new listener object
@@ -80,6 +88,8 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   private final Map<Integer, ExecutionContext> rddExecutionRegistry =
       Collections.synchronizedMap(new HashMap<>());
   private final JobMetricsHolder jobMetrics = JobMetricsHolder.getInstance();
+  private final JobMetricsLifecycleManager jobMetricsLifecycle =
+      new JobMetricsLifecycleManager(jobMetrics);
   private final Function1<SparkSession, SparkContext> sparkContextFromSession =
       ScalaConversionUtils.toScalaFn(SparkSession::sparkContext);
   private final Function0<Option<SparkContext>> activeSparkContext =
@@ -145,6 +155,8 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     getSparkSQLExecutionContext(startEvent.executionId())
         .ifPresent(
             context -> {
+              jobMetricsLifecycle.registerExecution(
+                  startEvent.executionId(), getRootExecutionId(startEvent));
               meterRegistry.counter("openlineage.spark.event.sql.start").increment();
               circuitBreaker.run(
                   () -> {
@@ -160,24 +172,28 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     log.debug("sparkSQLExecEnd with activeJobId {}", activeJobId);
     ExecutionContext context = sparkSqlExecutionRegistry.remove(endEvent.executionId());
     meterRegistry.counter("openlineage.spark.event.sql.end").increment();
-    if (context != null) {
-      circuitBreaker.run(
-          () -> {
-            activeJobId.ifPresent(context::setActiveJobId);
-            context.end(endEvent);
-            return null;
-          });
-    } else {
-      contextFactory
-          .createSparkSQLExecutionContext(endEvent)
-          .ifPresent(
-              c ->
-                  circuitBreaker.run(
-                      () -> {
-                        activeJobId.ifPresent(c::setActiveJobId);
-                        c.end(endEvent);
-                        return null;
-                      }));
+    try {
+      if (context != null) {
+        circuitBreaker.run(
+            () -> {
+              activeJobId.ifPresent(context::setActiveJobId);
+              context.end(endEvent);
+              return null;
+            });
+      } else {
+        contextFactory
+            .createSparkSQLExecutionContext(endEvent)
+            .ifPresent(
+                c ->
+                    circuitBreaker.run(
+                        () -> {
+                          activeJobId.ifPresent(c::setActiveJobId);
+                          c.end(endEvent);
+                          return null;
+                        }));
+      }
+    } finally {
+      jobMetricsLifecycle.endExecution(endEvent.executionId());
     }
   }
 
@@ -210,37 +226,57 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       jobMetrics.addJobStages(jobStart.jobId(), stages);
     }
 
-    Optional.ofNullable(getSqlExecutionId(jobStart.properties()))
-        .map(Optional::of)
-        .orElseGet(
-            () ->
-                asJavaOptional(
-                        SparkSession.getDefaultSession()
-                            .map(sparkContextFromSession)
-                            .orElse(activeSparkContext))
-                    .flatMap(
-                        ctx ->
-                            Optional.ofNullable(ctx.dagScheduler())
-                                .map(ds -> ds.jobIdToActiveJob().get(jobStart.jobId()))
-                                .flatMap(ScalaConversionUtils::asJavaOptional))
-                    .map(job -> getSqlExecutionId(job.properties())))
-        .map(Long::parseLong)
-        .map(id -> getExecutionContext(jobStart.jobId(), id))
-        .orElseGet(() -> getExecutionContext(jobStart.jobId()))
-        .ifPresent(
-            context -> {
-              // set it in the rddExecutionRegistry so jobEnd is called
-              activeJob.ifPresent(context::setActiveJob);
-              circuitBreaker.run(
-                  () -> {
-                    context.start(jobStart);
-                    return null;
-                  });
-            });
+    Optional<Properties> activeJobProperties = activeJob.map(ActiveJob::properties);
+    Optional<Long> executionId =
+        getLongProperty(jobStart.properties(), activeJobProperties, SQL_EXECUTION_ID_KEY);
+    Optional<Long> rootExecutionId =
+        getLongProperty(jobStart.properties(), activeJobProperties, SQL_EXECUTION_ROOT_ID_KEY);
+
+    Optional<ExecutionContext> executionContext =
+        executionId
+            .map(id -> getExecutionContext(jobStart.jobId(), id))
+            .orElseGet(() -> getExecutionContext(jobStart.jobId()));
+    executionContext.ifPresent(
+        context -> {
+          executionId.ifPresent(
+              id -> jobMetricsLifecycle.registerJob(jobStart.jobId(), id, rootExecutionId));
+          // set it in the rddExecutionRegistry so jobEnd is called
+          activeJob.ifPresent(context::setActiveJob);
+          circuitBreaker.run(
+              () -> {
+                context.start(jobStart);
+                return null;
+              });
+        });
   }
 
-  private String getSqlExecutionId(Properties properties) {
-    return properties.getProperty("spark.sql.execution.id");
+  private Optional<Long> getLongProperty(Properties properties, String key) {
+    return Optional.ofNullable(properties)
+        .map(value -> value.getProperty(key))
+        .map(Long::parseLong);
+  }
+
+  private Optional<Long> getLongProperty(
+      Properties properties, Optional<Properties> fallbackProperties, String key) {
+    Optional<Long> value = getLongProperty(properties, key);
+    return value.isPresent()
+        ? value
+        : fallbackProperties.flatMap(fallback -> getLongProperty(fallback, key));
+  }
+
+  private long getRootExecutionId(SparkListenerSQLExecutionStart startEvent) {
+    try {
+      Object rootExecutionId =
+          startEvent.getClass().getMethod("rootExecutionId").invoke(startEvent);
+      if (rootExecutionId instanceof Option && ((Option<?>) rootExecutionId).isDefined()) {
+        return ((Number) ((Option<?>) rootExecutionId).get()).longValue();
+      }
+    } catch (NoSuchMethodException e) {
+      // Spark versions before 3.4 do not expose a root execution ID.
+    } catch (IllegalAccessException | InvocationTargetException | ClassCastException e) {
+      log.debug("Unable to read Spark SQL root execution ID", e);
+    }
+    return startEvent.executionId();
   }
 
   /** called by the SparkListener when a job ends */
@@ -251,7 +287,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       if (disabledContext != null) {
         disabledContext.evictJob(jobEnd.jobId());
       }
-      jobMetrics.cleanUp(jobEnd.jobId());
+      jobMetricsLifecycle.cleanUpJob(jobEnd.jobId());
       return;
     }
     log.debug("onJobEnd called [{}].", jobEnd);
@@ -269,11 +305,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       if (context != null) {
         context.evictJob(jobEnd.jobId());
       }
-      if (context != null && context.retainsJobMetrics(jobEnd.jobId())) {
-        jobMetrics.completeJob(jobEnd.jobId());
-      } else {
-        jobMetrics.cleanUp(jobEnd.jobId());
-      }
+      jobMetricsLifecycle.completeJob(jobEnd.jobId());
     }
   }
 
@@ -318,7 +350,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     executionContexts().forEach(ExecutionContext::clearRetainedState);
     sparkSqlExecutionRegistry.clear();
     rddExecutionRegistry.clear();
-    jobMetrics.cleanUpAll();
+    jobMetricsLifecycle.cleanUpAll();
   }
 
   @Override
@@ -470,6 +502,14 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
         BUILDER_JOBS_GAUGE, this, OpenLineageSparkListener::getRetainedBuilderJobCount);
     meterRegistry.gauge(
         BUILDER_STAGES_GAUGE, this, OpenLineageSparkListener::getRetainedBuilderStageCount);
+    meterRegistry.gauge(
+        METRICS_EXECUTION_GROUPS_GAUGE,
+        jobMetricsLifecycle,
+        JobMetricsLifecycleManager::getExecutionGroupCount);
+    meterRegistry.gauge(
+        METRICS_PENDING_JOBS_GAUGE,
+        jobMetricsLifecycle,
+        JobMetricsLifecycleManager::getPendingJobCount);
     jobMetrics.registerStateGauges(meterRegistry);
     stateGaugesRegistered = true;
   }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -282,16 +282,15 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   /** called by the SparkListener when a job ends */
   @Override
   public void onJobEnd(SparkListenerJobEnd jobEnd) {
+    ExecutionContext context = rddExecutionRegistry.remove(jobEnd.jobId());
     if (checkIfDisabled()) {
-      ExecutionContext disabledContext = rddExecutionRegistry.remove(jobEnd.jobId());
-      if (disabledContext != null) {
-        disabledContext.evictJob(jobEnd.jobId());
+      if (context != null) {
+        context.evictJob(jobEnd.jobId());
       }
       jobMetricsLifecycle.cleanUpJob(jobEnd.jobId());
       return;
     }
     log.debug("onJobEnd called [{}].", jobEnd);
-    ExecutionContext context = rddExecutionRegistry.remove(jobEnd.jobId());
     meterRegistry.counter("openlineage.spark.event.job.end").increment();
     try {
       circuitBreaker.run(

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -27,6 +27,7 @@ import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -58,6 +59,11 @@ import scala.Option;
 
 @Slf4j
 public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkListener {
+  static final String SQL_REGISTRY_GAUGE = "openlineage.spark.state.sql_execution_registry";
+  static final String RDD_REGISTRY_GAUGE = "openlineage.spark.state.rdd_execution_registry";
+  static final String BUILDER_JOBS_GAUGE = "openlineage.spark.state.builder.jobs";
+  static final String BUILDER_STAGES_GAUGE = "openlineage.spark.state.builder.stages";
+
   // These are used only in integration tests to override default factory,
   // before SparkSession creates new listener object
   private static ContextFactory defaultContextFactory;
@@ -67,6 +73,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   private MeterRegistry meterRegistry = defaultMeterRegistry;
 
   private CircuitBreaker circuitBreaker = new NoOpCircuitBreaker();
+  private boolean stateGaugesRegistered;
 
   private final Map<Long, ExecutionContext> sparkSqlExecutionRegistry =
       Collections.synchronizedMap(new HashMap<>());
@@ -114,6 +121,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   public void skipInitializationForTests(ContextFactory contextFactory) {
     this.contextFactory = contextFactory;
     this.meterRegistry = contextFactory.getMeterRegistry();
+    registerStateGauges();
   }
 
   @Override
@@ -239,18 +247,34 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   @Override
   public void onJobEnd(SparkListenerJobEnd jobEnd) {
     if (checkIfDisabled()) {
+      ExecutionContext disabledContext = rddExecutionRegistry.remove(jobEnd.jobId());
+      if (disabledContext != null) {
+        disabledContext.evictJob(jobEnd.jobId());
+      }
+      jobMetrics.cleanUp(jobEnd.jobId());
       return;
     }
     log.debug("onJobEnd called [{}].", jobEnd);
     ExecutionContext context = rddExecutionRegistry.remove(jobEnd.jobId());
     meterRegistry.counter("openlineage.spark.event.job.end").increment();
-    circuitBreaker.run(
-        () -> {
-          if (context != null) {
-            context.end(jobEnd);
-          }
-          return null;
-        });
+    try {
+      circuitBreaker.run(
+          () -> {
+            if (context != null) {
+              context.end(jobEnd);
+            }
+            return null;
+          });
+    } finally {
+      if (context != null) {
+        context.evictJob(jobEnd.jobId());
+      }
+      if (context != null && context.retainsJobMetrics(jobEnd.jobId())) {
+        jobMetrics.completeJob(jobEnd.jobId());
+      } else {
+        jobMetrics.cleanUp(jobEnd.jobId());
+      }
+    }
   }
 
   @Override
@@ -291,13 +315,16 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   }
 
   private void clear() {
+    executionContexts().forEach(ExecutionContext::clearRetainedState);
     sparkSqlExecutionRegistry.clear();
     rddExecutionRegistry.clear();
+    jobMetrics.cleanUpAll();
   }
 
   @Override
   public void onApplicationEnd(SparkListenerApplicationEnd applicationEnd) {
     if (checkIfDisabled()) {
+      close();
       return;
     }
     log.debug("onApplicationEnd called [{}].", applicationEnd);
@@ -306,21 +333,27 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
         .counter("openlineage.spark.event.app.end.memoryusage")
         .increment(RuntimeUtils.getMemoryFractionUsage());
 
-    circuitBreaker.run(
-        () -> {
-          getSparkApplicationExecutionContext().end(applicationEnd);
-          return null;
-        });
-    close();
-    super.onApplicationEnd(applicationEnd);
+    try {
+      circuitBreaker.run(
+          () -> {
+            getSparkApplicationExecutionContext().end(applicationEnd);
+            return null;
+          });
+    } finally {
+      close();
+      super.onApplicationEnd(applicationEnd);
+    }
   }
 
   /** To close the underlying resources. */
   public void close() {
-    circuitBreaker.close();
-    clear();
-    if (contextFactory != null) {
-      contextFactory.close();
+    try {
+      circuitBreaker.close();
+    } finally {
+      clear();
+      if (contextFactory != null) {
+        contextFactory.close();
+      }
     }
   }
 
@@ -345,6 +378,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
 
   private void initializeContextFactoryIfNotInitialized() {
     if (contextFactory != null) {
+      registerStateGauges();
       return;
     }
     asJavaOptional(activeSparkContext.apply())
@@ -378,6 +412,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       initializeMetrics(config);
       contextFactory = new ContextFactory(new EventEmitter(config, appName), meterRegistry, config);
       circuitBreaker = new CircuitBreakerFactory(config.getCircuitBreaker()).build();
+      registerStateGauges();
     } catch (URISyntaxException e) {
       log.error("Unable to parse OpenLineage endpoint. Lineage events will not be collected", e);
     }
@@ -423,6 +458,39 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
                             Tag.of("openlineage.spark.integration.version", Versions.getVersion()),
                             Tag.of("openlineage.spark.version", sparkVersion),
                             Tag.of("openlineage.spark.disabled.facets", disabledFacets))));
+  }
+
+  private void registerStateGauges() {
+    if (stateGaugesRegistered || meterRegistry == null) {
+      return;
+    }
+    meterRegistry.gauge(SQL_REGISTRY_GAUGE, sparkSqlExecutionRegistry, Map::size);
+    meterRegistry.gauge(RDD_REGISTRY_GAUGE, rddExecutionRegistry, Map::size);
+    meterRegistry.gauge(
+        BUILDER_JOBS_GAUGE, this, OpenLineageSparkListener::getRetainedBuilderJobCount);
+    meterRegistry.gauge(
+        BUILDER_STAGES_GAUGE, this, OpenLineageSparkListener::getRetainedBuilderStageCount);
+    jobMetrics.registerStateGauges(meterRegistry);
+    stateGaugesRegistered = true;
+  }
+
+  private int getRetainedBuilderJobCount() {
+    return executionContexts().stream().mapToInt(ExecutionContext::getRetainedJobCount).sum();
+  }
+
+  private int getRetainedBuilderStageCount() {
+    return executionContexts().stream().mapToInt(ExecutionContext::getRetainedStageCount).sum();
+  }
+
+  private Set<ExecutionContext> executionContexts() {
+    Set<ExecutionContext> contexts = Collections.newSetFromMap(new IdentityHashMap<>());
+    synchronized (sparkSqlExecutionRegistry) {
+      contexts.addAll(sparkSqlExecutionRegistry.values());
+    }
+    synchronized (rddExecutionRegistry) {
+      contexts.addAll(rddExecutionRegistry.values());
+    }
+    return contexts;
   }
 
   /**

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -254,55 +254,76 @@ class RddExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
-    if (isDisabled()) {
-      log.info(
-          "OpenLineage received Spark event that is configured to be skipped: RDD SparkListenerJobEnd");
-      return;
-    }
-    log.debug("end SparkListenerJobEnd {}", jobEnd);
-    if (outputs.isEmpty() && !(jobEnd.jobResult() instanceof JobFailed)) {
-      // Oftentimes SparkListener is triggered for actions which do not contain any
-      // meaningful
-      // lineage data and are useless in the context of lineage graph. We assume this
-      // occurs
-      // for RDD operations which have no output dataset
-      log.info("Output RDDs are empty: skipping sending OpenLineage event");
-      return;
-    }
+    try {
+      if (isDisabled()) {
+        log.info(
+            "OpenLineage received Spark event that is configured to be skipped: RDD SparkListenerJobEnd");
+        return;
+      }
+      log.debug("end SparkListenerJobEnd {}", jobEnd);
+      if (outputs.isEmpty() && !(jobEnd.jobResult() instanceof JobFailed)) {
+        // Oftentimes SparkListener is triggered for actions which do not contain any
+        // meaningful
+        // lineage data and are useless in the context of lineage graph. We assume this
+        // occurs
+        // for RDD operations which have no output dataset
+        log.info("Output RDDs are empty: skipping sending OpenLineage event");
+        return;
+      }
 
-    List<InputDataset> inputDatasets = buildInputs(inputs, true);
-    List<OutputDataset> outputDatasets = buildOutputs(outputs, true);
-    RunFacetsBuilder runFacetsBuilder =
-        buildRunFacets(buildJobErrorFacet(jobEnd.jobResult()), jobEnd);
+      List<InputDataset> inputDatasets = buildInputs(inputs, true);
+      List<OutputDataset> outputDatasets = buildOutputs(outputs, true);
+      RunFacetsBuilder runFacetsBuilder =
+          buildRunFacets(buildJobErrorFacet(jobEnd.jobResult()), jobEnd);
 
-    olContext.getLineageRunStatus().capturedInputs(inputDatasets.size());
-    olContext.getLineageRunStatus().capturedOutputs(outputDatasets.size());
-    FacetUtils.attachSmartDebugFacet(olContext, runFacetsBuilder);
+      olContext.getLineageRunStatus().capturedInputs(inputDatasets.size());
+      olContext.getLineageRunStatus().capturedOutputs(outputDatasets.size());
+      FacetUtils.attachSmartDebugFacet(olContext, runFacetsBuilder);
 
-    EventType eventType = getEventType(jobEnd.jobResult());
-    OpenLineage.RunEvent event =
-        olContext
-            .getOpenLineage()
-            .newRunEventBuilder()
-            .eventTime(toZonedTime(jobEnd.time()))
-            .eventType(eventType)
-            .inputs(inputDatasets)
-            .outputs(outputDatasets)
-            .run(
-                olContext
-                    .getOpenLineage()
-                    .newRunBuilder()
-                    .runId(runId)
-                    .facets(runFacetsBuilder.build())
-                    .build())
-            .job(buildJob(jobEnd.jobId()))
-            .build();
-    if (eventType.equals(EventType.COMPLETE)) {
-      // clean up metrics on complete only
+      EventType eventType = getEventType(jobEnd.jobResult());
+      OpenLineage.RunEvent event =
+          olContext
+              .getOpenLineage()
+              .newRunEventBuilder()
+              .eventTime(toZonedTime(jobEnd.time()))
+              .eventType(eventType)
+              .inputs(inputDatasets)
+              .outputs(outputDatasets)
+              .run(
+                  olContext
+                      .getOpenLineage()
+                      .newRunBuilder()
+                      .runId(runId)
+                      .facets(runFacetsBuilder.build())
+                      .build())
+              .job(buildJob(jobEnd.jobId()))
+              .build();
+      log.debug("Posting event for end {}: {}", jobEnd, event);
+      eventEmitter.emit(event);
+    } finally {
       JobMetricsHolder.getInstance().cleanUp(jobEnd.jobId());
+      runEventBuilder.evictJob(jobEnd.jobId());
     }
-    log.debug("Posting event for end {}: {}", jobEnd, event);
-    eventEmitter.emit(event);
+  }
+
+  @Override
+  public void evictJob(int jobId) {
+    runEventBuilder.evictJob(jobId);
+  }
+
+  @Override
+  public void clearRetainedState() {
+    runEventBuilder.clearRetainedState();
+  }
+
+  @Override
+  public int getRetainedJobCount() {
+    return runEventBuilder.getRetainedJobCount();
+  }
+
+  @Override
+  public int getRetainedStageCount() {
+    return runEventBuilder.getRetainedStageCount();
   }
 
   protected OpenLineage.RunFacetsBuilder buildRunFacets(

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -301,13 +301,13 @@ class RddExecutionContext implements ExecutionContext {
       log.debug("Posting event for end {}: {}", jobEnd, event);
       eventEmitter.emit(event);
     } finally {
-      JobMetricsHolder.getInstance().cleanUp(jobEnd.jobId());
-      runEventBuilder.evictJob(jobEnd.jobId());
+      evictJob(jobEnd.jobId());
     }
   }
 
   @Override
   public void evictJob(int jobId) {
+    JobMetricsHolder.getInstance().cleanUp(jobId);
     runEventBuilder.evictJob(jobId);
   }
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -68,6 +68,21 @@ class SparkApplicationExecutionContext implements ExecutionContext {
   public void end(SparkListenerStageCompleted stageCompleted) {}
 
   @Override
+  public void clearRetainedState() {
+    runEventBuilder.clearRetainedState();
+  }
+
+  @Override
+  public int getRetainedJobCount() {
+    return runEventBuilder.getRetainedJobCount();
+  }
+
+  @Override
+  public int getRetainedStageCount() {
+    return runEventBuilder.getRetainedStageCount();
+  }
+
+  @Override
   public void start(SparkListenerApplicationStart applicationStart) {
     String applicationId =
         olContext.getSparkContext().map(context -> context.applicationId()).orElse(null);

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -57,9 +57,11 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   private boolean emittedOnSqlExecutionStart = false;
   private boolean emittedOnSqlExecutionEnd = false;
+  private boolean sqlExecutionEnded = false;
   private boolean emittedOnJobStart = false;
   private boolean emittedOnJobEnd = false;
   private Integer activeJobId;
+  private Optional<Integer> retainedMetricsJobId = Optional.empty();
   private AtomicBoolean finished = new AtomicBoolean(false);
 
   private SparkSQLQueryParser sqlRecorder = new SparkSQLQueryParser();
@@ -119,55 +121,62 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerSQLExecutionEnd endEvent) {
-    if (log.isDebugEnabled()) {
-      log.debug("SparkListenerSQLExecutionEnd - executionId: {}", endEvent.executionId());
-    }
-    // TODO: can we get failed event here?
-    // If not, then we probably need to use this only for LogicalPlans that emit no Job events.
-    // Maybe use QueryExecutionListener?
-    olContext.setActiveJobId(activeJobId);
-    if (!olContext.getQueryExecution().isPresent()) {
-      log.info(NO_EXECUTION_INFO, olContext);
-      return;
-    } else if (EventFilterUtils.isDisabled(olContext, endEvent)) {
-      log.info(
-          "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionEnd");
-      return;
-    }
+    boolean jobEndPending = emittedOnJobStart && !emittedOnJobEnd;
+    sqlExecutionEnded = true;
+    try {
+      if (log.isDebugEnabled()) {
+        log.debug("SparkListenerSQLExecutionEnd - executionId: {}", endEvent.executionId());
+      }
+      // TODO: can we get failed event here?
+      // If not, then we probably need to use this only for LogicalPlans that emit no Job events.
+      // Maybe use QueryExecutionListener?
+      olContext.setActiveJobId(activeJobId);
+      if (!olContext.getQueryExecution().isPresent()) {
+        log.info(NO_EXECUTION_INFO, olContext);
+        return;
+      } else if (EventFilterUtils.isDisabled(olContext, endEvent)) {
+        log.info(
+            "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionEnd");
+        return;
+      }
 
-    // only one COMPLETE event is expected, verify if jobEnd was not emitted
-    EventType eventType;
-    if (emittedOnJobStart && !emittedOnJobEnd) {
-      // expecting jobEnd event later on
-      eventType = RUNNING;
-    } else {
-      eventType = COMPLETE;
-    }
-    emittedOnSqlExecutionEnd = true;
+      // only one COMPLETE event is expected, verify if jobEnd was not emitted
+      EventType eventType;
+      if (emittedOnJobStart && !emittedOnJobEnd) {
+        // expecting jobEnd event later on
+        eventType = RUNNING;
+      } else {
+        eventType = COMPLETE;
+      }
+      emittedOnSqlExecutionEnd = true;
 
-    RunEvent event =
-        runEventBuilder.buildRun(
-            OpenLineageRunEventContext.builder()
-                .applicationParentRunFacet(buildApplicationParentFacet())
-                .event(endEvent)
-                .runEventBuilder(
-                    olContext
-                        .getOpenLineage()
-                        .newRunEventBuilder()
-                        .eventTime(toZonedTime(endEvent.time())))
-                .eventType(eventType)
-                .jobBuilder(buildJob())
-                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
-                .build());
+      RunEvent event =
+          runEventBuilder.buildRun(
+              OpenLineageRunEventContext.builder()
+                  .applicationParentRunFacet(buildApplicationParentFacet())
+                  .event(endEvent)
+                  .runEventBuilder(
+                      olContext
+                          .getOpenLineage()
+                          .newRunEventBuilder()
+                          .eventTime(toZonedTime(endEvent.time())))
+                  .eventType(eventType)
+                  .jobBuilder(buildJob())
+                  .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                  .build());
 
-    if (eventType.equals(EventType.COMPLETE)) {
-      // clean up metrics on complete only
-      olContext.getActiveJobId().ifPresent(i -> JobMetricsHolder.getInstance().cleanUp(i));
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+      }
+      eventEmitter.emit(event);
+    } finally {
+      retainedMetricsJobId.ifPresent(JobMetricsHolder.getInstance()::cleanUp);
+      retainedMetricsJobId = Optional.empty();
+      if (!jobEndPending) {
+        olContext.getActiveJobId().ifPresent(JobMetricsHolder.getInstance()::cleanUp);
+      }
     }
-    if (log.isDebugEnabled()) {
-      log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
-    }
-    eventEmitter.emit(event);
   }
 
   // TODO: not invoked until https://github.com/OpenLineage/OpenLineage/issues/470 is completed
@@ -302,59 +311,111 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
-    log.debug("SparkListenerJobEnd - executionId: {}", executionId);
-    olContext.setActiveJobId(jobEnd.jobId());
-    if (!finished.compareAndSet(false, true)) {
-      log.debug("Event already finished, returning");
-      return;
+    boolean retainMetrics = false;
+    try {
+      log.debug("SparkListenerJobEnd - executionId: {}", executionId);
+      olContext.setActiveJobId(jobEnd.jobId());
+      if (!finished.compareAndSet(false, true)) {
+        log.debug("Event already finished, returning");
+        retainMetrics = emittedOnSqlExecutionStart && !sqlExecutionEnded;
+        if (retainMetrics) {
+          retainMetricsUntilSqlEnd(jobEnd.jobId());
+        }
+        return;
+      }
+
+      if (!olContext.getQueryExecution().isPresent()) {
+        log.info(NO_EXECUTION_INFO, olContext);
+        return;
+      } else if (EventFilterUtils.isDisabled(olContext, jobEnd)) {
+        log.info(
+            "OpenLineage received Spark event that is configured to be skipped: SparkListenerJobEnd");
+        retainMetrics = emittedOnSqlExecutionStart && !sqlExecutionEnded;
+        if (retainMetrics) {
+          retainMetricsUntilSqlEnd(jobEnd.jobId());
+        }
+        return;
+      }
+
+      retainMetrics = emittedOnSqlExecutionStart && !sqlExecutionEnded;
+      if (retainMetrics) {
+        retainMetricsUntilSqlEnd(jobEnd.jobId());
+      }
+
+      // only one COMPLETE event is expected,
+      EventType eventType;
+      if (jobEnd.jobResult() instanceof JobFailed) {
+        eventType = FAIL;
+      } else if (emittedOnSqlExecutionStart && !emittedOnSqlExecutionEnd) {
+        // still waiting for sqlExecutionEnd event which will emit COMPLETE event
+        eventType = RUNNING;
+      } else {
+        eventType = COMPLETE;
+      }
+      emittedOnJobEnd = true;
+
+      RunEvent event =
+          runEventBuilder.buildRun(
+              OpenLineageRunEventContext.builder()
+                  .applicationParentRunFacet(buildApplicationParentFacet())
+                  .event(jobEnd)
+                  .runEventBuilder(
+                      olContext
+                          .getOpenLineage()
+                          .newRunEventBuilder()
+                          .eventTime(toZonedTime(jobEnd.time())))
+                  .eventType(eventType)
+                  .jobBuilder(buildJob())
+                  .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                  .build());
+
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+      }
+
+      eventEmitter.emit(event);
+    } finally {
+      runEventBuilder.evictJob(jobEnd.jobId());
+      if (retainMetrics) {
+        JobMetricsHolder.getInstance().completeJob(jobEnd.jobId());
+      } else {
+        JobMetricsHolder.getInstance().cleanUp(jobEnd.jobId());
+      }
     }
+  }
 
-    if (!olContext.getQueryExecution().isPresent()) {
-      log.info(NO_EXECUTION_INFO, olContext);
-      return;
-    } else if (EventFilterUtils.isDisabled(olContext, jobEnd)) {
-      log.info(
-          "OpenLineage received Spark event that is configured to be skipped: SparkListenerJobEnd");
-      return;
-    }
+  @Override
+  public void evictJob(int jobId) {
+    runEventBuilder.evictJob(jobId);
+  }
 
-    // only one COMPLETE event is expected,
-    EventType eventType;
-    if (jobEnd.jobResult() instanceof JobFailed) {
-      eventType = FAIL;
-    } else if (emittedOnSqlExecutionStart && !emittedOnSqlExecutionEnd) {
-      // still waiting for sqlExecutionEnd event which will emit COMPLETE event
-      eventType = RUNNING;
-    } else {
-      eventType = COMPLETE;
-    }
-    emittedOnJobEnd = true;
+  @Override
+  public boolean retainsJobMetrics(int jobId) {
+    return retainedMetricsJobId.filter(id -> id == jobId).isPresent();
+  }
 
-    RunEvent event =
-        runEventBuilder.buildRun(
-            OpenLineageRunEventContext.builder()
-                .applicationParentRunFacet(buildApplicationParentFacet())
-                .event(jobEnd)
-                .runEventBuilder(
-                    olContext
-                        .getOpenLineage()
-                        .newRunEventBuilder()
-                        .eventTime(toZonedTime(jobEnd.time())))
-                .eventType(eventType)
-                .jobBuilder(buildJob())
-                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
-                .build());
+  @Override
+  public void clearRetainedState() {
+    runEventBuilder.clearRetainedState();
+    retainedMetricsJobId = Optional.empty();
+  }
 
-    if (eventType.equals(EventType.COMPLETE)) {
-      // clean up metrics on complete only
-      JobMetricsHolder.getInstance().cleanUp(jobEnd.jobId());
-    }
+  @Override
+  public int getRetainedJobCount() {
+    return runEventBuilder.getRetainedJobCount();
+  }
 
-    if (log.isDebugEnabled()) {
-      log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
-    }
+  @Override
+  public int getRetainedStageCount() {
+    return runEventBuilder.getRetainedStageCount();
+  }
 
-    eventEmitter.emit(event);
+  private void retainMetricsUntilSqlEnd(int jobId) {
+    retainedMetricsJobId
+        .filter(id -> id != jobId)
+        .ifPresent(JobMetricsHolder.getInstance()::cleanUp);
+    retainedMetricsJobId = Optional.of(jobId);
   }
 
   @Override

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -16,7 +16,6 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.spark.agent.EventEmitter;
-import io.openlineage.spark.agent.JobMetricsHolder;
 import io.openlineage.spark.agent.filters.EventFilterUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -57,11 +56,9 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   private boolean emittedOnSqlExecutionStart = false;
   private boolean emittedOnSqlExecutionEnd = false;
-  private boolean sqlExecutionEnded = false;
   private boolean emittedOnJobStart = false;
   private boolean emittedOnJobEnd = false;
   private Integer activeJobId;
-  private Optional<Integer> retainedMetricsJobId = Optional.empty();
   private AtomicBoolean finished = new AtomicBoolean(false);
 
   private SparkSQLQueryParser sqlRecorder = new SparkSQLQueryParser();
@@ -121,62 +118,51 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerSQLExecutionEnd endEvent) {
-    boolean jobEndPending = emittedOnJobStart && !emittedOnJobEnd;
-    sqlExecutionEnded = true;
-    try {
-      if (log.isDebugEnabled()) {
-        log.debug("SparkListenerSQLExecutionEnd - executionId: {}", endEvent.executionId());
-      }
-      // TODO: can we get failed event here?
-      // If not, then we probably need to use this only for LogicalPlans that emit no Job events.
-      // Maybe use QueryExecutionListener?
-      olContext.setActiveJobId(activeJobId);
-      if (!olContext.getQueryExecution().isPresent()) {
-        log.info(NO_EXECUTION_INFO, olContext);
-        return;
-      } else if (EventFilterUtils.isDisabled(olContext, endEvent)) {
-        log.info(
-            "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionEnd");
-        return;
-      }
-
-      // only one COMPLETE event is expected, verify if jobEnd was not emitted
-      EventType eventType;
-      if (emittedOnJobStart && !emittedOnJobEnd) {
-        // expecting jobEnd event later on
-        eventType = RUNNING;
-      } else {
-        eventType = COMPLETE;
-      }
-      emittedOnSqlExecutionEnd = true;
-
-      RunEvent event =
-          runEventBuilder.buildRun(
-              OpenLineageRunEventContext.builder()
-                  .applicationParentRunFacet(buildApplicationParentFacet())
-                  .event(endEvent)
-                  .runEventBuilder(
-                      olContext
-                          .getOpenLineage()
-                          .newRunEventBuilder()
-                          .eventTime(toZonedTime(endEvent.time())))
-                  .eventType(eventType)
-                  .jobBuilder(buildJob())
-                  .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
-                  .build());
-
-      if (log.isDebugEnabled()) {
-        log.debug(
-            "Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
-      }
-      eventEmitter.emit(event);
-    } finally {
-      retainedMetricsJobId.ifPresent(JobMetricsHolder.getInstance()::cleanUp);
-      retainedMetricsJobId = Optional.empty();
-      if (!jobEndPending) {
-        olContext.getActiveJobId().ifPresent(JobMetricsHolder.getInstance()::cleanUp);
-      }
+    if (log.isDebugEnabled()) {
+      log.debug("SparkListenerSQLExecutionEnd - executionId: {}", endEvent.executionId());
     }
+    // TODO: can we get failed event here?
+    // If not, then we probably need to use this only for LogicalPlans that emit no Job events.
+    // Maybe use QueryExecutionListener?
+    olContext.setActiveJobId(activeJobId);
+    if (!olContext.getQueryExecution().isPresent()) {
+      log.info(NO_EXECUTION_INFO, olContext);
+      return;
+    } else if (EventFilterUtils.isDisabled(olContext, endEvent)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionEnd");
+      return;
+    }
+
+    // only one COMPLETE event is expected, verify if jobEnd was not emitted
+    EventType eventType;
+    if (emittedOnJobStart && !emittedOnJobEnd) {
+      // expecting jobEnd event later on
+      eventType = RUNNING;
+    } else {
+      eventType = COMPLETE;
+    }
+    emittedOnSqlExecutionEnd = true;
+
+    RunEvent event =
+        runEventBuilder.buildRun(
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(endEvent)
+                .runEventBuilder(
+                    olContext
+                        .getOpenLineage()
+                        .newRunEventBuilder()
+                        .eventTime(toZonedTime(endEvent.time())))
+                .eventType(eventType)
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
+
+    if (log.isDebugEnabled()) {
+      log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    }
+    eventEmitter.emit(event);
   }
 
   // TODO: not invoked until https://github.com/OpenLineage/OpenLineage/issues/470 is completed
@@ -311,16 +297,11 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
-    boolean retainMetrics = false;
     try {
       log.debug("SparkListenerJobEnd - executionId: {}", executionId);
       olContext.setActiveJobId(jobEnd.jobId());
       if (!finished.compareAndSet(false, true)) {
         log.debug("Event already finished, returning");
-        retainMetrics = emittedOnSqlExecutionStart && !sqlExecutionEnded;
-        if (retainMetrics) {
-          retainMetricsUntilSqlEnd(jobEnd.jobId());
-        }
         return;
       }
 
@@ -330,16 +311,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
       } else if (EventFilterUtils.isDisabled(olContext, jobEnd)) {
         log.info(
             "OpenLineage received Spark event that is configured to be skipped: SparkListenerJobEnd");
-        retainMetrics = emittedOnSqlExecutionStart && !sqlExecutionEnded;
-        if (retainMetrics) {
-          retainMetricsUntilSqlEnd(jobEnd.jobId());
-        }
         return;
-      }
-
-      retainMetrics = emittedOnSqlExecutionStart && !sqlExecutionEnded;
-      if (retainMetrics) {
-        retainMetricsUntilSqlEnd(jobEnd.jobId());
       }
 
       // only one COMPLETE event is expected,
@@ -377,11 +349,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
       eventEmitter.emit(event);
     } finally {
       runEventBuilder.evictJob(jobEnd.jobId());
-      if (retainMetrics) {
-        JobMetricsHolder.getInstance().completeJob(jobEnd.jobId());
-      } else {
-        JobMetricsHolder.getInstance().cleanUp(jobEnd.jobId());
-      }
     }
   }
 
@@ -391,14 +358,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
   }
 
   @Override
-  public boolean retainsJobMetrics(int jobId) {
-    return retainedMetricsJobId.filter(id -> id == jobId).isPresent();
-  }
-
-  @Override
   public void clearRetainedState() {
     runEventBuilder.clearRetainedState();
-    retainedMetricsJobId = Optional.empty();
   }
 
   @Override
@@ -409,13 +370,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
   @Override
   public int getRetainedStageCount() {
     return runEventBuilder.getRetainedStageCount();
-  }
-
-  private void retainMetricsUntilSqlEnd(int jobId) {
-    retainedMetricsJobId
-        .filter(id -> id != jobId)
-        .ifPresent(JobMetricsHolder.getInstance()::cleanUp);
-    retainedMetricsJobId = Optional.of(jobId);
   }
 
   @Override

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsCleanupIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsCleanupIntegrationTest.java
@@ -7,7 +7,9 @@ package io.openlineage.spark.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.atLeastOnce;
 
+import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
@@ -23,6 +25,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 @ExtendWith(SparkAgentTestExtension.class)
 @Tag("integration-test")
@@ -56,6 +60,17 @@ class JobMetricsCleanupIntegrationTest {
     StaticExecutionContextFactory.waitForExecutionEnd();
 
     assertThat(completedJobs.get()).isPositive();
+    ArgumentCaptor<RunEvent> events = ArgumentCaptor.forClass(RunEvent.class);
+    Mockito.verify(SparkAgentTestExtension.EVENT_EMITTER, atLeastOnce()).emit(events.capture());
+    assertThat(events.getAllValues())
+        .filteredOn(event -> event.getOutputs() != null && !event.getOutputs().isEmpty())
+        .anySatisfy(
+            event ->
+                assertThat(event.getOutputs())
+                    .anySatisfy(
+                        output ->
+                            assertThat(output.getOutputFacets().getOutputStatistics())
+                                .isNotNull()));
     assertNoRetainedMetrics(completedJobs.get());
   }
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsCleanupIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsCleanupIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.spark.scheduler.SparkListener;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+@ExtendWith(SparkAgentTestExtension.class)
+@Tag("integration-test")
+class JobMetricsCleanupIntegrationTest {
+  private static final int JOB_COUNT = 10;
+
+  @Test
+  void completedSparkJobsLeaveNoRetainedMetrics(SparkSession spark)
+      throws InterruptedException, TimeoutException, ReflectiveOperationException {
+    AtomicInteger completedJobs = countCompletedJobs(spark);
+
+    for (int job = 0; job < JOB_COUNT; job++) {
+      spark.range(job * 100L, (job + 1) * 100L, 1, 2).count();
+    }
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    assertThat(completedJobs.get()).isGreaterThanOrEqualTo(JOB_COUNT);
+    assertNoRetainedMetrics(completedJobs.get());
+  }
+
+  @Test
+  void completedOutputJobLeavesNoRetainedMetrics(@TempDir Path outputDir, SparkSession spark)
+      throws InterruptedException, TimeoutException, ReflectiveOperationException {
+    AtomicInteger completedJobs = countCompletedJobs(spark);
+
+    spark
+        .range(0, 100, 1, 2)
+        .write()
+        .mode(SaveMode.Overwrite)
+        .parquet(outputDir.resolve("output").toString());
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    assertThat(completedJobs.get()).isPositive();
+    assertNoRetainedMetrics(completedJobs.get());
+  }
+
+  private AtomicInteger countCompletedJobs(SparkSession spark) {
+    AtomicInteger completedJobs = new AtomicInteger();
+    spark
+        .sparkContext()
+        .addSparkListener(
+            new SparkListener() {
+              @Override
+              public void onJobEnd(SparkListenerJobEnd jobEnd) {
+                completedJobs.incrementAndGet();
+              }
+            });
+    return completedJobs;
+  }
+
+  private void assertNoRetainedMetrics(int completedJobs) throws ReflectiveOperationException {
+    assertThat(retainedMetricsState())
+        .as("retained metrics state after %d completed Spark jobs", completedJobs)
+        .containsOnly(entry("jobStages", 0), entry("stageMetrics", 0), entry("jobMetrics", 0));
+  }
+
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+  private Map<String, Integer> retainedMetricsState() throws ReflectiveOperationException {
+    Map<String, Integer> retainedState = new LinkedHashMap<>();
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    for (String fieldName : new String[] {"jobStages", "stageMetrics", "jobMetrics"}) {
+      Field field = JobMetricsHolder.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      retainedState.put(fieldName, ((Map<?, ?>) field.get(holder)).size());
+    }
+    return retainedState;
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsLifecycleManagerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsLifecycleManagerTest.java
@@ -1,0 +1,146 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.spark.executor.TaskMetrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JobMetricsLifecycleManagerTest {
+  private JobMetricsHolder jobMetrics;
+  private JobMetricsLifecycleManager manager;
+
+  @BeforeEach
+  void setup() {
+    jobMetrics = new JobMetricsHolder();
+    manager = new JobMetricsLifecycleManager(jobMetrics);
+  }
+
+  @Test
+  void nestedExecutionKeepsMetricsUntilRootExecutionEnds() {
+    manager.registerExecution(10, 10);
+    manager.registerExecution(11, 10);
+    manager.registerJob(1, 11, Optional.of(10L));
+    addMetricBearingJob(1, 100);
+
+    manager.completeJob(1);
+
+    assertThat(jobMetrics.getJobStagesSize()).isZero();
+    assertThat(jobMetrics.getStageMetricsSize()).isZero();
+    assertThat(jobMetrics.getJobMetricsSize()).isOne();
+    assertThat(manager.getExecutionGroupCount()).isOne();
+    assertThat(manager.getPendingJobCount()).isOne();
+
+    manager.endExecution(11);
+
+    assertThat(jobMetrics.getJobMetricsSize()).isOne();
+    assertThat(manager.getPendingJobCount()).isOne();
+
+    manager.endExecution(10);
+
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+    assertThat(manager.getExecutionGroupCount()).isZero();
+    assertThat(manager.getPendingJobCount()).isZero();
+  }
+
+  @Test
+  void endingOneRootDoesNotCleanAnotherRootsMetrics() {
+    manager.registerExecution(10, 10);
+    manager.registerExecution(20, 20);
+    manager.registerJob(1, 10, Optional.of(10L));
+    manager.registerJob(2, 20, Optional.of(20L));
+    addMetricBearingJob(1, 100);
+    addMetricBearingJob(2, 200);
+    manager.completeJob(1);
+    manager.completeJob(2);
+
+    manager.endExecution(10);
+
+    assertThat(jobMetrics.getJobMetricsSize()).isOne();
+    assertThat(manager.getExecutionGroupCount()).isOne();
+    assertThat(manager.getPendingJobCount()).isOne();
+
+    manager.endExecution(20);
+
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+    assertThat(manager.getExecutionGroupCount()).isZero();
+    assertThat(manager.getPendingJobCount()).isZero();
+  }
+
+  @Test
+  void jobWithoutSqlExecutionIsCleanedImmediately() {
+    addMetricBearingJob(1, 100);
+
+    manager.completeJob(1);
+
+    assertThat(jobMetrics.getJobStagesSize()).isZero();
+    assertThat(jobMetrics.getStageMetricsSize()).isZero();
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+    assertThat(manager.getPendingJobCount()).isZero();
+  }
+
+  @Test
+  void jobEndingAfterItsExecutionIsCleanedImmediately() {
+    manager.registerExecution(10, 10);
+    manager.registerJob(1, 10, Optional.of(10L));
+    addMetricBearingJob(1, 100);
+
+    manager.endExecution(10);
+
+    assertThat(jobMetrics.getJobStagesSize()).isOne();
+    assertThat(jobMetrics.getStageMetricsSize()).isOne();
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+
+    manager.completeJob(1);
+
+    assertThat(jobMetrics.getJobStagesSize()).isZero();
+    assertThat(jobMetrics.getStageMetricsSize()).isZero();
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+    assertThat(manager.getPendingJobCount()).isZero();
+  }
+
+  @Test
+  void emptyMetricsAreNotRetainedForAnActiveExecution() {
+    manager.registerExecution(10, 10);
+    manager.registerJob(1, 10, Optional.of(10L));
+    jobMetrics.addJobStages(1, Collections.singleton(100));
+
+    manager.completeJob(1);
+
+    assertThat(jobMetrics.getJobStagesSize()).isZero();
+    assertThat(jobMetrics.getStageMetricsSize()).isZero();
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+    assertThat(manager.getPendingJobCount()).isZero();
+  }
+
+  @Test
+  void tenThousandExecutionGroupsLeaveNoLifecycleState() {
+    for (int jobId = 0; jobId < 10_000; jobId++) {
+      long executionId = jobId;
+      manager.registerExecution(executionId, executionId);
+      manager.registerJob(jobId, executionId, Optional.of(executionId));
+      manager.completeJob(jobId);
+      manager.endExecution(executionId);
+    }
+
+    assertThat(jobMetrics.getJobStagesSize()).isZero();
+    assertThat(jobMetrics.getStageMetricsSize()).isZero();
+    assertThat(jobMetrics.getJobMetricsSize()).isZero();
+    assertThat(manager.getExecutionGroupCount()).isZero();
+    assertThat(manager.getPendingJobCount()).isZero();
+  }
+
+  private void addMetricBearingJob(int jobId, int stageId) {
+    TaskMetrics taskMetrics = new TaskMetrics();
+    taskMetrics.outputMetrics()._bytesWritten().add(1);
+    jobMetrics.addJobStages(jobId, Collections.singleton(stageId));
+    jobMetrics.addMetrics(stageId, taskMetrics);
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -288,6 +288,15 @@ class OpenLineageSparkListenerTest {
         .isEqualTo(2);
     assertThat(meterRegistry.get(OpenLineageSparkListener.BUILDER_STAGES_GAUGE).gauge().value())
         .isEqualTo(3);
+    assertThat(
+            meterRegistry
+                .get(OpenLineageSparkListener.METRICS_EXECUTION_GROUPS_GAUGE)
+                .gauge()
+                .value())
+        .isEqualTo(1);
+    assertThat(
+            meterRegistry.get(OpenLineageSparkListener.METRICS_PENDING_JOBS_GAUGE).gauge().value())
+        .isZero();
     assertThat(meterRegistry.get(JobMetricsHolder.JOB_STAGES_GAUGE).gauge().value()).isEqualTo(1);
     assertThat(meterRegistry.get(JobMetricsHolder.STAGE_METRICS_GAUGE).gauge().value())
         .isEqualTo(1);
@@ -298,6 +307,12 @@ class OpenLineageSparkListenerTest {
     assertThat(meterRegistry.get(OpenLineageSparkListener.SQL_REGISTRY_GAUGE).gauge().value())
         .isZero();
     assertThat(meterRegistry.get(OpenLineageSparkListener.BUILDER_JOBS_GAUGE).gauge().value())
+        .isZero();
+    assertThat(
+            meterRegistry
+                .get(OpenLineageSparkListener.METRICS_EXECUTION_GROUPS_GAUGE)
+                .gauge()
+                .value())
         .isZero();
     assertThat(meterRegistry.get(JobMetricsHolder.JOB_STAGES_GAUGE).gauge().value()).isZero();
     assertThat(meterRegistry.get(JobMetricsHolder.STAGE_METRICS_GAUGE).gauge().value()).isZero();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -28,11 +28,13 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
@@ -102,6 +104,7 @@ class OpenLineageSparkListenerTest {
   @AfterEach
   public void teardown() throws Exception {
     OpenLineageSparkListener.resetDefaultFactoryForTests();
+    JobMetricsHolder.getInstance().cleanUpAll();
   }
 
   @Test
@@ -230,6 +233,76 @@ class OpenLineageSparkListenerTest {
 
     assertThat(meterRegistry.counter("openlineage.spark.event.app.start").count()).isEqualTo(1.0);
     assertThat(meterRegistry.counter("openlineage.spark.event.app.end").count()).isEqualTo(1.0);
+  }
+
+  @Test
+  void testJobEndWithoutContextCleansMetrics() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ContextFactory contextFactory = mock(ContextFactory.class);
+    when(contextFactory.getMeterRegistry()).thenReturn(meterRegistry);
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
+    listener.skipInitializationForTests(contextFactory);
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(61);
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    holder.addJobStages(61, Collections.singleton(610));
+
+    listener.onJobEnd(jobEnd);
+
+    assertThat(holder.getJobStagesSize()).isZero();
+    assertThat(holder.getStageMetricsSize()).isZero();
+    assertThat(holder.getJobMetricsSize()).isZero();
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
+  void testRetainedStateGaugesTrackContextsAndMetrics() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    ContextFactory contextFactory = mock(ContextFactory.class);
+    ExecutionContext executionContext = mock(ExecutionContext.class);
+    when(contextFactory.getMeterRegistry()).thenReturn(meterRegistry);
+    when(contextFactory.createSparkSQLExecutionContext(62L))
+        .thenReturn(Optional.of(executionContext));
+    when(executionContext.getRetainedJobCount()).thenReturn(2);
+    when(executionContext.getRetainedStageCount()).thenReturn(3);
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
+    listener.skipInitializationForTests(contextFactory);
+    SparkListenerSQLExecutionStart sqlStart = mock(SparkListenerSQLExecutionStart.class);
+    when(sqlStart.executionId()).thenReturn(62L);
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    holder.addJobStages(62, Collections.singleton(620));
+    holder.addMetrics(620, new TaskMetrics());
+    TaskMetrics completedMetrics = new TaskMetrics();
+    completedMetrics.outputMetrics()._bytesWritten().add(1);
+    holder.addJobStages(63, Collections.singleton(630));
+    holder.addMetrics(630, completedMetrics);
+    holder.completeJob(63);
+
+    listener.onOtherEvent(sqlStart);
+
+    assertThat(meterRegistry.get(OpenLineageSparkListener.SQL_REGISTRY_GAUGE).gauge().value())
+        .isEqualTo(1);
+    assertThat(meterRegistry.get(OpenLineageSparkListener.RDD_REGISTRY_GAUGE).gauge().value())
+        .isZero();
+    assertThat(meterRegistry.get(OpenLineageSparkListener.BUILDER_JOBS_GAUGE).gauge().value())
+        .isEqualTo(2);
+    assertThat(meterRegistry.get(OpenLineageSparkListener.BUILDER_STAGES_GAUGE).gauge().value())
+        .isEqualTo(3);
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_STAGES_GAUGE).gauge().value()).isEqualTo(1);
+    assertThat(meterRegistry.get(JobMetricsHolder.STAGE_METRICS_GAUGE).gauge().value())
+        .isEqualTo(1);
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_METRICS_GAUGE).gauge().value()).isEqualTo(1);
+
+    listener.close();
+
+    assertThat(meterRegistry.get(OpenLineageSparkListener.SQL_REGISTRY_GAUGE).gauge().value())
+        .isZero();
+    assertThat(meterRegistry.get(OpenLineageSparkListener.BUILDER_JOBS_GAUGE).gauge().value())
+        .isZero();
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_STAGES_GAUGE).gauge().value()).isZero();
+    assertThat(meterRegistry.get(JobMetricsHolder.STAGE_METRICS_GAUGE).gauge().value()).isZero();
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_METRICS_GAUGE).gauge().value()).isZero();
+    verify(executionContext).clearRetainedState();
   }
 
   @Test

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/RddExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/RddExecutionContextTest.java
@@ -14,6 +14,7 @@ import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.JobMetricsHolder;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
@@ -24,6 +25,9 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.JobSucceeded$;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +50,11 @@ class RddExecutionContextTest {
       new RddExecutionContext(olContext, eventEmitter, runEventBuilder);
 
   private SparkConf sparkConf;
+
+  @AfterEach
+  void cleanupMetrics() {
+    JobMetricsHolder.getInstance().cleanUpAll();
+  }
 
   @BeforeEach
   void setup() {
@@ -95,5 +104,20 @@ class RddExecutionContextTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getName()).isEqualTo("/tmp/input.csv");
+  }
+
+  @Test
+  void outputlessSuccessfulJobCleansMetrics() {
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(51);
+    when(jobEnd.jobResult()).thenReturn(JobSucceeded$.MODULE$);
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    holder.addJobStages(51, Collections.singleton(510));
+
+    context.end(jobEnd);
+
+    assertThat(holder.getJobStagesSize()).isZero();
+    assertThat(holder.getStageMetricsSize()).isZero();
+    assertThat(holder.getJobMetricsSize()).isZero();
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
@@ -19,6 +19,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.JobMetricsHolder;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.filters.EventFilterUtils;
@@ -27,8 +28,10 @@ import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
 import io.openlineage.spark.api.OpenLineageRunStatus;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import io.openlineage.spark.api.VisitedNodes;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.scheduler.JobFailed;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
@@ -61,6 +64,7 @@ class SparkSQLExecutionContextTest {
 
   @AfterEach
   void reset() {
+    JobMetricsHolder.getInstance().cleanUpAll();
     Mockito.reset(olContext, eventEmitter, queryExecution);
   }
 
@@ -163,6 +167,7 @@ class SparkSQLExecutionContextTest {
   @Test
   void testCompleteIsSentWhenNoSqlStart(SparkSession spark) {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    JobMetricsHolder.getInstance().addJobStages(0, Collections.singleton(10));
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
 
@@ -175,13 +180,16 @@ class SparkSQLExecutionContextTest {
         .hasFieldOrPropertyWithValue("eventType", EventType.START);
     assertThat(lineageEvent.getAllValues().get(1))
         .hasFieldOrPropertyWithValue("eventType", EventType.COMPLETE);
+    assertMetricsStateIsEmpty();
   }
 
   @Test
   void testFailIsSent(SparkSession spark) {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(41);
     when(jobEnd.jobResult()).thenReturn(mock(JobFailed.class));
+    JobMetricsHolder.getInstance().addJobStages(41, Collections.singleton(410));
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
 
@@ -194,6 +202,140 @@ class SparkSQLExecutionContextTest {
         .hasFieldOrPropertyWithValue("eventType", EventType.START);
     assertThat(lineageEvent.getAllValues().get(1))
         .hasFieldOrPropertyWithValue("eventType", EventType.FAIL);
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testFilteredJobEndCleansMetrics(SparkSession spark) {
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(42);
+    JobMetricsHolder.getInstance().addJobStages(42, Collections.singleton(420));
+
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(olContext, jobEnd)).thenReturn(true);
+      context.end(jobEnd);
+    }
+
+    verify(eventEmitter, times(0)).emit(any());
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testMissingQueryExecutionOnJobEndCleansMetrics(SparkSession spark) {
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(43);
+    when(olContext.getQueryExecution()).thenReturn(Optional.empty());
+    JobMetricsHolder.getInstance().addJobStages(43, Collections.singleton(430));
+
+    context.end(jobEnd);
+
+    verify(eventEmitter, times(0)).emit(any());
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testMetricsAreRetainedOnlyUntilSqlEnd(SparkSession spark) {
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(44);
+    addMetricBearingJob(44, 440);
+
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+      context.start(mock(SparkListenerSQLExecutionStart.class));
+      context.end(jobEnd);
+
+      assertThat(JobMetricsHolder.getInstance().getJobStagesSize()).isZero();
+      assertThat(JobMetricsHolder.getInstance().getStageMetricsSize()).isZero();
+      assertThat(JobMetricsHolder.getInstance().getJobMetricsSize()).isOne();
+
+      context.end(mock(SparkListenerSQLExecutionEnd.class));
+    }
+
+    verify(eventEmitter, times(3)).emit(any());
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testSqlEndCleansMetricsWhenNoJobEndIsPending(SparkSession spark) {
+    int jobId = 49;
+    context.setActiveJobId(jobId);
+    when(olContext.getActiveJobId()).thenReturn(Optional.of(jobId));
+    JobMetricsHolder.getInstance().addJobStages(jobId, Collections.singleton(490));
+
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+      context.end(mock(SparkListenerSQLExecutionEnd.class));
+    }
+
+    verify(eventEmitter).emit(any());
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testFailedJobMetricsAreRetainedUntilPendingSqlEnd(SparkSession spark) {
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(45);
+    when(jobEnd.jobResult()).thenReturn(mock(JobFailed.class));
+    addMetricBearingJob(45, 450);
+
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+      context.start(mock(SparkListenerSQLExecutionStart.class));
+      context.end(jobEnd);
+
+      assertThat(JobMetricsHolder.getInstance().getJobStagesSize()).isZero();
+      assertThat(JobMetricsHolder.getInstance().getStageMetricsSize()).isZero();
+      assertThat(JobMetricsHolder.getInstance().getJobMetricsSize()).isOne();
+
+      context.end(mock(SparkListenerSQLExecutionEnd.class));
+    }
+
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testFilteredSqlEndBeforeJobEndDoesNotRetainMetrics(SparkSession spark) {
+    SparkListenerSQLExecutionEnd sqlEnd = mock(SparkListenerSQLExecutionEnd.class);
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(46);
+    JobMetricsHolder.getInstance().addJobStages(46, Collections.singleton(460));
+
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(olContext, sqlEnd)).thenReturn(true);
+      when(EventFilterUtils.isDisabled(olContext, jobEnd)).thenReturn(false);
+      context.start(mock(SparkListenerSQLExecutionStart.class));
+      context.end(sqlEnd);
+      context.end(jobEnd);
+    }
+
+    assertMetricsStateIsEmpty();
+  }
+
+  @Test
+  void testMultipleJobsRetainOnlyLatestMetricsUntilSqlEnd(SparkSession spark) {
+    SparkListenerJobEnd firstJobEnd = mock(SparkListenerJobEnd.class);
+    SparkListenerJobEnd secondJobEnd = mock(SparkListenerJobEnd.class);
+    when(firstJobEnd.jobId()).thenReturn(47);
+    when(secondJobEnd.jobId()).thenReturn(48);
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    addMetricBearingJob(47, 470);
+    addMetricBearingJob(48, 480);
+
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+      context.start(mock(SparkListenerSQLExecutionStart.class));
+      context.end(firstJobEnd);
+      context.end(secondJobEnd);
+
+      assertThat(holder.getJobStagesSize()).isZero();
+      assertThat(holder.getStageMetricsSize()).isZero();
+      assertThat(holder.getJobMetricsSize()).isOne();
+
+      context.end(mock(SparkListenerSQLExecutionEnd.class));
+    }
+
+    verify(eventEmitter, times(3)).emit(any());
+    assertMetricsStateIsEmpty();
   }
 
   @Test
@@ -323,5 +465,19 @@ class SparkSQLExecutionContextTest {
       assertThat(rootJob.getNamespace()).isEqualTo("root_job_namespace");
       assertThat(rootRun.getRunId()).isEqualTo(rootUuid);
     }
+  }
+
+  private void assertMetricsStateIsEmpty() {
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    assertThat(holder.getJobStagesSize()).isZero();
+    assertThat(holder.getStageMetricsSize()).isZero();
+    assertThat(holder.getJobMetricsSize()).isZero();
+  }
+
+  private void addMetricBearingJob(int jobId, int stageId) {
+    TaskMetrics taskMetrics = new TaskMetrics();
+    taskMetrics.inputMetrics()._bytesRead().add(1);
+    JobMetricsHolder.getInstance().addJobStages(jobId, Collections.singleton(stageId));
+    JobMetricsHolder.getInstance().addMetrics(stageId, taskMetrics);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
@@ -19,7 +19,6 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.spark.agent.EventEmitter;
-import io.openlineage.spark.agent.JobMetricsHolder;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.filters.EventFilterUtils;
@@ -28,10 +27,8 @@ import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
 import io.openlineage.spark.api.OpenLineageRunStatus;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import io.openlineage.spark.api.VisitedNodes;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.scheduler.JobFailed;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
@@ -64,7 +61,6 @@ class SparkSQLExecutionContextTest {
 
   @AfterEach
   void reset() {
-    JobMetricsHolder.getInstance().cleanUpAll();
     Mockito.reset(olContext, eventEmitter, queryExecution);
   }
 
@@ -167,7 +163,6 @@ class SparkSQLExecutionContextTest {
   @Test
   void testCompleteIsSentWhenNoSqlStart(SparkSession spark) {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    JobMetricsHolder.getInstance().addJobStages(0, Collections.singleton(10));
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
 
@@ -180,7 +175,6 @@ class SparkSQLExecutionContextTest {
         .hasFieldOrPropertyWithValue("eventType", EventType.START);
     assertThat(lineageEvent.getAllValues().get(1))
         .hasFieldOrPropertyWithValue("eventType", EventType.COMPLETE);
-    assertMetricsStateIsEmpty();
   }
 
   @Test
@@ -189,7 +183,6 @@ class SparkSQLExecutionContextTest {
     SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
     when(jobEnd.jobId()).thenReturn(41);
     when(jobEnd.jobResult()).thenReturn(mock(JobFailed.class));
-    JobMetricsHolder.getInstance().addJobStages(41, Collections.singleton(410));
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
 
@@ -202,140 +195,6 @@ class SparkSQLExecutionContextTest {
         .hasFieldOrPropertyWithValue("eventType", EventType.START);
     assertThat(lineageEvent.getAllValues().get(1))
         .hasFieldOrPropertyWithValue("eventType", EventType.FAIL);
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testFilteredJobEndCleansMetrics(SparkSession spark) {
-    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
-    when(jobEnd.jobId()).thenReturn(42);
-    JobMetricsHolder.getInstance().addJobStages(42, Collections.singleton(420));
-
-    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
-      when(EventFilterUtils.isDisabled(olContext, jobEnd)).thenReturn(true);
-      context.end(jobEnd);
-    }
-
-    verify(eventEmitter, times(0)).emit(any());
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testMissingQueryExecutionOnJobEndCleansMetrics(SparkSession spark) {
-    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
-    when(jobEnd.jobId()).thenReturn(43);
-    when(olContext.getQueryExecution()).thenReturn(Optional.empty());
-    JobMetricsHolder.getInstance().addJobStages(43, Collections.singleton(430));
-
-    context.end(jobEnd);
-
-    verify(eventEmitter, times(0)).emit(any());
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testMetricsAreRetainedOnlyUntilSqlEnd(SparkSession spark) {
-    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
-    when(jobEnd.jobId()).thenReturn(44);
-    addMetricBearingJob(44, 440);
-
-    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
-      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      context.start(mock(SparkListenerSQLExecutionStart.class));
-      context.end(jobEnd);
-
-      assertThat(JobMetricsHolder.getInstance().getJobStagesSize()).isZero();
-      assertThat(JobMetricsHolder.getInstance().getStageMetricsSize()).isZero();
-      assertThat(JobMetricsHolder.getInstance().getJobMetricsSize()).isOne();
-
-      context.end(mock(SparkListenerSQLExecutionEnd.class));
-    }
-
-    verify(eventEmitter, times(3)).emit(any());
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testSqlEndCleansMetricsWhenNoJobEndIsPending(SparkSession spark) {
-    int jobId = 49;
-    context.setActiveJobId(jobId);
-    when(olContext.getActiveJobId()).thenReturn(Optional.of(jobId));
-    JobMetricsHolder.getInstance().addJobStages(jobId, Collections.singleton(490));
-
-    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
-      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      context.end(mock(SparkListenerSQLExecutionEnd.class));
-    }
-
-    verify(eventEmitter).emit(any());
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testFailedJobMetricsAreRetainedUntilPendingSqlEnd(SparkSession spark) {
-    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
-    when(jobEnd.jobId()).thenReturn(45);
-    when(jobEnd.jobResult()).thenReturn(mock(JobFailed.class));
-    addMetricBearingJob(45, 450);
-
-    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
-      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      context.start(mock(SparkListenerSQLExecutionStart.class));
-      context.end(jobEnd);
-
-      assertThat(JobMetricsHolder.getInstance().getJobStagesSize()).isZero();
-      assertThat(JobMetricsHolder.getInstance().getStageMetricsSize()).isZero();
-      assertThat(JobMetricsHolder.getInstance().getJobMetricsSize()).isOne();
-
-      context.end(mock(SparkListenerSQLExecutionEnd.class));
-    }
-
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testFilteredSqlEndBeforeJobEndDoesNotRetainMetrics(SparkSession spark) {
-    SparkListenerSQLExecutionEnd sqlEnd = mock(SparkListenerSQLExecutionEnd.class);
-    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
-    when(jobEnd.jobId()).thenReturn(46);
-    JobMetricsHolder.getInstance().addJobStages(46, Collections.singleton(460));
-
-    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
-      when(EventFilterUtils.isDisabled(olContext, sqlEnd)).thenReturn(true);
-      when(EventFilterUtils.isDisabled(olContext, jobEnd)).thenReturn(false);
-      context.start(mock(SparkListenerSQLExecutionStart.class));
-      context.end(sqlEnd);
-      context.end(jobEnd);
-    }
-
-    assertMetricsStateIsEmpty();
-  }
-
-  @Test
-  void testMultipleJobsRetainOnlyLatestMetricsUntilSqlEnd(SparkSession spark) {
-    SparkListenerJobEnd firstJobEnd = mock(SparkListenerJobEnd.class);
-    SparkListenerJobEnd secondJobEnd = mock(SparkListenerJobEnd.class);
-    when(firstJobEnd.jobId()).thenReturn(47);
-    when(secondJobEnd.jobId()).thenReturn(48);
-    JobMetricsHolder holder = JobMetricsHolder.getInstance();
-    addMetricBearingJob(47, 470);
-    addMetricBearingJob(48, 480);
-
-    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
-      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      context.start(mock(SparkListenerSQLExecutionStart.class));
-      context.end(firstJobEnd);
-      context.end(secondJobEnd);
-
-      assertThat(holder.getJobStagesSize()).isZero();
-      assertThat(holder.getStageMetricsSize()).isZero();
-      assertThat(holder.getJobMetricsSize()).isOne();
-
-      context.end(mock(SparkListenerSQLExecutionEnd.class));
-    }
-
-    verify(eventEmitter, times(3)).emit(any());
-    assertMetricsStateIsEmpty();
   }
 
   @Test
@@ -465,19 +324,5 @@ class SparkSQLExecutionContextTest {
       assertThat(rootJob.getNamespace()).isEqualTo("root_job_namespace");
       assertThat(rootRun.getRunId()).isEqualTo(rootUuid);
     }
-  }
-
-  private void assertMetricsStateIsEmpty() {
-    JobMetricsHolder holder = JobMetricsHolder.getInstance();
-    assertThat(holder.getJobStagesSize()).isZero();
-    assertThat(holder.getStageMetricsSize()).isZero();
-    assertThat(holder.getJobMetricsSize()).isZero();
-  }
-
-  private void addMetricBearingJob(int jobId, int stageId) {
-    TaskMetrics taskMetrics = new TaskMetrics();
-    taskMetrics.inputMetrics()._bytesRead().add(1);
-    JobMetricsHolder.getInstance().addJobStages(jobId, Collections.singleton(stageId));
-    JobMetricsHolder.getInstance().addMetrics(stageId, taskMetrics);
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -32,6 +33,12 @@ import org.apache.spark.scheduler.SparkListenerTaskEnd;
  */
 @Slf4j
 public class JobMetricsHolder {
+  public static final String JOB_STAGES_GAUGE = "openlineage.spark.state.job_metrics.job_stages";
+  public static final String STAGE_METRICS_GAUGE =
+      "openlineage.spark.state.job_metrics.stage_metrics";
+  public static final String JOB_METRICS_GAUGE =
+      "openlineage.spark.state.job_metrics.completed_jobs";
+
   private final Map<Integer, Set<Integer>> jobStages = new ConcurrentHashMap<>();
   private final Map<Integer, TaskMetricsAggregate> stageMetrics = new ConcurrentHashMap<>();
 
@@ -65,16 +72,25 @@ public class JobMetricsHolder {
   }
 
   /**
-   * Can be only polled once. Polling metrics causes removing them from the map.
-   *
-   * @param jobId
-   * @return
+   * Aggregates a job's stage metrics and keeps the result available until {@link #cleanUp(int)}.
    */
   public Map<Metric, Number> pollMetrics(int jobId) {
-    if (!jobMetrics.containsKey(jobId)) {
-      jobMetrics.put(jobId, computeJobMetricsAndClearTemporaryResults(jobId));
-    }
-    return jobMetrics.get(jobId);
+    return completeJob(jobId);
+  }
+
+  /**
+   * Marks a job complete by releasing its stage state and retaining only its compact aggregate.
+   * This supports the Spark ordering where JobEnd is followed by the final SQLExecutionEnd event.
+   */
+  public Map<Metric, Number> completeJob(int jobId) {
+    Map<Metric, Number> completedMetrics =
+        jobMetrics.computeIfAbsent(
+            jobId,
+            id -> {
+              Map<Metric, Number> metrics = computeJobMetricsAndClearTemporaryResults(id);
+              return metrics.isEmpty() ? null : metrics;
+            });
+    return completedMetrics == null ? Collections.emptyMap() : completedMetrics;
   }
 
   public boolean containsWriteMetrics(int jobId) {
@@ -94,7 +110,7 @@ public class JobMetricsHolder {
   }
 
   private Map<Metric, Number> computeJobMetricsAndClearTemporaryResults(int jobId) {
-    return Optional.ofNullable(jobStages.get(jobId))
+    return Optional.ofNullable(jobStages.remove(jobId))
         .map(
             stages ->
                 stages.stream()
@@ -107,17 +123,35 @@ public class JobMetricsHolder {
   }
 
   public void cleanUp(int jobId) {
-    jobMetrics.put(jobId, computeJobMetricsAndClearTemporaryResults(jobId));
+    jobMetrics.remove(jobId);
     Set<Integer> stages = jobStages.remove(jobId);
     stages = stages == null ? Collections.emptySet() : stages;
     stages.forEach(stageMetrics::remove);
   }
 
-  @VisibleForTesting
-  void cleanUpAll() {
+  public void cleanUpAll() {
     jobMetrics.clear();
     jobStages.clear();
     stageMetrics.clear();
+  }
+
+  /** Registers low-cardinality gauges for every retained metrics map. */
+  public void registerStateGauges(MeterRegistry meterRegistry) {
+    meterRegistry.gauge(JOB_STAGES_GAUGE, jobStages, Map::size);
+    meterRegistry.gauge(STAGE_METRICS_GAUGE, stageMetrics, Map::size);
+    meterRegistry.gauge(JOB_METRICS_GAUGE, jobMetrics, Map::size);
+  }
+
+  public int getJobStagesSize() {
+    return jobStages.size();
+  }
+
+  public int getStageMetricsSize() {
+    return stageMetrics.size();
+  }
+
+  public int getJobMetricsSize() {
+    return jobMetrics.size();
   }
 
   private Map<Metric, Number> mapMetrics(List<TaskMetricsAggregate> jobMetrics) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -49,4 +49,23 @@ public interface ExecutionContext {
   }
 
   default void setActiveJobId(Integer activeJobId) {}
+
+  /** Release scheduler objects retained for a completed Spark job. */
+  default void evictJob(int jobId) {}
+
+  /** Whether this context still needs a completed job's compact metrics for a later event. */
+  default boolean retainsJobMetrics(int jobId) {
+    return false;
+  }
+
+  /** Release any remaining scheduler objects retained by this context. */
+  default void clearRetainedState() {}
+
+  default int getRetainedJobCount() {
+    return 0;
+  }
+
+  default int getRetainedStageCount() {
+    return 0;
+  }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -53,11 +53,6 @@ public interface ExecutionContext {
   /** Release scheduler objects retained for a completed Spark job. */
   default void evictJob(int jobId) {}
 
-  /** Whether this context still needs a completed job's compact metrics for a later event. */
-  default boolean retainsJobMetrics(int jobId) {
-    return false;
-  }
-
   /** Release any remaining scheduler objects retained by this context. */
   default void clearRetainedState() {}
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -181,6 +181,33 @@ class OpenLineageRunEventBuilder {
    */
   void registerJob(ActiveJob job) {
     jobMap.put(job.jobId(), job);
+    registerStages(job);
+  }
+
+  void evictJob(int jobId) {
+    jobMap.remove(jobId);
+    rebuildStageMap();
+  }
+
+  void clearRetainedState() {
+    jobMap.clear();
+    stageMap.clear();
+  }
+
+  int getRetainedJobCount() {
+    return jobMap.size();
+  }
+
+  int getRetainedStageCount() {
+    return stageMap.size();
+  }
+
+  private void rebuildStageMap() {
+    stageMap.clear();
+    jobMap.values().forEach(this::registerStages);
+  }
+
+  private void registerStages(ActiveJob job) {
     stageMap.put(job.finalStage().id(), job.finalStage());
     job.finalStage()
         .parents()

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.spark.agent.JobMetricsHolder.Metric;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,10 +43,11 @@ class JobMetricsHolderTest {
         .containsEntry(Metric.READ_RECORDS, 2L)
         .containsEntry(JobMetricsHolder.Metric.READ_BYTES, 110L);
 
-    // second poll event should clear the maps
+    // Polling after cleanup must not recreate an empty completed-job entry.
     underTest.cleanUp(0);
     Map<JobMetricsHolder.Metric, Number> secondPollResult = underTest.pollMetrics(0);
     assertThat(secondPollResult).isEmpty();
+    assertThat(underTest.getJobMetricsSize()).isZero();
   }
 
   @Test
@@ -80,9 +82,9 @@ class JobMetricsHolderTest {
 
     underTest.cleanUp(0);
 
-    assertThat(true).isTrue();
     assertThat(underTest.getJobStages()).isEmpty();
     assertThat(underTest.getStageMetrics()).isEmpty();
+    assertThat(underTest.getJobMetricsSize()).isZero();
   }
 
   /**
@@ -120,7 +122,7 @@ class JobMetricsHolderTest {
   }
 
   @Test
-  void testMetricsCanBePolledAfterCleanup() {
+  void testCleanupDiscardsCompletedMetrics() {
     // add some stage and metric
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
     underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
@@ -128,7 +130,7 @@ class JobMetricsHolderTest {
     underTest.cleanUp(0);
     Map<JobMetricsHolder.Metric, Number> jobMetrics = underTest.pollMetrics(0);
 
-    assertThat(jobMetrics.get(Metric.WRITE_RECORDS)).isEqualTo(10L);
+    assertThat(jobMetrics).isEmpty();
   }
 
   @Test
@@ -184,6 +186,61 @@ class JobMetricsHolderTest {
     underTest.addMetrics(1, taskMetrics(0, 0, 1, 0));
     assertThat(underTest.containsReadMetrics(0)).isFalse();
     assertThat(underTest.containsWriteMetrics(0)).isTrue();
+  }
+
+  @Test
+  void testCompleteJobKeepsOnlyCompactMetricsUntilCleanup() {
+    underTest.addJobStages(0, Collections.singleton(1));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
+
+    assertThat(underTest.completeJob(0).get(Metric.WRITE_RECORDS)).isEqualTo(10L);
+    assertThat(underTest.getJobStagesSize()).isZero();
+    assertThat(underTest.getStageMetricsSize()).isZero();
+    assertThat(underTest.getJobMetricsSize()).isOne();
+
+    underTest.cleanUp(0);
+
+    assertThat(underTest.getJobMetricsSize()).isZero();
+  }
+
+  @Test
+  void testStateGaugesMeasureRetainedEntries() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    underTest.registerStateGauges(meterRegistry);
+    underTest.addJobStages(0, Collections.singleton(1));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
+
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_STAGES_GAUGE).gauge().value()).isEqualTo(1);
+    assertThat(meterRegistry.get(JobMetricsHolder.STAGE_METRICS_GAUGE).gauge().value())
+        .isEqualTo(1);
+
+    underTest.completeJob(0);
+
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_STAGES_GAUGE).gauge().value()).isZero();
+    assertThat(meterRegistry.get(JobMetricsHolder.STAGE_METRICS_GAUGE).gauge().value()).isZero();
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_METRICS_GAUGE).gauge().value()).isEqualTo(1);
+
+    underTest.cleanUp(0);
+    assertThat(meterRegistry.get(JobMetricsHolder.JOB_METRICS_GAUGE).gauge().value()).isZero();
+  }
+
+  @Test
+  void testTenThousandCompletedJobsKeepStateBounded() {
+    int maximumCompletedJobs = 0;
+
+    for (int jobId = 0; jobId < 10_000; jobId++) {
+      // Empty jobs still exposed the original leak because their completed-metrics entries were
+      // cached forever. The metric-bearing paths are covered by the focused tests above.
+      underTest.completeJob(jobId);
+      maximumCompletedJobs = Math.max(maximumCompletedJobs, underTest.getJobMetricsSize());
+      underTest.cleanUp(jobId);
+
+      assertThat(underTest.getJobStagesSize()).isZero();
+      assertThat(underTest.getStageMetricsSize()).isZero();
+      assertThat(underTest.getJobMetricsSize()).isZero();
+    }
+
+    assertThat(maximumCompletedJobs).isZero();
   }
 
   private TaskMetrics taskMetrics(

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilderTest.java
@@ -31,11 +31,14 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.Stage;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.PartialFunction;
+import scala.collection.JavaConverters;
 
 class OpenLineageRunEventBuilderTest {
 
@@ -141,5 +144,33 @@ class OpenLineageRunEventBuilderTest {
 
     // test that the debug facet contains the timeout message
     assertThat(facet.getLogs().get(0)).startsWith("Incomplete lineage:");
+  }
+
+  @Test
+  void testEvictJobRemovesActiveJobAndStages() {
+    OpenLineageRunEventBuilder builder =
+        new OpenLineageRunEventBuilder(openLineageContext, openLineageEventHandlerFactory);
+    ActiveJob activeJob = mock(ActiveJob.class);
+    Stage finalStage = mock(Stage.class);
+    Stage parentStage = mock(Stage.class);
+    when(activeJob.jobId()).thenReturn(7);
+    when(activeJob.finalStage()).thenReturn(finalStage);
+    when(finalStage.id()).thenReturn(70);
+    when(parentStage.id()).thenReturn(71);
+    when(finalStage.parents())
+        .thenReturn(
+            JavaConverters.asScalaBufferConverter(Collections.singletonList(parentStage))
+                .asScala()
+                .toList());
+
+    builder.registerJob(activeJob);
+
+    assertThat(builder.getRetainedJobCount()).isOne();
+    assertThat(builder.getRetainedStageCount()).isEqualTo(2);
+
+    builder.evictJob(7);
+
+    assertThat(builder.getRetainedJobCount()).isZero();
+    assertThat(builder.getRetainedStageCount()).isZero();
   }
 }


### PR DESCRIPTION
### One-line summary for changelog:

Fix unbounded Spark listener state retention by cleaning completed job metrics and evicting completed jobs and stages without changing emitted lineage events.

### Meaningful description

#### Problem

The Spark integration retains state after jobs finish:

- On the normal terminal-cleanup path, `JobMetricsHolder.cleanUp` replaces the completed job with another `jobMetrics` entry—even when the aggregate is empty—so the JVM-wide singleton grows with normally completed job count.
- Failure, filtered, missing-query, missing-context, and outputless paths can bypass cleanup of `jobStages` and `stageMetrics`.
- `OpenLineageRunEventBuilder` retains `ActiveJob` and `Stage` objects until the whole execution context becomes collectible. These objects can keep scheduler state and RDD graphs reachable.
- Application shutdown clears listener registries but not all state retained by their contexts or the singleton metrics holder.

This matters most for long-lived streaming jobs, notebooks, Thrift servers, and shared-cluster drivers, where completed job count is effectively unbounded.

#### What changed

- Make job-metrics cleanup unconditional for successful, failed, filtered, missing-query, missing-context, and outputless terminal paths.
- Retain a compact completed-job aggregate only while a later SQL execution event still needs it, then remove it.
- Do not cache empty completed-job aggregates.
- Evict completed `ActiveJob` and `Stage` entries after `JobEnd`, rebuilding the stage index from the jobs that remain active so shared stages stay available.
- Clear execution-context and singleton metrics state during application shutdown, including when OpenLineage is disabled.
- Add low-cardinality gauges for SQL/RDD registries, builder job/stage maps, and all three `JobMetricsHolder` maps.
- Add deterministic lifecycle tests and a 10,000-job bounded-state soak test.

#### Baseline comparison

Compared rebased commit `2317436a3` with its exact parent, upstream `main` at `f20097d7d`, using identical disposable test sources (same SHA-1) on the same host and Java 11 JVM.

Workloads:

- Small timing: 20,000 jobs, one stage and one `TaskMetrics` update per job.
- Medium timing: 10,000 jobs, 10 stages and one `TaskMetrics` update per stage (100,000 stage/task aggregates).
- Retained heap: 100,000 completed one-stage jobs; median of five forced-GC samples.
- Builder retention: 10,000 jobs with 10 stage IDs each.
- Timing values are medians of nine measured runs after three warm-up runs.

| Measurement | `main` baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Completed `jobMetrics` entries after 100,000 jobs | 100,000 | 0 | -100% |
| Median retained heap after 100,000 jobs | 6.576 MiB | 0.000 MiB | -6.576 MiB |
| Builder jobs retained after 10,000 job ends | 10,000 | 0 | -100% |
| Builder stages retained after 100,000 stage completions | 100,000 | 0 | -100% |
| Small metrics-loop median | 10.112 ms | 5.296 ms | -47.6% |
| Medium metrics-loop median | 13.042 ms | 11.396 ms | -12.6% |

The heap result isolates the completed-entry leak in `JobMetricsHolder`; it does not include the potentially much larger real `ActiveJob`, stage, or RDD graphs. The builder workload reuses mocks, so its result proves retained-key cardinality rather than estimating real graph size. Timing is a directional microbenchmark, not an end-to-end Spark throughput claim. The deterministic 10,000-job soak is part of this PR; the larger comparison harness was kept disposable to avoid adding a GC-sensitive performance test to CI.

#### Validation and confidence

- `./gradlew :shared:check :app:check` passes after rebasing onto newest `main`, including PMD, Spotless, shared Scala variants, and the Spark app unit-test matrix.
- A new integration test runs the actual Spark listener via `spark.extraListeners` for both repeated `count()` actions and an output-producing Parquet write. The byte-identical test source (SHA-1 `cf5dacb01ec1b24f7dbac25ab27e99b9992c361d`) was run against `main` and this PR:

| Real Spark integration case | Completed jobs | `main` retained state | This PR retained state |
| --- | ---: | --- | --- |
| Ten `range(...).count()` actions | 20 | `jobStages=20`, `stageMetrics=20`, `jobMetrics=0` | all zero |
| One Parquet output write | 1 | `jobStages=0`, `stageMetrics=0`, `jobMetrics=1` | all zero |

  Baseline command: `./gradlew :app:integrationTest --tests io.openlineage.spark.agent.JobMetricsCleanupIntegrationTest` (expected two failures). The same command passes on this PR.
- Commit-time pre-commit hooks passed, including Spark PMD and Spotless.
- Added coverage for success, failure, filtered events, missing query execution, missing listener context, outputless RDD jobs, both SQL/job terminal orderings, multiple jobs per SQL execution, and application shutdown.
- The 10,000-job committed soak asserts all three metrics maps return to zero after every terminal cleanup; empty jobs have a completed-map high-water mark of zero.
- Gauge tests verify retained state rises while live and returns to zero on close.

### Checklist

- [x] AI was used in creating this PR
