### PR TITLE
spark: report datasets for writes through Iceberg's cached catalog

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DefaultRelationHandlers.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DefaultRelationHandlers.java
@@ -1,0 +1,21 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import com.google.common.collect.ImmutableList;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.IcebergRelationHandler;
+import java.util.List;
+
+/** Relation handlers available to every Spark 3.x / 4.x version. */
+final class DefaultRelationHandlers {
+  private DefaultRelationHandlers() {}
+
+  static List<RelationHandler> list(OpenLineageContext context) {
+    return ImmutableList.of(new IcebergRelationHandler(context));
+  }
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -14,6 +14,7 @@ import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.ViewInputDatasetBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
 import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
@@ -162,5 +163,10 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
   @Override
   public List<CatalogHandler> getCatalogHandlers(OpenLineageContext context) {
     return DefaultCatalogHandlers.list(context);
+  }
+
+  @Override
+  public List<RelationHandler> getRelationHandlers(OpenLineageContext context) {
+    return DefaultRelationHandlers.list(context);
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -12,6 +12,7 @@ import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
 import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
@@ -133,5 +134,10 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
   @Override
   public List<CatalogHandler> getCatalogHandlers(OpenLineageContext context) {
     return DefaultCatalogHandlers.list(context);
+  }
+
+  @Override
+  public List<RelationHandler> getRelationHandlers(OpenLineageContext context) {
+    return DefaultRelationHandlers.list(context);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -684,6 +684,73 @@ class SparkIcebergIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
+  void testRewriteDataFilesReportsCompactedTable() {
+    // the job name of a plain write to the table, going through its own catalog - as opposed to the
+    // compaction's append, which goes through SparkCachedTableCatalog and so is named after it
+    String plainWriteJobName =
+        "iceberg_integration_test.append_data.spark_catalog_default_compaction_target";
+    // the catalog Iceberg registers for its table cache, which the compaction writes through
+    String cacheCatalogName = "default_cache_iceberg";
+
+    clearTables("compaction_target", "compaction_marker");
+
+    spark.sql("CREATE TABLE compaction_target (a long, b long) USING iceberg");
+    // separate inserts so each one commits its own data file and there is something to compact
+    spark.sql("INSERT INTO compaction_target VALUES (1, 2)");
+    spark.sql("INSERT INTO compaction_target VALUES (3, 4)");
+    spark.sql("INSERT INTO compaction_target VALUES (5, 6)");
+
+    getEventsEmittedWithJobName(mockServer, plainWriteJobName);
+    MockServerUtils.clearRequests(mockServer);
+
+    Row rewriteResult =
+        spark
+            .sql(
+                "CALL spark_catalog.system.rewrite_data_files("
+                    + "table => 'default.compaction_target', "
+                    + "options => map('min-input-files','2'))")
+            .head();
+
+    // guard the premise of this test: the compaction really did rewrite the files
+    assertThat(rewriteResult.getInt(0)).as("rewritten data files").isGreaterThanOrEqualTo(2);
+    assertThat(rewriteResult.getInt(1)).as("added data files").isGreaterThanOrEqualTo(1);
+
+    // a plain write after the compaction, so waiting for its event means the compaction has
+    // finished reporting too - the assertions below then see whatever it did emit, empty or not
+    spark.sql("CREATE TABLE compaction_marker USING iceberg AS SELECT * FROM compaction_target");
+    getEventsEmittedWithJobName(mockServer, "compaction_marker");
+    List<RunEvent> events = getEventsEmitted(mockServer);
+
+    // The append that writes the compacted files is the one going through
+    // SparkCachedTableCatalog, so it is named after that catalog rather than the table's own.
+    // Selecting on the cache catalog's name is what makes this test specific: every other write
+    // here - the inserts, whose events routinely land asynchronously after clearRequests, and the
+    // marker table's own append - also emits append_data, and any of those would otherwise
+    // satisfy the assertions below on their own.
+    List<RunEvent> compactionEvents =
+        events.stream()
+            .filter(e -> e.getJob().getName().contains("append_data"))
+            .filter(e -> e.getJob().getName().contains(cacheCatalogName))
+            .filter(e -> e.getEventType() == RunEvent.EventType.COMPLETE)
+            .collect(Collectors.toList());
+
+    assertThat(compactionEvents)
+        .as("compaction must report the table it rewrote")
+        .isNotEmpty()
+        .allSatisfy(e -> assertThat(e.getOutputs()).isNotEmpty());
+
+    // and the reported dataset must be the real table, not the cache catalog's UUID key
+    assertThat(
+            compactionEvents.stream()
+                .flatMap(e -> e.getOutputs().stream())
+                .map(OutputDataset::getName)
+                .collect(Collectors.toList()))
+        .isNotEmpty()
+        .allSatisfy(name -> assertThat(name).endsWith("/default/compaction_target"));
+  }
+
+  @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testScanReportFacet() {
     if (JAVA_VERSION.startsWith("1.8") && System.getProperty(SPARK_VERSION).startsWith("3.5")) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactory.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent.lifecycle;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -62,6 +63,15 @@ public interface DatasetBuilderFactory {
    * resolution flow without lower modules depending on them.
    */
   default List<CatalogHandler> getCatalogHandlers(OpenLineageContext context) {
+    return Collections.emptyList();
+  }
+
+  /**
+   * Relation handlers contributed by this Spark version. They resolve a dataset straight from a
+   * {@code DataSourceV2Relation}, which is the only way to identify datasets written through
+   * catalogs no {@link CatalogHandler} supports.
+   */
+  default List<RelationHandler> getRelationHandlers(OpenLineageContext context) {
     return Collections.emptyList();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/catalog/CatalogUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/catalog/CatalogUtils.java
@@ -13,14 +13,29 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 public class CatalogUtils {
 
-  private static List<RelationHandler> relationHandlers = getRelationHandlers();
+  /**
+   * {@code hasClasses()} probes the classloader, and a miss costs a thrown {@link
+   * ClassNotFoundException} with its stack trace. The answer cannot change within a JVM, so it is
+   * memoized per handler class - the handler instances themselves are rebuilt per call, since they
+   * capture the context.
+   */
+  private static final Map<Class<?>, Boolean> HAS_CLASSES = new ConcurrentHashMap<>();
+
+  /** Declared after {@code HAS_CLASSES}, which its initializer filters through. */
+  private static final List<RelationHandler> SHARED_RELATION_HANDLERS = getSharedRelationHandlers();
+
+  private static boolean hasClasses(RelationHandler handler) {
+    return HAS_CLASSES.computeIfAbsent(handler.getClass(), k -> handler.hasClasses());
+  }
 
   private static List<CatalogHandler> getHandlers(OpenLineageContext context) {
     return context.getDatasetBuilderFactory().getCatalogHandlers(context).stream()
@@ -28,9 +43,17 @@ public class CatalogUtils {
         .collect(Collectors.toList());
   }
 
-  private static List<RelationHandler> getRelationHandlers() {
+  private static List<RelationHandler> getSharedRelationHandlers() {
     List<RelationHandler> handlers = Arrays.asList(new CosmosHandler());
-    return handlers.stream().filter(RelationHandler::hasClasses).collect(Collectors.toList());
+    return handlers.stream().filter(CatalogUtils::hasClasses).collect(Collectors.toList());
+  }
+
+  private static List<RelationHandler> getRelationHandlers(OpenLineageContext context) {
+    return Stream.concat(
+            SHARED_RELATION_HANDLERS.stream(),
+            context.getDatasetBuilderFactory().getRelationHandlers(context).stream()
+                .filter(CatalogUtils::hasClasses))
+        .collect(Collectors.toList());
   }
 
   public static DatasetIdentifier getDatasetIdentifier(
@@ -69,8 +92,31 @@ public class CatalogUtils {
     return getHandlers(context).stream().filter(handler -> handler.isClass(catalog)).findAny();
   }
 
+  /**
+   * @deprecated Resolves the relation against the version-independent handlers only. Use {@link
+   *     #getDatasetIdentifierFromRelation(OpenLineageContext, DataSourceV2Relation)}, which also
+   *     consults the handlers contributed by the running Spark version.
+   */
+  @Deprecated
   public static DatasetIdentifier getDatasetIdentifierFromRelation(DataSourceV2Relation relation) {
-    return getDatasetIdentifierFromRelation(relation, relationHandlers);
+    return getDatasetIdentifierFromRelation(relation, SHARED_RELATION_HANDLERS);
+  }
+
+  public static DatasetIdentifier getDatasetIdentifierFromRelation(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+    return getDatasetIdentifierFromRelation(relation, getRelationHandlers(context));
+  }
+
+  /**
+   * The catalog that owns the relation's table, according to the first {@link RelationHandler} that
+   * recognises the relation. Empty when no handler matches or none can recover a catalog.
+   */
+  public static Optional<RelationHandler.OwningCatalog> getOwningCatalogFromRelation(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+    return getRelationHandlers(context).stream()
+        .filter(handler -> handler.isClass(relation))
+        .findAny()
+        .flatMap(handler -> handler.getOwningCatalog(relation));
   }
 
   public static DatasetIdentifier getDatasetIdentifierFromRelation(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/catalog/RelationHandler.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/catalog/RelationHandler.java
@@ -6,14 +6,48 @@
 package io.openlineage.spark.agent.lifecycle.plan.catalog;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import java.util.Optional;
+import lombok.Getter;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 public interface RelationHandler {
+
+  /**
+   * The catalog that owns the table a relation points at, together with the table's identifier
+   * within it. Both may differ from {@code relation.catalog()} / {@code relation.identifier()} when
+   * the relation was loaded through an intermediate catalog.
+   */
+  @Getter
+  class OwningCatalog {
+    private final TableCatalog catalog;
+    private final Identifier identifier;
+
+    private OwningCatalog(TableCatalog catalog, Identifier identifier) {
+      this.catalog = catalog;
+      this.identifier = identifier;
+    }
+
+    public static OwningCatalog of(TableCatalog catalog, Identifier identifier) {
+      return new OwningCatalog(catalog, identifier);
+    }
+  }
+
   boolean hasClasses();
 
   boolean isClass(DataSourceV2Relation relation);
 
   DatasetIdentifier getDatasetIdentifier(DataSourceV2Relation relation);
+
+  /**
+   * The catalog that owns the relation's table, when the handler can recover one. Used to resolve
+   * facets - storage, catalog, dataset version - which otherwise would be looked up against a
+   * catalog no {@link CatalogHandler} supports and silently come back empty.
+   */
+  default Optional<OwningCatalog> getOwningCatalog(DataSourceV2Relation relation) {
+    return Optional.empty();
+  }
 
   String getName();
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergRelationHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergRelationHandler.java
@@ -1,0 +1,157 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.SparkSessionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+/**
+ * Resolves Iceberg datasets straight from the relation, without going through the catalog that the
+ * relation was loaded from.
+ *
+ * <p>This is required because Iceberg's rewrite actions ({@code rewrite_data_files}, {@code
+ * rewrite_position_delete_files}, …) do not write through the table's own catalog. They stage the
+ * table in {@code SparkTableCache} under a random UUID and then read and write through {@code
+ * org.apache.iceberg.spark.SparkCachedTableCatalog}, which Iceberg silently registers as {@code
+ * spark.sql.catalog.default_cache_iceberg}. That catalog implements {@link TableCatalog} directly -
+ * it is neither a {@code SparkCatalog} nor a {@code SparkSessionCatalog} - so {@link
+ * IcebergHandler#isClass(TableCatalog)} rejects it and the whole catalog-based resolution fails,
+ * leaving the emitted event with no datasets at all.
+ *
+ * <p>The relation itself still carries everything needed: {@code relation.table()} is a {@link
+ * SparkTable} wrapping the real Iceberg {@link Table}, whose {@code name()} is the fully qualified
+ * name assigned by the catalog that originally loaded it (for example {@code
+ * prod_catalog.namespace.table}). That is used to find the owning catalog and delegate to {@link
+ * IcebergHandler}, so a compaction job reports exactly the same dataset identifier - symlinks
+ * included - as a regular write to the same table.
+ */
+@Slf4j
+public class IcebergRelationHandler implements RelationHandler {
+  private static final String SPARK_TABLE_CLASS_NAME = "org.apache.iceberg.spark.source.SparkTable";
+
+  /** A table name that can be split into a catalog and a table has at least those two parts. */
+  private static final int MIN_NAME_PARTS = 2;
+
+  private final OpenLineageContext context;
+
+  public IcebergRelationHandler(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean hasClasses() {
+    try {
+      IcebergRelationHandler.class.getClassLoader().loadClass(SPARK_TABLE_CLASS_NAME);
+      return true;
+    } catch (NoClassDefFoundError | Exception e) {
+      log.debug("The iceberg spark runtime is not present");
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isClass(DataSourceV2Relation relation) {
+    return relation.table() instanceof SparkTable;
+  }
+
+  @Override
+  public DatasetIdentifier getDatasetIdentifier(DataSourceV2Relation relation) {
+    Table icebergTable = ((SparkTable) relation.table()).table();
+    return getOwningCatalog(relation)
+        .flatMap(owner -> resolveThroughOwningCatalog(relation, icebergTable, owner))
+        .orElseGet(() -> fromTableLocation(icebergTable));
+  }
+
+  /**
+   * Recovers the catalog that originally loaded the table from the table's fully qualified name.
+   * Returns empty when the name cannot be split into catalog and table parts (tables loaded by path
+   * are named by their location), when there is no Spark session to look the catalog up in, or when
+   * the registered catalog is not a {@link TableCatalog}.
+   */
+  @Override
+  public Optional<OwningCatalog> getOwningCatalog(DataSourceV2Relation relation) {
+    if (!(relation.table() instanceof SparkTable) || !context.getSparkSession().isPresent()) {
+      return Optional.empty();
+    }
+
+    String tableName = ((SparkTable) relation.table()).table().name();
+    if (tableName == null || tableName.contains("/")) {
+      return Optional.empty();
+    }
+
+    String[] parts = tableName.split("\\.");
+    if (parts.length < MIN_NAME_PARTS) {
+      return Optional.empty();
+    }
+
+    // Only the catalog segment is taken from the qualified name; the remaining segments are split
+    // into namespace and table exactly as Spark parses a multipart identifier. The relation's own
+    // identifier is deliberately not used - for the cached-catalog writes this handler exists for,
+    // it is the SparkTableCache UUID key rather than the table's real identifier.
+    Identifier identifier =
+        Identifier.of(Arrays.copyOfRange(parts, 1, parts.length - 1), parts[parts.length - 1]);
+
+    return SparkSessionUtils.catalog(context.getSparkSession().get(), parts[0])
+        .filter(TableCatalog.class::isInstance)
+        .map(catalog -> OwningCatalog.of((TableCatalog) catalog, identifier));
+  }
+
+  /**
+   * Last resort when the owning catalog cannot be recovered. A table with no usable location leaves
+   * nothing to identify it by, so this raises {@link UnsupportedCatalogException} - the one
+   * exception the caller of {@link RelationHandler} is contracted to handle - rather than letting
+   * {@code new Path(null)} throw {@link IllegalArgumentException} out of the handler.
+   */
+  private DatasetIdentifier fromTableLocation(Table icebergTable) {
+    String location = icebergTable.location();
+    if (location == null || location.trim().isEmpty()) {
+      throw new UnsupportedCatalogException(
+          String.format("Iceberg table %s has no location to identify it by", icebergTable.name()));
+    }
+    return PathUtils.fromPath(new Path(location));
+  }
+
+  /**
+   * Re-runs the regular {@link IcebergHandler} resolution against the catalog that owns the table.
+   * Returns empty when that catalog is not one the {@link IcebergHandler} supports, in which case
+   * the caller falls back to the table location.
+   */
+  private Optional<DatasetIdentifier> resolveThroughOwningCatalog(
+      DataSourceV2Relation relation, Table icebergTable, OwningCatalog owner) {
+    try {
+      return Optional.of(
+          CatalogUtils.getDatasetIdentifier(
+              context, owner.getCatalog(), owner.getIdentifier(), relation.table().properties()));
+    } catch (UnsupportedCatalogException e) {
+      log.debug("Catalog owning iceberg table {} is unsupported", icebergTable.name());
+      return Optional.empty();
+    } catch (Exception | LinkageError e) {
+      // hasClasses() only proves SparkTable loads; the resolution above reaches deeper into the
+      // Iceberg and Spark APIs, where a version mismatch surfaces as a linkage error.
+      log.debug("Could not resolve dataset of iceberg table {}", icebergTable.name(), e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "iceberg";
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
 import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -77,21 +78,26 @@ public class DataSourceV2RelationDatasetExtractor {
               if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
                 ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
               } else {
-                TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
-
-                if (includeVersionFacet && relation.identifier().isDefined()) {
+                if (includeVersionFacet) {
                   DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
                           context, relation)
                       .ifPresent(s -> datasetFactory.buildVersionFacets(datasetFacetsBuilder, s));
                 }
 
-                Map<String, String> tableProperties = relation.table().properties();
-                try {
-                  CatalogUtils.addStorageAndCatalogFacets(
-                      context, tableCatalog, tableProperties, datasetFacetsBuilder);
-                } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
-                  log.warn("Could not add catalog facets of table {}", identifier.getName(), e);
-                }
+                facetSource(context, relation)
+                    .ifPresent(
+                        catalog -> {
+                          Map<String, String> tableProperties = relation.table().properties();
+                          try {
+                            CatalogUtils.addStorageAndCatalogFacets(
+                                context, catalog, tableProperties, datasetFacetsBuilder);
+                          } catch (Exception | NoSuchMethodError | NoClassDefFoundError e) {
+                            log.warn(
+                                "Could not add catalog facets of table {}",
+                                identifier.getName(),
+                                e);
+                          }
+                        });
               }
               datasetFacetsBuilder
                   .getFacets()
@@ -157,7 +163,7 @@ public class DataSourceV2RelationDatasetExtractor {
     if (relation.identifier() == null || relation.identifier().isEmpty()) {
       // Since identifier is null, short circuit and check if we can get the dataset identifier
       // from the relation itself.
-      return getDatasetIdentifierFromRelation(relation);
+      return getDatasetIdentifierFromRelation(context, relation);
     }
     return Optional.of(relation)
         .filter(r -> r.identifier() != null)
@@ -208,7 +214,9 @@ public class DataSourceV2RelationDatasetExtractor {
     // Check if the catalog is present and is an instance of TableCatalog
     if (relation.catalog().isEmpty() || !(relation.catalog().get() instanceof TableCatalog)) {
       log.warn("Couldn't find catalog for dataset in plan {}", relation);
-      return Collections.emptyList();
+      return getDatasetIdentifierFromRelation(context, relation)
+          .map(Collections::singletonList)
+          .orElse(Collections.emptyList());
     }
 
     Identifier identifier = relation.identifier().get();
@@ -219,6 +227,20 @@ public class DataSourceV2RelationDatasetExtractor {
         resolveDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
     if (datasetIdentifier.isPresent()) {
       return Collections.singletonList(datasetIdentifier.get());
+    }
+
+    // The catalog may be one no CatalogHandler supports - Iceberg's rewrite actions, for example,
+    // read and write through SparkCachedTableCatalog. Fall back to resolving the dataset from the
+    // relation, which still carries the underlying table. Gated on the catalog being unsupported so
+    // that catalogs which do have a handler keep their existing fallback - the Unity Catalog one
+    // below - unchanged: that path names a table after the catalog it was handed, which is right
+    // for a real Unity Catalog and wrong for a cached catalog, whose name is the UUID cache key.
+    if (!CatalogUtils.getCatalogHandler(context, tableCatalog).isPresent()) {
+      Optional<DatasetIdentifier> relationIdentifier =
+          getDatasetIdentifierFromRelation(context, relation);
+      if (relationIdentifier.isPresent()) {
+        return Collections.singletonList(relationIdentifier.get());
+      }
     }
 
     return unityCatalogIdentifier(context, tableCatalog, identifier)
@@ -265,13 +287,47 @@ public class DataSourceV2RelationDatasetExtractor {
         new DatasetIdentifier(name, DatabricksUtils.UNITY_CATALOG_SYMLINK_NAMESPACE));
   }
 
-  private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
-      DataSourceV2Relation relation) {
+  /**
+   * The catalog to resolve storage and catalog facets against. Normally the relation's own, but
+   * when no {@link io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler} supports that
+   * catalog - Iceberg's rewrite actions write through {@code SparkCachedTableCatalog} - facets
+   * looked up against it come back empty. Fall back to the catalog that owns the table, the same
+   * one {@link #getDatasetIdentifierExtended} resolves the identifier through, so a compaction
+   * event carries the same facets as a regular write to the table.
+   */
+  private static Optional<TableCatalog> facetSource(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+    if (relation.catalog().isDefined() && relation.catalog().get() instanceof TableCatalog) {
+      TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
+      if (CatalogUtils.getCatalogHandler(context, tableCatalog).isPresent()) {
+        return Optional.of(tableCatalog);
+      }
+    }
+
     try {
-      return (Optional.of(CatalogUtils.getDatasetIdentifierFromRelation(relation)));
+      return CatalogUtils.getOwningCatalogFromRelation(context, relation)
+          .map(RelationHandler.OwningCatalog::getCatalog);
+    } catch (Exception | LinkageError e) {
+      log.warn("Could not resolve the catalog owning relation {}", relation.simpleString(5), e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+    try {
+      return (Optional.of(CatalogUtils.getDatasetIdentifierFromRelation(context, relation)));
     } catch (UnsupportedCatalogException ex) {
       log.warn(String.format("Catalog %s is unsupported", ex.getMessage()));
       // update this if change the exception thrown in catalogutils
+      return Optional.empty();
+    } catch (Exception | LinkageError e) {
+      // Relation handlers reach into the underlying table's own API - Iceberg's, for example - so a
+      // version mismatch surfaces here as a linkage error. Callers of this method treat an
+      // unresolvable relation as "no dataset", and one relation must not take the whole plan's
+      // lineage down with it: InputFieldsCollector calls getDatasetIdentifierExtended directly,
+      // outside any PlanUtils#safeApply.
+      log.warn("Could not resolve dataset from relation {}", relation.simpleString(5), e);
       return Optional.empty();
     }
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtils.java
@@ -9,10 +9,8 @@ import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptiona
 
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
@@ -30,20 +28,48 @@ public final class DatasetVersionDatasetFacetUtils {
    */
   public static Optional<String> extractVersionFromDataSourceV2Relation(
       OpenLineageContext context, DataSourceV2Relation table) {
-    if (table.identifier().isEmpty()) {
-      log.warn("Couldn't find identifier for dataset in plan {}", table);
+    if (table.identifier() != null
+        && table.identifier().isDefined()
+        && table.catalog() != null
+        && table.catalog().isDefined()
+        && table.catalog().get() instanceof TableCatalog) {
+      TableCatalog tableCatalog = (TableCatalog) table.catalog().get();
+      Optional<String> version =
+          CatalogUtils.getDatasetVersion(
+              context, tableCatalog, table.identifier().get(), table.table().properties());
+      if (version.isPresent()) {
+        return version;
+      }
+
+      // A supported catalog that reports no version has genuinely none to report - the table has no
+      // snapshot yet, which is the normal state on a START event. The owning catalog recovered from
+      // the table name is that same catalog, so falling back would only repeat the table load.
+      if (CatalogUtils.getCatalogHandler(context, tableCatalog).isPresent()) {
+        return Optional.empty();
+      }
+    }
+
+    // No CatalogHandler supports the relation's catalog - Iceberg's rewrite actions write through
+    // SparkCachedTableCatalog - so the version above came back empty. Fall back to the catalog that
+    // owns the table, the same one the dataset identifier is resolved through.
+    return owningCatalogVersion(context, table);
+  }
+
+  private static Optional<String> owningCatalogVersion(
+      OpenLineageContext context, DataSourceV2Relation table) {
+    try {
+      return CatalogUtils.getOwningCatalogFromRelation(context, table)
+          .flatMap(
+              owner ->
+                  CatalogUtils.getDatasetVersion(
+                      context,
+                      owner.getCatalog(),
+                      owner.getIdentifier(),
+                      table.table().properties()));
+    } catch (Exception | LinkageError e) {
+      log.warn("Couldn't extract dataset version of relation {}", table, e);
       return Optional.empty();
     }
-    Identifier identifier = table.identifier().get();
-
-    if (table.catalog().isEmpty() || !(table.catalog().get() instanceof TableCatalog)) {
-      log.warn("Couldn't find catalog for dataset in plan {}", table);
-      return Optional.empty();
-    }
-    TableCatalog tableCatalog = (TableCatalog) table.catalog().get();
-
-    Map<String, String> tableProperties = table.table().properties();
-    return CatalogUtils.getDatasetVersion(context, tableCatalog, identifier, tableProperties);
   }
 
   /**

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergRelationHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergRelationHandlerTest.java
@@ -1,0 +1,240 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import io.openlineage.spark.agent.lifecycle.DatasetBuilderFactory;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkCachedTableCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import scala.PartialFunction;
+
+class IcebergRelationHandlerTest {
+
+  private static final String TABLE_LOCATION = "file:/tmp/wh/db/tbl";
+  private static final String TABLE_PATH = "/tmp/wh/db/tbl";
+  private static final String QUALIFIED_NAME = "c.db.tbl";
+
+  private final OpenLineageContext context = mock(OpenLineageContext.class);
+  private final IcebergRelationHandler handler = new IcebergRelationHandler(context);
+
+  @Test
+  void testHasClasses() {
+    assertThat(handler.hasClasses()).isTrue();
+  }
+
+  @Test
+  void testIsClassForIcebergRelation() {
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class, RETURNS_DEEP_STUBS);
+    when(relation.table()).thenReturn(mock(SparkTable.class));
+
+    assertThat(handler.isClass(relation)).isTrue();
+  }
+
+  @Test
+  void testIsClassForNonIcebergRelation() {
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class, RETURNS_DEEP_STUBS);
+
+    assertThat(handler.isClass(relation)).isFalse();
+  }
+
+  /**
+   * With no Spark session there is no catalog manager to recover the owning catalog from, so the
+   * handler falls back to the table location - which is still the correct dataset.
+   */
+  @Test
+  void testGetDatasetIdentifierFallsBackToTableLocation() {
+    when(context.getSparkSession()).thenReturn(Optional.empty());
+
+    DatasetIdentifier di = handler.getDatasetIdentifier(relationOf(TABLE_LOCATION, QUALIFIED_NAME));
+
+    assertThat(di.getName()).isEqualTo(TABLE_PATH);
+    assertThat(di.getNamespace()).isEqualTo("file");
+  }
+
+  /** A table loaded without a catalog is named by its location, which cannot be split up. */
+  @Test
+  void testGetDatasetIdentifierForTableWithoutCatalog() {
+    when(context.getSparkSession()).thenReturn(Optional.empty());
+
+    DatasetIdentifier di = handler.getDatasetIdentifier(relationOf(TABLE_LOCATION, TABLE_LOCATION));
+
+    assertThat(di.getName()).isEqualTo(TABLE_PATH);
+  }
+
+  @Test
+  void testGetName() {
+    assertThat(handler.getName()).isEqualTo("iceberg");
+  }
+
+  /** Guards the registration - an unregistered handler is dead code. */
+  @Test
+  void testHandlerIsRegisteredForIcebergRelations() {
+    OpenLineageContext contributingContext = contextContributing(handler);
+    when(context.getSparkSession()).thenReturn(Optional.empty());
+
+    DatasetIdentifier di =
+        CatalogUtils.getDatasetIdentifierFromRelation(
+            contributingContext, relationOf("file:/tmp/wh/db/registered", "c.db.registered"));
+
+    assertThat(di.getName()).isEqualTo("/tmp/wh/db/registered");
+  }
+
+  /** A relation that no handler recognises must still raise, so the caller can log and skip. */
+  @Test
+  void testUnknownRelationStillThrows() {
+    OpenLineageContext contributingContext = contextContributing(handler);
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class, RETURNS_DEEP_STUBS);
+    when(relation.table()).thenReturn(mock(org.apache.spark.sql.connector.catalog.Table.class));
+
+    assertThat(handler.isClass(relation)).isFalse();
+    assertThatThrownBy(
+            () -> CatalogUtils.getDatasetIdentifierFromRelation(contributingContext, relation))
+        .isInstanceOf(UnsupportedCatalogException.class);
+  }
+
+  @Test
+  void testIcebergCatalogHandlerStillRejectsCachedCatalog() {
+    // the reason this relation handler exists in the first place
+    TableCatalog cached = mock(SparkCachedTableCatalog.class);
+    assertThat(new IcebergHandler(context).isClass(cached)).isFalse();
+  }
+
+  /**
+   * The path this handler exists for. The owning catalog is recovered from the table's qualified
+   * name and the identifier resolved through it, so the result is whatever the regular {@link
+   * IcebergHandler} would have produced for a plain write - symlink included. Asserting on the
+   * symlink is what separates this from the location fallback, which resolves to the same primary
+   * name from the table location alone and would otherwise satisfy the assertion on its own.
+   */
+  @Test
+  void testGetDatasetIdentifierResolvesThroughOwningCatalog() {
+    DatasetIdentifier throughCatalog =
+        new DatasetIdentifier(TABLE_PATH, "file")
+            .withSymlink("db.tbl", "hive://metastore", SymlinkType.TABLE);
+    TableCatalog owning = mock(TableCatalog.class);
+    withSessionCatalog(context, "c", owning);
+
+    try (MockedStatic<CatalogUtils> catalogUtils =
+        mockStatic(CatalogUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      catalogUtils
+          .when(
+              () ->
+                  CatalogUtils.getDatasetIdentifier(
+                      Mockito.eq(context),
+                      Mockito.eq(owning),
+                      Mockito.eq(Identifier.of(new String[] {"db"}, "tbl")),
+                      Mockito.any()))
+          .thenReturn(throughCatalog);
+
+      DatasetIdentifier di =
+          handler.getDatasetIdentifier(relationOf(TABLE_LOCATION, QUALIFIED_NAME));
+
+      assertThat(di.getName()).isEqualTo(TABLE_PATH);
+      assertThat(di.getSymlinks())
+          .as("the identifier must come from the owning catalog, not the table location")
+          .isNotEmpty();
+    }
+  }
+
+  /**
+   * The facet lookup takes the same route as the identifier: the catalog reported here is the one
+   * that owns the table, not the cached catalog the write went through.
+   */
+  @Test
+  void testGetOwningCatalogRecoversCatalogAndIdentifier() {
+    TableCatalog owning = mock(TableCatalog.class);
+    withSessionCatalog(context, "c", owning);
+
+    Optional<RelationHandler.OwningCatalog> owner =
+        handler.getOwningCatalog(relationOf(TABLE_LOCATION, QUALIFIED_NAME));
+
+    assertThat(owner).isPresent();
+    assertThat(owner.get().getCatalog()).isSameAs(owning);
+    assertThat(owner.get().getIdentifier()).isEqualTo(Identifier.of(new String[] {"db"}, "tbl"));
+  }
+
+  /** A catalog registered under a name that is not a {@link TableCatalog} cannot be resolved. */
+  @Test
+  void testGetOwningCatalogRejectsNonTableCatalog() {
+    withSessionCatalog(context, "c", mock(CatalogPlugin.class));
+
+    assertThat(handler.getOwningCatalog(relationOf(TABLE_LOCATION, QUALIFIED_NAME))).isEmpty();
+  }
+
+  /** Registers {@code catalog} under {@code name} in the context's session catalog manager. */
+  private static void withSessionCatalog(
+      OpenLineageContext context, String name, CatalogPlugin catalog) {
+    SparkSession session = mock(SparkSession.class, RETURNS_DEEP_STUBS);
+    when(session.sessionState().catalogManager().catalog(name)).thenReturn(catalog);
+    when(context.getSparkSession()).thenReturn(Optional.of(session));
+  }
+
+  private DataSourceV2Relation relationOf(String location, String name) {
+    Table icebergTable = mock(Table.class);
+    when(icebergTable.location()).thenReturn(location);
+    when(icebergTable.name()).thenReturn(name);
+
+    SparkTable sparkTable = mock(SparkTable.class);
+    when(sparkTable.table()).thenReturn(icebergTable);
+
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class, RETURNS_DEEP_STUBS);
+    when(relation.table()).thenReturn(sparkTable);
+    return relation;
+  }
+
+  /** Builds a context whose factory contributes exactly the given relation handlers. */
+  private static OpenLineageContext contextContributing(RelationHandler... handlers) {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    when(context.getDatasetBuilderFactory())
+        .thenReturn(
+            new DatasetBuilderFactory() {
+              @Override
+              public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>>
+                  getInputBuilders(OpenLineageContext ctx) {
+                return Collections.emptyList();
+              }
+
+              @Override
+              public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>>
+                  getOutputBuilders(OpenLineageContext ctx) {
+                return Collections.emptyList();
+              }
+
+              @Override
+              public List<RelationHandler> getRelationHandlers(OpenLineageContext ctx) {
+                return Arrays.asList(handlers);
+              }
+            });
+    return context;
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -8,6 +8,7 @@ package io.openlineage.spark3.agent.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -18,7 +19,10 @@ import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.lifecycle.DatasetBuilderFactory;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
 import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -27,6 +31,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkDatasetBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,9 +52,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
+import scala.PartialFunction;
 
 class DataSourceV2RelationDatasetExtractorTest {
   private static final String NAME = "name";
+  private static final String NAMESPACE = "namespace";
+  private static final String CATALOG_DB_TABLE = "catalog.db.table";
 
   OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
   SparkSession sparkSession = mock(SparkSession.class);
@@ -68,6 +76,7 @@ class DataSourceV2RelationDatasetExtractorTest {
     tableProperties = new HashMap<>();
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(sparkSession));
     when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
+    when(openLineageContext.getDatasetBuilderFactory()).thenReturn(DatasetBuilderFactory.EMPTY);
     when(dataSourceV2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
     when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(identifier));
     when(dataSourceV2Relation.schema()).thenReturn(schema);
@@ -123,6 +132,9 @@ class DataSourceV2RelationDatasetExtractorTest {
     try (MockedStatic<CatalogUtils> mocked = mockStatic(CatalogUtils.class)) {
       when(CatalogUtils.getDatasetIdentifier(
               openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenThrow(new UnsupportedCatalogException("exception"));
+      // the relation cannot be resolved either, so there is nothing left to fall back to
+      when(CatalogUtils.getDatasetIdentifierFromRelation(openLineageContext, dataSourceV2Relation))
           .thenThrow(new UnsupportedCatalogException("exception"));
 
       assertEquals(
@@ -221,7 +233,7 @@ class DataSourceV2RelationDatasetExtractorTest {
     assertEquals(1, result.size());
     assertThat(result.get(0))
         .hasFieldOrPropertyWithValue(NAME, "some-name")
-        .hasFieldOrPropertyWithValue("namespace", "some-namespace");
+        .hasFieldOrPropertyWithValue(NAMESPACE, "some-namespace");
 
     OpenLineage.DatasetFacet datasetFacet =
         result.get(0).getFacets().getAdditionalProperties().get("customFacet");
@@ -267,7 +279,7 @@ class DataSourceV2RelationDatasetExtractorTest {
     assertEquals(1, result.size());
     assertThat(result.get(0))
         .hasFieldOrPropertyWithValue(NAME, "bigquery-public-data.samples.shakespeare")
-        .hasFieldOrPropertyWithValue("namespace", "bigquery");
+        .hasFieldOrPropertyWithValue(NAMESPACE, "bigquery");
   }
 
   @Test
@@ -288,7 +300,7 @@ class DataSourceV2RelationDatasetExtractorTest {
               .thenReturn(true);
           databricks
               .when(() -> DatabricksUtils.qualifiedUnityCatalogTableName(tableCatalog, identifier))
-              .thenReturn("catalog.db.table");
+              .thenReturn(CATALOG_DB_TABLE);
           planUtils
               .when(
                   () ->
@@ -305,11 +317,172 @@ class DataSourceV2RelationDatasetExtractorTest {
 
           assertEquals(1, result.size());
           assertThat(result.get(0))
-              .hasFieldOrPropertyWithValue(NAME, "catalog.db.table")
-              .hasFieldOrPropertyWithValue("namespace", "unity-catalog");
+              .hasFieldOrPropertyWithValue(NAME, CATALOG_DB_TABLE)
+              .hasFieldOrPropertyWithValue(NAMESPACE, "unity-catalog");
         }
       }
     }
+  }
+
+  /**
+   * The relation fallback must not steal the Unity Catalog fallback's turn. A catalog that does
+   * have a {@link io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler} - a real Unity
+   * Catalog does - keeps naming its tables the Unity Catalog way even when a relation handler could
+   * have produced something too.
+   */
+  @Test
+  void testUnityCatalogFallbackWinsOverRelationFallbackForSupportedCatalog() {
+    SparkConf sparkConf = new SparkConf();
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    when(dataSourceV2Relation.schema()).thenReturn(new StructType());
+
+    // a handler exists for this catalog, it just cannot resolve this particular table
+    CatalogHandler supportingHandler = mock(CatalogHandler.class);
+    when(supportingHandler.hasClasses()).thenReturn(true);
+    when(supportingHandler.isClass(tableCatalog)).thenReturn(true);
+    RelationHandler relationHandler = alwaysResolvingRelationHandler();
+    DatasetBuilderFactory factory =
+        factoryContributing(
+            Collections.singletonList(supportingHandler),
+            Collections.singletonList(relationHandler));
+    when(openLineageContext.getDatasetBuilderFactory()).thenReturn(factory);
+
+    try (MockedStatic<PlanUtils3> planUtils = mockStatic(PlanUtils3.class);
+        MockedStatic<DatabricksUtils> databricks = mockStatic(DatabricksUtils.class);
+        MockedStatic<PlanUtils> mockedPlanUtils = mockStatic(PlanUtils.class)) {
+      databricks
+          .when(() -> DatabricksUtils.isDatabricksUnityCatalogEnabled(sparkConf))
+          .thenReturn(true);
+      databricks
+          .when(() -> DatabricksUtils.qualifiedUnityCatalogTableName(tableCatalog, identifier))
+          .thenReturn(CATALOG_DB_TABLE);
+      planUtils
+          .when(
+              () ->
+                  PlanUtils3.getDatasetIdentifier(
+                      openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> result =
+          DataSourceV2RelationDatasetExtractor.extract(
+              DatasetFactory.output(openLineageContext),
+              openLineageContext,
+              dataSourceV2Relation,
+              false);
+
+      assertEquals(1, result.size());
+      assertThat(result.get(0))
+          .hasFieldOrPropertyWithValue(NAME, CATALOG_DB_TABLE)
+          .hasFieldOrPropertyWithValue(NAMESPACE, "unity-catalog");
+    }
+  }
+
+  /** A relation handler that recognises everything and always resolves. */
+  private RelationHandler alwaysResolvingRelationHandler() {
+    RelationHandler handler = mock(RelationHandler.class);
+    when(handler.hasClasses()).thenReturn(true);
+    when(handler.isClass(dataSourceV2Relation)).thenReturn(true);
+    when(handler.getDatasetIdentifier(dataSourceV2Relation))
+        .thenReturn(new DatasetIdentifier("from-relation", "relation-namespace"));
+    return handler;
+  }
+
+  /**
+   * The cached-catalog case: no handler supports the relation's own catalog, so storage and catalog
+   * facets are resolved against the catalog that owns the table instead of coming back empty.
+   */
+  @Test
+  void testFacetsAreResolvedThroughOwningCatalogWhenCatalogUnsupported() {
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    when(dataSourceV2Relation.schema()).thenReturn(new StructType());
+
+    TableCatalog owningCatalog = mock(TableCatalog.class);
+    Identifier owningIdentifier = mock(Identifier.class);
+    RelationHandler relationHandler = mock(RelationHandler.class);
+    when(relationHandler.hasClasses()).thenReturn(true);
+    when(relationHandler.isClass(dataSourceV2Relation)).thenReturn(true);
+    when(relationHandler.getOwningCatalog(dataSourceV2Relation))
+        .thenReturn(Optional.of(RelationHandler.OwningCatalog.of(owningCatalog, owningIdentifier)));
+    when(openLineageContext.getDatasetBuilderFactory())
+        .thenReturn(
+            factoryContributing(
+                Collections.emptyList(), Collections.singletonList(relationHandler)));
+
+    try (MockedStatic<CatalogUtils> catalogUtils = mockStatic(CatalogUtils.class);
+        MockedStatic<PlanUtils3> planUtils = mockStatic(PlanUtils3.class)) {
+      catalogUtils
+          .when(() -> CatalogUtils.getCatalogHandler(openLineageContext, tableCatalog))
+          .thenReturn(Optional.empty());
+      catalogUtils
+          .when(
+              () ->
+                  CatalogUtils.getOwningCatalogFromRelation(
+                      openLineageContext, dataSourceV2Relation))
+          .thenReturn(
+              Optional.of(RelationHandler.OwningCatalog.of(owningCatalog, owningIdentifier)));
+      catalogUtils
+          .when(
+              () ->
+                  CatalogUtils.getDatasetIdentifierFromRelation(
+                      openLineageContext, dataSourceV2Relation))
+          .thenReturn(new DatasetIdentifier("/warehouse/db/table", "file"));
+      planUtils
+          .when(
+              () ->
+                  PlanUtils3.getDatasetIdentifier(
+                      openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> result =
+          DataSourceV2RelationDatasetExtractor.extract(
+              DatasetFactory.output(openLineageContext),
+              openLineageContext,
+              dataSourceV2Relation,
+              false);
+
+      assertEquals(1, result.size());
+      assertThat(result.get(0)).hasFieldOrPropertyWithValue(NAME, "/warehouse/db/table");
+      // the facets were resolved against the owning catalog, not the relation's unsupported one
+      catalogUtils.verify(
+          () ->
+              CatalogUtils.addStorageAndCatalogFacets(
+                  eq(openLineageContext),
+                  eq(owningCatalog),
+                  eq(tableProperties),
+                  any(DatasetCompositeFacetsBuilder.class)));
+    }
+  }
+
+  private static DatasetBuilderFactory factoryContributing(
+      List<CatalogHandler> catalogHandlers, List<RelationHandler> relationHandlers) {
+    return new DatasetBuilderFactory() {
+      @Override
+      public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
+          OpenLineageContext context) {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
+          OpenLineageContext context) {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public List<CatalogHandler> getCatalogHandlers(OpenLineageContext context) {
+        return catalogHandlers;
+      }
+
+      @Override
+      public List<RelationHandler> getRelationHandlers(OpenLineageContext context) {
+        return relationHandlers;
+      }
+    };
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtilsTest.java
@@ -8,10 +8,14 @@ package io.openlineage.spark3.agent.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.DatasetBuilderFactory;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.RelationHandler;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,6 +62,10 @@ class DatasetVersionDatasetFacetUtilsTest {
     when(fsRelation.location()).thenReturn(tahoeLogFileIndex);
     when(tahoeLogFileIndex.getSnapshot()).thenReturn(snapshot);
     when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
+    // The owning-catalog fallback asks the factory for relation handlers, so it has to be a real
+    // factory rather than an unstubbed mock returning null - otherwise the fallback returns empty
+    // via its exception handler instead of via "no handler matched".
+    when(openLineageContext.getDatasetBuilderFactory()).thenReturn(DatasetBuilderFactory.EMPTY);
   }
 
   @Test
@@ -102,6 +110,93 @@ class DatasetVersionDatasetFacetUtilsTest {
           .thenReturn(Optional.of("some-version"));
       assertEquals(
           Optional.of("some-version"),
+          DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
+              openLineageContext, v2Relation));
+    }
+  }
+
+  /**
+   * A supported catalog reporting no version has none to report - an Iceberg table with no snapshot
+   * yet, which is the normal state on a START event. The owning catalog recovered from the table
+   * name is that same catalog, so falling back would only repeat the table load.
+   */
+  @Test
+  void testExtractVersionDoesNotFallBackWhenCatalogIsSupported() {
+    when(v2Relation.identifier()).thenReturn(Option.apply(identifier));
+    when(v2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
+    when(v2Relation.table()).thenReturn(table);
+    when(table.properties()).thenReturn(tableProperties);
+
+    try (MockedStatic<CatalogUtils> mocked = mockStatic(CatalogUtils.class)) {
+      when(CatalogUtils.getDatasetVersion(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.empty());
+      when(CatalogUtils.getCatalogHandler(openLineageContext, tableCatalog))
+          .thenReturn(Optional.of(mock(CatalogHandler.class)));
+
+      assertEquals(
+          Optional.empty(),
+          DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
+              openLineageContext, v2Relation));
+
+      mocked.verify(
+          () -> CatalogUtils.getOwningCatalogFromRelation(openLineageContext, v2Relation), never());
+    }
+  }
+
+  /**
+   * The cached-catalog case: no handler supports the relation's own catalog, so the version comes
+   * from the catalog that owns the table, resolved through a relation handler.
+   */
+  @Test
+  void testExtractVersionFallsBackToOwningCatalogWhenCatalogUnsupported() {
+    when(v2Relation.identifier()).thenReturn(Option.apply(identifier));
+    when(v2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
+    when(v2Relation.table()).thenReturn(table);
+    when(table.properties()).thenReturn(tableProperties);
+
+    TableCatalog owningCatalog = mock(TableCatalog.class);
+    Identifier owningIdentifier = mock(Identifier.class);
+
+    try (MockedStatic<CatalogUtils> mocked = mockStatic(CatalogUtils.class)) {
+      when(CatalogUtils.getDatasetVersion(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.empty());
+      when(CatalogUtils.getCatalogHandler(openLineageContext, tableCatalog))
+          .thenReturn(Optional.empty());
+      when(CatalogUtils.getOwningCatalogFromRelation(openLineageContext, v2Relation))
+          .thenReturn(
+              Optional.of(RelationHandler.OwningCatalog.of(owningCatalog, owningIdentifier)));
+      when(CatalogUtils.getDatasetVersion(
+              openLineageContext, owningCatalog, owningIdentifier, tableProperties))
+          .thenReturn(Optional.of("owning-version"));
+
+      assertEquals(
+          Optional.of("owning-version"),
+          DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
+              openLineageContext, v2Relation));
+    }
+  }
+
+  /** A linkage error from the relation handler must not escape as a version lookup failure. */
+  @Test
+  void testExtractVersionSwallowsFailureOfOwningCatalogLookup() {
+    when(v2Relation.identifier()).thenReturn(Option.apply(identifier));
+    when(v2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
+    when(v2Relation.table()).thenReturn(table);
+    when(table.properties()).thenReturn(tableProperties);
+
+    try (MockedStatic<CatalogUtils> mocked = mockStatic(CatalogUtils.class)) {
+      when(CatalogUtils.getDatasetVersion(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.empty());
+      when(CatalogUtils.getCatalogHandler(openLineageContext, tableCatalog))
+          .thenReturn(Optional.empty());
+      when(CatalogUtils.getOwningCatalogFromRelation(openLineageContext, v2Relation))
+          .thenThrow(new NoSuchMethodError("SparkTable.table()"));
+
+      assertEquals(
+          Optional.empty(),
           DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
               openLineageContext, v2Relation));
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:

**Spark: report datasets for Iceberg writes going through the cached table catalog** — Iceberg maintenance actions such as `rewrite_data_files` write through `SparkCachedTableCatalog` and until now emitted events with no datasets at all.

### Meaningful description

#### Problem

Iceberg's rewrite actions (`rewrite_data_files`, `rewrite_position_delete_files`, …) do not write through the table's own catalog. They stage the table in `SparkTableCache` under a random UUID and then read and write through `org.apache.iceberg.spark.SparkCachedTableCatalog`, which Iceberg registers as `spark.sql.catalog.default_cache_iceberg`.

That catalog implements `TableCatalog` directly — it is neither a `SparkCatalog` nor a `SparkSessionCatalog` — so `IcebergHandler.isClass` rejects it, `CatalogUtils` throws `UnsupportedCatalogException`, and `DataSourceV2RelationDatasetExtractor` returns an empty list. The resulting `append_data` event names the table it compacted in the job name but carries **no datasets at all**, so a compaction silently contributes no lineage.

#### Solution

Resolve such datasets from the *relation* instead of the catalog.

A new `IcebergRelationHandler` unwraps `relation.table()` to the underlying Iceberg `Table`, recovers the catalog that originally loaded it from the table's fully qualified name, and delegates back to `IcebergHandler` — so a compaction reports exactly the same dataset identifier, symlinks included, as a regular write to the same table. It falls back to the table location when the owning catalog cannot be recovered, and raises `UnsupportedCatalogException` — the one exception the caller is contracted to handle — when there is no location either, rather than letting `new Path(null)` throw out of the handler.

Relation handlers so far were a context-free static list, which a handler needing the Spark session cannot join. `DatasetBuilderFactory` now contributes them per Spark version the same way it already contributes catalog handlers, and `CatalogUtils` merges the shared and the contributed ones. The context-free `CatalogUtils.getDatasetIdentifierFromRelation(relation)` is kept, deprecated in favour of the context-taking overload, so out-of-tree callers still compile. Handler `hasClasses()` answers are memoized per handler class: the probe costs a thrown `ClassNotFoundException`, cannot change within a JVM, and the list is otherwise rebuilt per relation per event.

Both the identifier and the facets take this fallback on the same condition — that no `CatalogHandler` supports the relation's catalog. Gating on *that* rather than on resolution merely having failed leaves the existing Unity Catalog fallback untouched: it names a table after the catalog it was handed, which is right for a real Unity Catalog proxy and wrong for a cached catalog, whose name is the UUID cache key. So storage, catalog and dataset version resolve against the owning catalog too, and a compaction event carries the same facets as a plain write.

Both the relation resolution and the facet lookup catch linkage errors as well as exceptions, since a relation handler reaches into the underlying table's own API and `InputFieldsCollector` calls `getDatasetIdentifierExtended` outside any `PlanUtils#safeApply` — one unresolvable relation must not take the whole plan's lineage down with it.

### Checklist
- [x] AI was used in creating this PR
