### PR TITLE
spark: stop reporting read-only V2 plans as outputs

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -25,6 +25,7 @@ import io.openlineage.client.OpenLineage.OutputStatisticsOutputDatasetFacet;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -795,6 +796,33 @@ class SparkIcebergIntegrationTest {
 
     assertThat(icebergScanReport.get().getMetadata().getAdditionalProperties())
         .containsEntry("engine-name", "spark");
+  }
+
+  @Test
+  @SneakyThrows
+  void testLocalCheckpointReadDoesNotEmitOutput() {
+    clearTables("checkpoint_source");
+    spark.sql("CREATE TABLE checkpoint_source USING iceberg AS SELECT 1 AS id");
+
+    getEventsEmittedWithJobName(mockServer, "checkpoint_source");
+    StaticExecutionContextFactory.waitForExecutionEnd();
+    MockServerUtils.clearRequests(mockServer);
+
+    spark.table("checkpoint_source").localCheckpoint(false).count();
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    List<RunEvent> readEvents =
+        getEventsEmitted(mockServer).stream()
+            .filter(e -> e.getEventType() == RunEvent.EventType.COMPLETE)
+            .filter(
+                e ->
+                    e.getInputs().stream()
+                        .anyMatch(input -> input.getName().endsWith("checkpoint_source")))
+            .collect(Collectors.toList());
+
+    assertThat(readEvents)
+        .isNotEmpty()
+        .allSatisfy(event -> assertThat(event.getOutputs()).isEmpty());
   }
 
   @Test

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -140,6 +140,11 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
             .collect(Collectors.toList()));
   }
 
+  protected boolean isQueryPlanRoot(LogicalPlan logicalPlan) {
+    return context.getOptimizedPlanOptional().filter(root -> root == logicalPlan).isPresent()
+        || context.getAnalyzedPlanOptional().filter(root -> root == logicalPlan).isPresent();
+  }
+
   /**
    * Similar to the logic in {@link AbstractPartial}, this reads the type from the <i>second</i>
    * generic argument on the class, if it is present and non-null.

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -39,7 +39,9 @@ public class DataSourceV2RelationOutputDatasetBuilder
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan logicalPlan) {
-    return logicalPlan instanceof DataSourceV2Relation;
+    // Write builders delegate their target relations here. A relation at the query root has no
+    // write command and must not be classified as an output.
+    return logicalPlan instanceof DataSourceV2Relation && !isQueryPlanRoot(logicalPlan);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasOutputDatasetBuilder.java
@@ -28,7 +28,9 @@ public class SubqueryAliasOutputDatasetBuilder
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return x instanceof SubqueryAlias;
+    // Top-level aliases represent reads. Write builders still delegate aliases around their target
+    // relations to this builder.
+    return x instanceof SubqueryAlias && !isQueryPlanRoot(x);
   }
 
   @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilderTest.java
@@ -17,6 +17,7 @@ import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import java.util.List;
+import java.util.Optional;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
@@ -41,6 +42,24 @@ class DataSourceV2RelationOutputDatasetBuilderTest {
   void testDataSourceV2RelationOutputDatasetBuilderIsDefinedAtLogicalPlan() {
     assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
     assertTrue(builder.isDefinedAtLogicalPlan(mock(DataSourceV2Relation.class)));
+  }
+
+  @Test
+  void testDataSourceV2RelationQueryRootIsNotAnOutput() {
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+    when(context.getOptimizedPlanOptional()).thenReturn(Optional.of(relation));
+    when(context.getAnalyzedPlanOptional()).thenReturn(Optional.of(relation));
+
+    assertFalse(builder.isDefinedAtLogicalPlan(relation));
+  }
+
+  @Test
+  void testNestedDataSourceV2RelationCanBeAnOutput() {
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+    when(context.getOptimizedPlanOptional()).thenReturn(Optional.of(mock(LogicalPlan.class)));
+    when(context.getAnalyzedPlanOptional()).thenReturn(Optional.of(mock(LogicalPlan.class)));
+
+    assertTrue(builder.isDefinedAtLogicalPlan(relation));
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasOutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasOutputDatasetBuilderTest.java
@@ -1,0 +1,42 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Optional;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.junit.jupiter.api.Test;
+
+class SubqueryAliasOutputDatasetBuilderTest {
+
+  private final OpenLineageContext context = mock(OpenLineageContext.class);
+  private final SubqueryAliasOutputDatasetBuilder builder =
+      new SubqueryAliasOutputDatasetBuilder(context);
+
+  @Test
+  void testQueryRootIsNotAnOutput() {
+    SubqueryAlias alias = mock(SubqueryAlias.class);
+    when(context.getOptimizedPlanOptional()).thenReturn(Optional.of(alias));
+    when(context.getAnalyzedPlanOptional()).thenReturn(Optional.of(alias));
+
+    assertFalse(builder.isDefinedAtLogicalPlan(alias));
+  }
+
+  @Test
+  void testNestedAliasCanBeAnOutput() {
+    SubqueryAlias alias = mock(SubqueryAlias.class);
+    when(context.getOptimizedPlanOptional()).thenReturn(Optional.of(mock(LogicalPlan.class)));
+    when(context.getAnalyzedPlanOptional()).thenReturn(Optional.of(mock(LogicalPlan.class)));
+
+    assertTrue(builder.isDefinedAtLogicalPlan(alias));
+  }
+}


### PR DESCRIPTION
### One-line summary for changelog:

Prevent read-only V2 scans from being reported as output datasets.

### Meaningful description

A lazy `localCheckpoint` over an Iceberg table creates a read-only SQL execution whose analyzed plan can be a top-level `SubqueryAlias` around a `DataSourceV2Relation`. Both output builders treated those roots as write targets, so the table was emitted in `outputs` even though Spark never committed to it.

This change excludes the optimized and analyzed query roots from those output builders. The same builders still match nested relations and aliases when append, overwrite, replace, MERGE, and other write-specific builders delegate to their targets.

The regression test materializes an Iceberg checkpoint and verifies that the source remains an input without becoming an output. Existing write tests continue to pass.

Closes #4897

### Checklist
- [x] AI was used in creating this PR
