### PR TITLE
website: derive integrations redirects from existing routes

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -151,13 +151,18 @@ const config = {
     [
       "@docusaurus/plugin-client-redirects",
       {
-        redirects: [
-          { from: "/docs/integrations/about", to: "/docs/integrations" },
-          {
-            from: "/docs/integrations/flink/about",
-            to: "/docs/integrations/flink",
-          },
-        ],
+        // Link the integrations and Flink category URLs with their about.md, in whichever direction
+        // exists: docs with the `slug` front matter redirect .../about to the category URL, older
+        // versioned snapshots without it redirect the category URL to .../about.
+        /** @param {string} existingPath */
+        createRedirects(existingPath) {
+          const category = existingPath.match(/^(.*\/integrations(?:\/flink)?)\/?$/);
+          if (category) {
+            return [`${category[1]}/about`];
+          }
+          const about = existingPath.match(/^(.*\/integrations(?:\/flink)?)\/about\/?$/);
+          return about ? [about[1]] : undefined;
+        },
       },
     ],
     [


### PR DESCRIPTION
### One-line summary for changelog:

Fix the openlineage-site build failing on the integrations landing-page redirects added in #4872.

### Meaningful description

**Problem**

#4872 added `@docusaurus/plugin-client-redirects` with hardcoded targets:

```js
redirects: [
  { from: "/docs/integrations/about", to: "/docs/integrations" },
  { from: "/docs/integrations/flink/about", to: "/docs/integrations/flink" },
]
```

Those routes only exist in this repo, where the docs are unversioned and served at `/docs`.
`website-snapshot.yml` copies `website/` into `OpenLineage/openlineage-site`, which holds 36 versioned
snapshots. There `/docs` serves the latest version — whose `integrations/about.md` was snapshotted before
the `slug` front matter was added — and the current docs move to `/docs/next`. The redirect targets
therefore do not exist and the deploy build fails:

```
[ERROR] Error: Unable to build website for locale en.
  [cause]: Error: You are trying to create client-side redirections to invalid paths.
  These paths are redirected to but do not exist:
  - /docs/integrations
  - /docs/integrations/flink
```

The site has not been redeployed since. CI here stayed green because this repo has no versioned docs.

Failing run: https://github.com/OpenLineage/openlineage-site/actions/runs/32718012629/job/97403285412

**Solution**

Replace the hardcoded list with `createRedirects`, which Docusaurus calls once per route that actually
exists, so the redirects adapt to either docs layout:

- a route ending in `/integrations` or `/integrations/flink` (slug present) gets `.../about` redirected to it;
- a route ending in `/integrations/about` (older snapshots, no slug) gets the category URL redirected to it.

Every version keeps a working integrations landing page, and no redirect ever points at a missing path.
No change is needed in `openlineage-site`: its `docusaurus.config.js` is overwritten from `website/` on
each snapshot push.

related: #4872

### Checklist

- [x] AI was used in creating this PR