### PR TITLE
Python: Use httpx2 instead of httpx

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "python-dateutil>=2.8.2",
   "pyyaml>=5.4",
   "requests>=2.32.4",
-  "httpx>=0.27.0",
+  "httpx2>=2.12.0",
   "packaging>=21.0",
 ]
 optional-dependencies.kafka = [

--- a/client/python/src/openlineage/client/generator/cli.py
+++ b/client/python/src/openlineage/client/generator/cli.py
@@ -6,7 +6,7 @@ import pathlib
 import tempfile
 
 import click
-import httpx
+import httpx2
 from openlineage.client.generator.base import (
     camel_to_snake,
     format_and_save_output,
@@ -19,7 +19,7 @@ BASE_SPEC_URL = "https://openlineage.io/spec/2-0-2/OpenLineage.json"
 
 def get_base_spec() -> pathlib.Path:
     """Get the base spec from the OpenLineage repository."""
-    response = httpx.get(BASE_SPEC_URL, timeout=10)
+    response = httpx2.get(BASE_SPEC_URL, timeout=10)
     response.raise_for_status()  # Raise an HTTPError for bad responses
     tmpfile = pathlib.Path(tempfile.mkdtemp()) / "OpenLineage.json"
     tmpfile.write_text(response.text)

--- a/client/python/src/openlineage/client/transport/async_http.py
+++ b/client/python/src/openlineage/client/transport/async_http.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import attr
-import httpx
+import httpx2
 from openlineage.client.event_v2 import RunEvent as RunEventV2
 from openlineage.client.run import RunEvent
 from openlineage.client.serde import Serde
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 Async HTTP Transport for OpenLineage Events
 
 This module provides asynchronous HTTP transport mechanisms for sending
-OpenLineage events to remote endpoints using httpx. The AsyncHttpTransport implements a sophisticated
+OpenLineage events to remote endpoints using httpx2. The AsyncHttpTransport implements a sophisticated
 event ordering and delivery system with race-condition-free task management.
 
 ## Transport Architecture
@@ -193,7 +193,7 @@ class AsyncHttpTransport(Transport):
             config,
         )
         try:
-            parsed = httpx.URL(url)
+            parsed = httpx2.URL(url)
             if not (parsed.scheme and parsed.host):
                 msg = f"Need valid url for OpenLineageClient, passed {url}"
                 raise ValueError(msg)
@@ -260,11 +260,11 @@ class AsyncHttpTransport(Transport):
         released_requests: deque[Request] = deque()
 
         # Httpx client for the worker
-        limits = httpx.Limits(
+        limits = httpx2.Limits(
             max_connections=self.max_concurrent, max_keepalive_connections=self.max_concurrent // 2
         )
 
-        transport = httpx.AsyncHTTPTransport(limits=limits, retries=self.config.retry["total"])
+        transport = httpx2.AsyncHTTPTransport(limits=limits, retries=self.config.retry["total"])
 
         def _should_exit() -> bool:
             return self.should_exit.is_set() or (
@@ -274,8 +274,8 @@ class AsyncHttpTransport(Transport):
                 and self.may_exit.is_set()
             )
 
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout=self.config.timeout),
+        async with httpx2.AsyncClient(
+            timeout=httpx2.Timeout(timeout=self.config.timeout),
             verify=self.config.verify,
             follow_redirects=True,
             transport=transport,
@@ -357,7 +357,7 @@ class AsyncHttpTransport(Transport):
 
     async def _process_event(
         self,
-        client: httpx.AsyncClient,
+        client: httpx2.AsyncClient,
         semaphore: asyncio.Semaphore,
         request: Request,
         from_main_queue: bool = True,
@@ -369,7 +369,7 @@ class AsyncHttpTransport(Transport):
         log.debug("Processing event %s", request.event_id)
 
         def handle_failure(
-            response: httpx.Response | None = None, exception: Exception | None = None
+            response: httpx2.Response | None = None, exception: Exception | None = None
         ) -> None:
             nonlocal pending_events
             pending_events = self._mark_failed(request)

--- a/client/python/tests/conftest.py
+++ b/client/python/tests/conftest.py
@@ -8,7 +8,7 @@ from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 from openlineage.client import event_v2, set_producer
 from openlineage.client.run import DatasetEvent, JobEvent, RunEvent
@@ -122,11 +122,11 @@ def test_server(docker_compose_file: str, test_server_url: str) -> Generator[str
 
     for attempt in range(max_retries):
         try:
-            response = httpx.get(f"{test_server_url}/health", timeout=5.0)
+            response = httpx2.get(f"{test_server_url}/health", timeout=5.0)
             if response.status_code == 200:
                 print(f"Test server is ready after {attempt + 1} attempts")
                 break
-        except (httpx.RequestError, httpx.TimeoutException):
+        except (httpx2.RequestError, httpx2.TimeoutException):
             if attempt == max_retries - 1:
                 # Cleanup on failure
                 print("Test server failed to start, cleaning up...")
@@ -166,7 +166,7 @@ def reset_test_server(request):
 
     # Reset before test
     try:
-        response = httpx.post(f"{test_server_url}/reset", timeout=5.0)
+        response = httpx2.post(f"{test_server_url}/reset", timeout=5.0)
         response.raise_for_status()
         print(f"✓ Reset test server before {request.node.name}")
 
@@ -176,7 +176,7 @@ def reset_test_server(request):
         time.sleep(0.1)
 
         # Verify reset worked
-        stats_response = httpx.get(f"{test_server_url}/stats", timeout=5.0)
+        stats_response = httpx2.get(f"{test_server_url}/stats", timeout=5.0)
         stats_response.raise_for_status()
         stats = stats_response.json()
         if stats["total_events"] > 0:
@@ -188,7 +188,7 @@ def reset_test_server(request):
 
     # Reset after test (for parameterized tests, this runs after each parameter)
     try:
-        response = httpx.post(f"{test_server_url}/reset", timeout=5.0)
+        response = httpx2.post(f"{test_server_url}/reset", timeout=5.0)
         response.raise_for_status()
         print(f"✓ Reset test server after {request.node.name}")
     except Exception as e:
@@ -253,16 +253,16 @@ def async_transport_custom(test_server: str):
 
 
 @pytest.fixture
-def test_server_client(test_server: str) -> httpx.Client:
+def test_server_client(test_server: str) -> httpx2.Client:
     """HTTP client for interacting with test server endpoints."""
-    with httpx.Client(base_url=test_server, timeout=10.0) as client:
+    with httpx2.Client(base_url=test_server, timeout=10.0) as client:
         yield client
 
 
 class TestServerHelper:
     """Helper class for interacting with the test server."""
 
-    def __init__(self, client: httpx.Client):
+    def __init__(self, client: httpx2.Client):
         self.client = client
 
     def get_events(self, **filters) -> list:
@@ -332,7 +332,7 @@ class TestServerHelper:
 
 
 @pytest.fixture
-def server_helper(test_server_client: httpx.Client) -> TestServerHelper:
+def server_helper(test_server_client: httpx2.Client) -> TestServerHelper:
     """Helper for interacting with test server."""
     return TestServerHelper(test_server_client)
 
@@ -368,7 +368,7 @@ def mock_async_http_client_class(mock_http_session):
     """Fixture providing a mock AsyncClient class that returns the mock client."""
     mock_client, mock_response = mock_http_session
 
-    with patch("httpx.AsyncClient") as mock_client_class:
+    with patch("httpx2.AsyncClient") as mock_client_class:
         # Configure the async context manager
         mock_client_class.return_value = mock_client
         yield mock_client_class, mock_client, mock_response

--- a/client/python/tests/fixtures/mock_responses.py
+++ b/client/python/tests/fixtures/mock_responses.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-import httpx
+import httpx2
 
 
 def create_mock_response(
@@ -14,8 +14,8 @@ def create_mock_response(
     content: str = "",
     json_data: dict[str, Any] | None = None,
 ) -> MagicMock:
-    """Create a mock httpx.Response object."""
-    mock_response = MagicMock(spec=httpx.Response)
+    """Create a mock httpx2.Response object."""
+    mock_response = MagicMock(spec=httpx2.Response)
     mock_response.status_code = status_code
     mock_response.headers = headers or {}
     mock_response.text = content
@@ -26,7 +26,7 @@ def create_mock_response(
     if 200 <= status_code < 300:
         mock_response.raise_for_status.return_value = None
     else:
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        mock_response.raise_for_status.side_effect = httpx2.HTTPStatusError(
             message=f"HTTP {status_code}", request=MagicMock(), response=mock_response
         )
 
@@ -50,17 +50,17 @@ def create_client_error_response(status_code: int = 400) -> MagicMock:
 
 def create_timeout_exception() -> Exception:
     """Create a timeout exception."""
-    return httpx.TimeoutException("Request timed out")
+    return httpx2.TimeoutException("Request timed out")
 
 
 def create_connection_error() -> Exception:
     """Create a connection error exception."""
-    return httpx.ConnectError("Connection failed")
+    return httpx2.ConnectError("Connection failed")
 
 
 def create_mock_async_client():
-    """Create a mock httpx.AsyncClient."""
-    mock_client = MagicMock(spec=httpx.AsyncClient)
+    """Create a mock httpx2.AsyncClient."""
+    mock_client = MagicMock(spec=httpx2.AsyncClient)
 
     # Set up context manager behavior
     mock_client.__aenter__ = MagicMock(return_value=mock_client)
@@ -70,8 +70,8 @@ def create_mock_async_client():
 
 
 def create_mock_sync_client():
-    """Create a mock httpx.Client."""
-    mock_client = MagicMock(spec=httpx.Client)
+    """Create a mock httpx2.Client."""
+    mock_client = MagicMock(spec=httpx2.Client)
 
     # Set up context manager behavior
     mock_client.__enter__ = MagicMock(return_value=mock_client)

--- a/client/python/tests/generator/test_cli.py
+++ b/client/python/tests/generator/test_cli.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from openlineage.client.generator.cli import get_base_spec, main
 
 
-@mock.patch("openlineage.client.generator.cli.httpx.get")
+@mock.patch("openlineage.client.generator.cli.httpx2.get")
 def test_get_base_spec(mock_get) -> None:
     mock_response = mock.MagicMock()
     mock_response.text = '{"$id": "test_id", "$defs": {}}'

--- a/client/python/tests/test_async_http.py
+++ b/client/python/tests/test_async_http.py
@@ -140,7 +140,7 @@ class TestAsyncHttpTransport:
         with pytest.raises(ValueError, match="Need valid url"):
             AsyncHttpTransport(AsyncHttpConfig(url=""))
 
-        # Test URL that causes httpx.URL to raise an exception
+        # Test URL that causes httpx2.URL to raise an exception
         with pytest.raises(ValueError, match="Need valid url"):
             AsyncHttpTransport(AsyncHttpConfig(url="://invalid"))
 
@@ -403,7 +403,7 @@ class TestAsyncHttpTransport:
             assert transport.may_exit.is_set()
             mock_wait.assert_called_once_with(1.0)
 
-    @patch("httpx.AsyncClient")
+    @patch("httpx2.AsyncClient")
     def test_async_http_transport_with_gzip_compression(self, mock_client_class):
         """Test AsyncHttpTransport with gzip compression"""
         config = AsyncHttpConfig(url="http://example.com", compression=HttpCompression.GZIP)

--- a/website/docs/client/python/configuration.md
+++ b/website/docs/client/python/configuration.md
@@ -253,7 +253,7 @@ The HTTP transport provides synchronous, blocking event emission. This is the de
 
 #### Behavior
 
-Events are serialized to JSON, and then are sent as HTTP POST request with `Content-Type: application/json`. Events are sent immediately and the call blocks until completion. Uses httpx with built-in retry support and raises exceptions on failure.
+Events are serialized to JSON, and then are sent as HTTP POST request with `Content-Type: application/json`. Events are sent immediately and the call blocks until completion. Uses httpx2 with built-in retry support and raises exceptions on failure.
 
 #### Examples
 


### PR DESCRIPTION
closes: #4901

### One-line summary for changelog:
Replace `httpx` with `httpx2` in `AsyncHttpTransport`


### Meaningful description
`httpx` is not developed anymore, switch to a modern `httpx2` client, drop-in replacement.


### Checklist
- [ ] AI was used in creating this PR
