### PR TITLE
python: queue async completion events atomically

### DIFF
--- a/client/python/src/openlineage/client/transport/async_http.py
+++ b/client/python/src/openlineage/client/transport/async_http.py
@@ -494,18 +494,18 @@ class AsyncHttpTransport(Transport):
                 return released
         return []
 
-    def _add_pending_completion_event(self, request: Request) -> None:
+    def _add_pending_completion_event(self, request: Request) -> bool:
         if not request.run_id:
-            return
+            return False
         with self.event_lock:
-            if request.run_id not in self.pending_completion_events:
-                self.pending_completion_events[request.run_id] = []
-            self.pending_completion_events[request.run_id].append(request)
+            start_event_id = f"{request.run_id}-START"
+            if start_event_id not in self.events:
+                return False
 
-    def _is_start_in_progress(self, run_id: str) -> bool:
-        with self.event_lock:
-            start_event_id = f"{run_id}-START"
-            return start_event_id in self.events
+            self.event_stats["pending"] += 1
+            self.events[request.event_id] = "pending"
+            self.pending_completion_events.setdefault(request.run_id, []).append(request)
+            return True
 
     def _all_processed(self) -> bool:
         with self.event_lock:
@@ -522,29 +522,23 @@ class AsyncHttpTransport(Transport):
             event_id = event.run.runId + "-" + event_type
             run_id = event.run.runId
 
-            # We don't want to emit terminal events until we have a successful START event
-            # Only queue as pending if START has been scheduled but not yet successful
-            # If START was never scheduled, process COMPLETE normally (fall through)
-            if event_type != "START":
-                if self._is_start_in_progress(run_id):
-                    body, headers = self._prepare_request(event_str)
-                    request = Request(
-                        event_id=event_id, run_id=run_id, event_type=event_type, body=body, headers=headers
-                    )
-                    self._add_event(request)
-                    self._add_pending_completion_event(request)
-
-                    log.debug(
-                        "Queued completion event %s for run %s, waiting for START event",
-                        event_type,
-                        run_id,
-                    )
-                    return
         else:
             event_id = hashlib.md5(event_str.encode("utf-8")).hexdigest()
 
         body, headers = self._prepare_request(event_str)
         request = Request(event_id=event_id, run_id=run_id, event_type=event_type, body=body, headers=headers)
+
+        # We don't want to emit terminal events until we have a successful START event.
+        # Checking for START and tracking the terminal event must be atomic so the worker
+        # cannot finish START between those operations and strand the terminal event.
+        if run_id and event_type != "START" and self._add_pending_completion_event(request):
+            log.debug(
+                "Queued completion event %s for run %s, waiting for START event",
+                event_type,
+                run_id,
+            )
+            return
+
         self._add_event(request)
 
         # Wait for space in the regular capacity portion of the queue

--- a/client/python/tests/test_async_http.py
+++ b/client/python/tests/test_async_http.py
@@ -236,6 +236,63 @@ class TestAsyncHttpTransport:
                 assert run_id in transport.pending_completion_events
                 assert len(transport.pending_completion_events[run_id]) == 1
 
+    def test_completion_is_not_stranded_when_start_finishes_during_emit(self):
+        config = AsyncHttpConfig(url="http://example.com", max_concurrent_requests=1)
+        transport = AsyncHttpTransport(config)
+        start_processing = threading.Event()
+        finish_start = threading.Event()
+        start_finished = threading.Event()
+
+        async def process_event(client, semaphore, request, from_main_queue=True):
+            if request.event_type == "START":
+                start_processing.set()
+                while not finish_start.is_set():
+                    await asyncio.sleep(0.01)
+
+            released = transport._mark_success(request)
+            if request.event_type == "START":
+                start_finished.set()
+            if from_main_queue:
+                transport.event_queue.task_done()
+            return released
+
+        def event(state, second):
+            return RunEvent(
+                eventType=state,
+                eventTime=f"2026-08-27T00:00:{second:02d}Z",
+                run=Run(runId="00000000-0000-0000-0000-000000000002"),
+                job=Job(namespace="test", name="atomic-completion-queueing"),
+                producer="test",
+                schemaURL="test",
+            )
+
+        original_prepare_request = transport._prepare_request
+
+        def finish_start_before_preparing_completion(event_str):
+            finish_start.set()
+            assert start_finished.wait(1)
+            return original_prepare_request(event_str)
+
+        try:
+            with patch.object(transport, "_process_event", side_effect=process_event):
+                transport.emit(event(RunState.START, 0))
+                assert start_processing.wait(1)
+
+                with patch.object(
+                    transport,
+                    "_prepare_request",
+                    side_effect=finish_start_before_preparing_completion,
+                ):
+                    transport.emit(event(RunState.COMPLETE, 1))
+
+                finish_start.set()
+                assert transport.wait_for_completion(timeout=1)
+                assert transport.get_stats() == {"pending": 0, "success": 2, "failed": 0}
+                assert not transport.pending_completion_events
+        finally:
+            finish_start.set()
+            transport.close(timeout=1)
+
     def test_async_http_transport_completion_without_start_scheduled(self):
         """Test that COMPLETE events without a scheduled START are processed immediately."""
         config = AsyncHttpConfig(url="http://example.com")
@@ -523,8 +580,8 @@ class TestAsyncHttpTransport:
                 headers={"header": "value"},
             )
 
-            # Add pending completion event first
-            transport._add_pending_completion_event(request)
+            transport._add_event(start_request)
+            assert transport._add_pending_completion_event(request)
 
             # Mark START as successful
             pending_events = transport._mark_success(start_request)
@@ -556,8 +613,7 @@ class TestAsyncHttpTransport:
             )
 
             transport._add_event(start_request)
-            transport._add_event(request)
-            transport._add_pending_completion_event(request)
+            assert transport._add_pending_completion_event(request)
 
             released = transport._mark_failed(start_request)
 
@@ -587,8 +643,7 @@ class TestAsyncHttpTransport:
                     event_id="run-1-COMPLETE", run_id="run-1", event_type="COMPLETE", body="", headers={}
                 )
                 transport._add_event(start_request)
-                transport._add_event(completion_request)
-                transport._add_pending_completion_event(completion_request)
+                assert transport._add_pending_completion_event(completion_request)
 
                 call_count = 0
 
@@ -635,8 +690,7 @@ class TestAsyncHttpTransport:
                     event_id="run-2-COMPLETE", run_id="run-2", event_type="COMPLETE", body="", headers={}
                 )
                 transport._add_event(start_request)
-                transport._add_event(completion_request)
-                transport._add_pending_completion_event(completion_request)
+                assert transport._add_pending_completion_event(completion_request)
 
                 call_count = 0
 
@@ -688,12 +742,21 @@ class TestAsyncHttpTransport:
                 body=b"data",
                 headers={"header": "value"},
             )
+            start_request = Request(
+                event_id="run-123-START",
+                event_type="START",
+                run_id="run-123",
+                body=b"data",
+                headers={"header": "value"},
+            )
 
-            transport._add_pending_completion_event(request)
+            transport._add_event(start_request)
+            assert transport._add_pending_completion_event(request)
 
             assert "run-123" in transport.pending_completion_events.keys()
             assert len(transport.pending_completion_events["run-123"]) == 1
             assert transport.pending_completion_events["run-123"][0] == request
+            assert transport.events[request.event_id] == "pending"
 
     def test_async_transport_all_processed(self):
         config = AsyncHttpConfig(url="http://example.com")
@@ -848,11 +911,13 @@ class TestAsyncHttpTransportErrorHandling:
 
         with closing_immediately(transport) as transport:
             run_id = "test-run-456"
+            start_request = Request(f"{run_id}-START", "", {}, run_id=run_id, event_type="START")
             request1 = Request("event1", "", {}, run_id=run_id, event_type="COMPLETE")
             request2 = Request("event2", "", {}, run_id=run_id, event_type="FAIL")
 
-            transport._add_pending_completion_event(request1)
-            transport._add_pending_completion_event(request2)
+            transport._add_event(start_request)
+            assert transport._add_pending_completion_event(request1)
+            assert transport._add_pending_completion_event(request2)
 
             assert len(transport.pending_completion_events[run_id]) == 2
 
@@ -926,7 +991,7 @@ class TestAsyncHttpTransportErrorHandling:
 
         with closing_immediately(transport) as transport:
             request = Request(event_id="test", body="", headers={}, run_id=None)
-            transport._add_pending_completion_event(request)
+            assert not transport._add_pending_completion_event(request)
 
             # Should not add anything to pending events
             assert len(transport.pending_completion_events) == 0
@@ -983,32 +1048,6 @@ class TestAsyncHttpTransportErrorHandling:
         transport.close()
 
         assert not transport.worker_thread.is_alive()
-
-    def test_is_start_in_progress(self):
-        """Test _is_start_in_progress method"""
-        config = AsyncHttpConfig(url="http://example.com")
-        transport = AsyncHttpTransport(config)
-
-        with closing_immediately(transport) as transport:
-            run_id = "test-run-123"
-
-            # Initially no START is in progress
-            assert not transport._is_start_in_progress(run_id)
-
-            # Add a START event to make it in progress
-            start_request = Request(
-                event_id=f"{run_id}-START", run_id=run_id, body="", event_type="START", headers={}
-            )
-            transport._add_event(start_request)
-
-            # Now it should be in progress
-            assert transport._is_start_in_progress(run_id)
-
-            # Complete the START event
-            transport._mark_success(start_request)
-
-            # Should no longer be in progress
-            assert not transport._is_start_in_progress(run_id)
 
     def test_wait_for_completion_with_infinite_timeout(self):
         """Test wait_for_completion with timeout=-1 (infinite wait)"""


### PR DESCRIPTION
### One-line summary for changelog:

Prevent `AsyncHttpTransport` from stranding terminal run events when `START` finishes concurrently.

### Meaningful description

Closes #4899

`AsyncHttpTransport.emit()` previously checked whether a run's `START` event was pending, released `event_lock`, and only then tracked and parked the later run event. The worker could complete `START` between those operations, pop the empty pending list, and leave the later event permanently stranded with no transition able to release it.

This change makes the decision and bookkeeping atomic: `_add_pending_completion_event()` now checks for the tracked `START`, records the later event, and adds it to the pending list while holding the same lock used by `START` completion. If `START` has already finished, the helper returns `False` and `emit()` queues the event normally. No lock is held across queue waits or network I/O.

A deterministic regression test forces `START` to finish at the old check-then-park boundary and verifies that both events are delivered, the pending count returns to zero, and no completion event remains held. Existing helper tests now exercise the combined tracking operation.

Validation on Python 3.13.13:

- `uvx prek run --files client/python/src/openlineage/client/transport/async_http.py client/python/tests/test_async_http.py`
- `.venv/bin/ruff format --check src/openlineage/client/transport/async_http.py tests/test_async_http.py`
- `.venv/bin/ruff check src/openlineage/client/transport/async_http.py tests/test_async_http.py`
- `.venv/bin/mypy src/openlineage/client/transport/async_http.py`
- `.venv/bin/pytest -q` — 651 passed, including 34 Docker-backed HTTP integration tests

### Checklist

- [x] AI was used in creating this PR
