### PR TITLE
spark: emit outputs for relation-backed streaming writes

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -42,6 +42,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuil
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.WriteToDataSourceV2DatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.column.JdbcColumnLineageVisitor;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.column.MergeIntoDelta11ColumnLineageVisitor;
@@ -95,6 +96,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -96,7 +96,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
-            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -22,6 +22,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetB
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.WriteToDataSourceV2DatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
@@ -43,6 +44,7 @@ public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -44,7 +44,7 @@ public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
-            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -39,6 +39,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuil
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.WriteToDataSourceV2DatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
@@ -95,6 +96,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -96,7 +96,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
-            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -93,7 +93,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
-            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -38,6 +38,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuil
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.WriteToDataSourceV2DatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
@@ -92,6 +93,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -97,7 +97,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
-            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -39,6 +39,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuil
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.UpdateCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.WriteToDataSourceV2DatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
@@ -96,6 +97,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new WriteToDataSourceV2DatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
             .add(new CopyIntoCommandOutputDatasetBuilder(context))

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 
 import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.ColumnLineageDatasetFacet;
 import io.openlineage.client.OpenLineage.IcebergCommitReportOutputDatasetFacet;
 import io.openlineage.client.OpenLineage.IcebergScanReportInputDatasetFacet;
@@ -26,6 +27,7 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -46,11 +49,14 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.functions;
+import org.apache.spark.sql.streaming.StreamingQuery;
+import org.apache.spark.sql.streaming.Trigger;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,6 +145,82 @@ class SparkIcebergIntegrationTest {
     spark.sql("INSERT INTO table VALUES (1, 2)");
 
     verifyEvents(mockServer, "pysparkWriteIcebergTableVersionEnd.json");
+  }
+
+  @Test
+  @SneakyThrows
+  void testStreamingWriteProducesOneCatalogAwareOutput() {
+    String table = "streaming_output";
+    String targetSuffix = "/default/" + table;
+    File streamingDirectory = new File("/tmp/iceberg/streaming-" + UUID.randomUUID().toString());
+    File inputDirectory = new File(streamingDirectory, "input");
+    File checkpointDirectory = new File(streamingDirectory, "checkpoint");
+
+    clearTables(table);
+    spark.sql("CREATE TABLE " + table + " (id bigint) USING iceberg");
+    Dataset<Row> input = spark.range(1).toDF();
+    StructType inputSchema = input.schema();
+    input.write().parquet(inputDirectory.getAbsolutePath());
+    MockServerUtils.clearRequests(mockServer);
+
+    StreamingQuery query =
+        spark
+            .readStream()
+            .schema(inputSchema)
+            .parquet(inputDirectory.getAbsolutePath())
+            .writeStream()
+            .format("iceberg")
+            .outputMode("append")
+            .queryName("iceberg_streaming_output")
+            .option("checkpointLocation", checkpointDirectory.getAbsolutePath())
+            .trigger(Trigger.Once())
+            .toTable(table);
+
+    try {
+      assertThat(query.awaitTermination(Duration.ofSeconds(30).toMillis())).isTrue();
+
+      List<RunEvent> outputEvents =
+          Awaitility.await()
+              .atMost(Duration.ofSeconds(30))
+              .until(
+                  () ->
+                      Arrays.stream(
+                              mockServer.retrieveRecordedRequests(
+                                  request().withPath("/api/v1/lineage")))
+                          .map(r -> OpenLineageClientUtils.runEventFromJson(r.getBodyAsString()))
+                          .filter(e -> RunEvent.EventType.COMPLETE.equals(e.getEventType()))
+                          .filter(
+                              e ->
+                                  e.getOutputs().stream()
+                                      .anyMatch(output -> output.getName().endsWith(targetSuffix)))
+                          .collect(Collectors.toList()),
+                  events -> !events.isEmpty());
+
+      assertThat(outputEvents)
+          .allSatisfy(
+              event -> {
+                List<OutputDataset> targetOutputs =
+                    event.getOutputs().stream()
+                        .filter(output -> output.getName().endsWith(targetSuffix))
+                        .collect(Collectors.toList());
+
+                assertThat(targetOutputs).hasSize(1);
+                OutputDataset target = targetOutputs.get(0);
+                assertThat(target.getFacets().getCatalog().getFramework()).isEqualTo("iceberg");
+                assertThat(target.getFacets().getSchema().getFields())
+                    .extracting(OpenLineage.SchemaDatasetFacetFields::getName)
+                    .containsExactly("id");
+                assertThat(target.getFacets().getSymlinks().getIdentifiers())
+                    .anySatisfy(
+                        identifier ->
+                            assertThat(identifier.getName()).isEqualTo("default." + table));
+              });
+    } finally {
+      if (query.isActive()) {
+        query.stop();
+      }
+      FileUtils.deleteDirectory(streamingDirectory);
+    }
   }
 
   @Test

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
@@ -30,6 +30,7 @@ public final class WriteToDataSourceV2Visitor
     extends QueryPlanVisitor<WriteToDataSourceV2, OutputDataset> {
   private static final String KAFKA_STREAMING_WRITE_CLASS_NAME =
       "org.apache.spark.sql.kafka010.KafkaStreamingWrite";
+  private static final boolean RELATION_ACCESSOR_AVAILABLE = hasRelationAccessor();
 
   public WriteToDataSourceV2Visitor(@NonNull OpenLineageContext context) {
     super(context);
@@ -60,6 +61,10 @@ public final class WriteToDataSourceV2Visitor
       String streamingWriteClassName = streamingWriteClass.getCanonicalName();
       if (KAFKA_STREAMING_WRITE_CLASS_NAME.equals(streamingWriteClassName)) {
         result = handleKafkaStreamingWrite(streamingWrite);
+      } else if (RELATION_ACCESSOR_AVAILABLE) {
+        log.debug(
+            "Deferring streaming write class '{}' to the relation-backed output dataset builder",
+            streamingWriteClass);
       } else {
         log.warn(
             "The streaming write class '{}' for '{}' is not supported",
@@ -71,6 +76,15 @@ public final class WriteToDataSourceV2Visitor
     }
 
     return result;
+  }
+
+  private static boolean hasRelationAccessor() {
+    try {
+      WriteToDataSourceV2.class.getMethod("relation");
+      return true;
+    } catch (NoSuchMethodException | SecurityException | LinkageError e) {
+      return false;
+    }
   }
 
   private @NotNull List<OutputDataset> handleKafkaStreamingWrite(StreamingWrite streamingWrite) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilder.java
@@ -8,9 +8,7 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -37,12 +35,8 @@ public class WriteToDataSourceV2DatasetBuilder
   private static final String KAFKA_STREAMING_WRITE_CLASS_NAME =
       "org.apache.spark.sql.kafka010.KafkaStreamingWrite";
 
-  private final DatasetFactory<OpenLineage.OutputDataset> factory;
-
-  public WriteToDataSourceV2DatasetBuilder(
-      OpenLineageContext context, DatasetFactory<OpenLineage.OutputDataset> factory) {
+  public WriteToDataSourceV2DatasetBuilder(OpenLineageContext context) {
     super(context, false);
-    this.factory = factory;
   }
 
   @Override
@@ -72,13 +66,9 @@ public class WriteToDataSourceV2DatasetBuilder
       return Collections.emptyList();
     }
 
-    DataSourceV2Relation target = relation.get();
-    // Run query-plan visitors first so connector extensions can attach their side effects, such as
-    // Iceberg metrics reporter injection. The relation visitor's datasets are deliberately not
-    // combined with the command result, which keeps a single output.
-    delegate(target, event);
-    return DataSourceV2RelationDatasetExtractor.extract(
-        factory, context, target, includeDatasetVersion(event));
+    // Let the relation builder preserve connector-specific outputs when an extension handles the
+    // table and fall back to generic relation extraction otherwise.
+    return delegate(relation.get(), event);
   }
 
   private String streamingWriteClassName(WriteToDataSourceV2 write) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilder.java
@@ -1,0 +1,93 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2;
+import org.apache.spark.sql.execution.streaming.sources.MicroBatchWrite;
+
+/**
+ * Extracts relation-backed output datasets from non-Kafka V2 streaming writes on Spark 3.2 and
+ * newer.
+ *
+ * <p>Kafka remains handled by {@code WriteToDataSourceV2Visitor}. Spark 3.1 does not expose {@link
+ * WriteToDataSourceV2#relation()} and therefore does not register this builder.
+ */
+@Slf4j
+public class WriteToDataSourceV2DatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<WriteToDataSourceV2> {
+
+  private static final String KAFKA_STREAMING_WRITE_CLASS_NAME =
+      "org.apache.spark.sql.kafka010.KafkaStreamingWrite";
+
+  private final DatasetFactory<OpenLineage.OutputDataset> factory;
+
+  public WriteToDataSourceV2DatasetBuilder(
+      OpenLineageContext context, DatasetFactory<OpenLineage.OutputDataset> factory) {
+    super(context, false);
+    this.factory = factory;
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan logicalPlan) {
+    if (!(logicalPlan instanceof WriteToDataSourceV2)) {
+      return false;
+    }
+
+    BatchWrite batchWrite = ((WriteToDataSourceV2) logicalPlan).batchWrite();
+    if (!(batchWrite instanceof MicroBatchWrite)) {
+      return false;
+    }
+
+    StreamingWrite streamingWrite = ((MicroBatchWrite) batchWrite).writeSupport();
+    return streamingWrite != null
+        && !KAFKA_STREAMING_WRITE_CLASS_NAME.equals(streamingWrite.getClass().getCanonicalName());
+  }
+
+  @Override
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, WriteToDataSourceV2 write) {
+    Optional<DataSourceV2Relation> relation = ScalaConversionUtils.asJavaOptional(write.relation());
+    if (!relation.isPresent()) {
+      log.warn(
+          "Cannot extract the output dataset for streaming write '{}' because its WriteToDataSourceV2 relation is empty",
+          streamingWriteClassName(write));
+      return Collections.emptyList();
+    }
+
+    DataSourceV2Relation target = relation.get();
+    // Run query-plan visitors first so connector extensions can attach their side effects, such as
+    // Iceberg metrics reporter injection. The relation visitor's datasets are deliberately not
+    // combined with the command result, which keeps a single output.
+    delegate(target, event);
+    return DataSourceV2RelationDatasetExtractor.extract(
+        factory, context, target, includeDatasetVersion(event));
+  }
+
+  private String streamingWriteClassName(WriteToDataSourceV2 write) {
+    BatchWrite batchWrite = write.batchWrite();
+    if (!(batchWrite instanceof MicroBatchWrite)) {
+      return "unknown";
+    }
+
+    StreamingWrite streamingWrite = ((MicroBatchWrite) batchWrite).writeSupport();
+    return streamingWrite == null ? "unknown" : streamingWrite.getClass().getName();
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilderTest.java
@@ -8,21 +8,24 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
@@ -36,15 +39,18 @@ import org.mockito.MockedStatic;
 
 class WriteToDataSourceV2DatasetBuilderTest {
 
+  private final SparkOpenLineageExtensionVisitorWrapper extensionVisitor =
+      mock(SparkOpenLineageExtensionVisitorWrapper.class);
   private final OpenLineageContext context =
       OpenLineageContext.builder()
           .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
           .meterRegistry(new SimpleMeterRegistry())
           .openLineageConfig(new SparkOpenLineageConfig())
+          .sparkExtensionVisitorWrapper(extensionVisitor)
           .build();
   private final DatasetFactory<OpenLineage.OutputDataset> factory = mock(DatasetFactory.class);
   private final WriteToDataSourceV2DatasetBuilder builder =
-      new WriteToDataSourceV2DatasetBuilder(context, factory);
+      new WriteToDataSourceV2DatasetBuilder(context);
 
   private WriteToDataSourceV2 write;
   private MicroBatchWrite microBatchWrite;
@@ -78,16 +84,41 @@ class WriteToDataSourceV2DatasetBuilderTest {
   }
 
   @Test
-  void extractsOneRelationBackedOutputWithoutCombiningDelegatedOutput() {
+  void preservesAllExtensionProvidedOutputs() {
     SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+    registerRelationBuilder(event);
     DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
-    OpenLineage.OutputDataset output = mock(OpenLineage.OutputDataset.class);
-    WriteToDataSourceV2DatasetBuilder spyBuilder = spy(builder);
+    Table table = mock(Table.class);
+    OpenLineage.OutputDataset firstOutput = mock(OpenLineage.OutputDataset.class);
+    OpenLineage.OutputDataset secondOutput = mock(OpenLineage.OutputDataset.class);
+    List<OpenLineage.OutputDataset> extensionOutputs = Arrays.asList(firstOutput, secondOutput);
 
     when(write.relation()).thenReturn(scala.Option.apply(relation));
-    org.mockito.Mockito.doReturn(Collections.singletonList(output))
-        .when(spyBuilder)
-        .delegate(relation, event);
+    when(relation.table()).thenReturn(table);
+    when(extensionVisitor.isDefinedAt(table)).thenReturn(true);
+    when(extensionVisitor.getOutputs(table, table.getClass().getName()))
+        .thenReturn(ImmutablePair.of(extensionOutputs, Collections.emptyList()));
+
+    try (MockedStatic<DataSourceV2RelationDatasetExtractor> extractor =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      List<OpenLineage.OutputDataset> outputs = builder.apply(event, write);
+
+      assertThat(outputs).containsExactly(firstOutput, secondOutput);
+      extractor.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void extractsOrdinaryRelationExactlyOnceThroughDelegation() {
+    SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+    registerRelationBuilder(event);
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+    Table table = mock(Table.class);
+    OpenLineage.OutputDataset output = mock(OpenLineage.OutputDataset.class);
+
+    when(write.relation()).thenReturn(scala.Option.apply(relation));
+    when(relation.table()).thenReturn(table);
+    when(extensionVisitor.isDefinedAt(table)).thenReturn(false);
 
     try (MockedStatic<DataSourceV2RelationDatasetExtractor> extractor =
         mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
@@ -96,10 +127,10 @@ class WriteToDataSourceV2DatasetBuilderTest {
               () -> DataSourceV2RelationDatasetExtractor.extract(factory, context, relation, true))
           .thenReturn(Collections.singletonList(output));
 
-      List<OpenLineage.OutputDataset> outputs = spyBuilder.apply(event, write);
-
-      assertThat(outputs).containsExactly(output);
-      verify(spyBuilder).delegate(relation, event);
+      assertThat(builder.apply(event, write)).containsExactly(output);
+      extractor.verify(
+          () -> DataSourceV2RelationDatasetExtractor.extract(factory, context, relation, true),
+          times(1));
     }
   }
 
@@ -113,5 +144,13 @@ class WriteToDataSourceV2DatasetBuilderTest {
 
       extractor.verifyNoInteractions();
     }
+  }
+
+  private void registerRelationBuilder(SparkListenerEvent event) {
+    context
+        .getOutputDatasetQueryPlanVisitors()
+        .add(
+            new DataSourceV2RelationOutputDatasetBuilder(context, factory)
+                .asQueryPlanVisitor(event));
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/WriteToDataSourceV2DatasetBuilderTest.java
@@ -1,0 +1,117 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2;
+import org.apache.spark.sql.execution.streaming.sources.MicroBatchWrite;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.kafka010.KafkaStreamingWrite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class WriteToDataSourceV2DatasetBuilderTest {
+
+  private final OpenLineageContext context =
+      OpenLineageContext.builder()
+          .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+          .meterRegistry(new SimpleMeterRegistry())
+          .openLineageConfig(new SparkOpenLineageConfig())
+          .build();
+  private final DatasetFactory<OpenLineage.OutputDataset> factory = mock(DatasetFactory.class);
+  private final WriteToDataSourceV2DatasetBuilder builder =
+      new WriteToDataSourceV2DatasetBuilder(context, factory);
+
+  private WriteToDataSourceV2 write;
+  private MicroBatchWrite microBatchWrite;
+
+  @BeforeEach
+  void setUp() {
+    write = mock(WriteToDataSourceV2.class);
+    microBatchWrite = mock(MicroBatchWrite.class);
+    when(write.batchWrite()).thenReturn(microBatchWrite);
+    when(microBatchWrite.writeSupport()).thenReturn(mock(StreamingWrite.class));
+  }
+
+  @Test
+  void isDefinedForNonKafkaMicroBatchWrite() {
+    assertThat(builder.isDefinedAtLogicalPlan(write)).isTrue();
+  }
+
+  @Test
+  void isNotDefinedForKafkaMicroBatchWrite() {
+    when(microBatchWrite.writeSupport()).thenReturn(new KafkaStreamingWrite());
+
+    assertThat(builder.isDefinedAtLogicalPlan(write)).isFalse();
+  }
+
+  @Test
+  void isNotDefinedForBatchWriteOrOtherPlan() {
+    when(write.batchWrite()).thenReturn(mock(BatchWrite.class));
+
+    assertThat(builder.isDefinedAtLogicalPlan(write)).isFalse();
+    assertThat(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class))).isFalse();
+  }
+
+  @Test
+  void extractsOneRelationBackedOutputWithoutCombiningDelegatedOutput() {
+    SparkListenerEvent event = new SparkListenerSQLExecutionEnd(1L, 1L);
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+    OpenLineage.OutputDataset output = mock(OpenLineage.OutputDataset.class);
+    WriteToDataSourceV2DatasetBuilder spyBuilder = spy(builder);
+
+    when(write.relation()).thenReturn(scala.Option.apply(relation));
+    org.mockito.Mockito.doReturn(Collections.singletonList(output))
+        .when(spyBuilder)
+        .delegate(relation, event);
+
+    try (MockedStatic<DataSourceV2RelationDatasetExtractor> extractor =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      extractor
+          .when(
+              () -> DataSourceV2RelationDatasetExtractor.extract(factory, context, relation, true))
+          .thenReturn(Collections.singletonList(output));
+
+      List<OpenLineage.OutputDataset> outputs = spyBuilder.apply(event, write);
+
+      assertThat(outputs).containsExactly(output);
+      verify(spyBuilder).delegate(relation, event);
+    }
+  }
+
+  @Test
+  void returnsNoOutputForAnEmptyRelation() {
+    when(write.relation()).thenReturn(scala.Option.empty());
+
+    try (MockedStatic<DataSourceV2RelationDatasetExtractor> extractor =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      assertThat(builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), write)).isEmpty();
+
+      extractor.verifyNoInteractions();
+    }
+  }
+}

--- a/integration/spark/spark3/src/test/java/org/apache/spark/sql/kafka010/KafkaStreamingWrite.java
+++ b/integration/spark/spark3/src/test/java/org/apache/spark/sql/kafka010/KafkaStreamingWrite.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.apache.spark.sql.kafka010;
+
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+
+/** Test double with the canonical class name handled by the shared Kafka visitor. */
+public class KafkaStreamingWrite implements StreamingWrite {
+
+  @Override
+  public StreamingDataWriterFactory createStreamingWriterFactory(PhysicalWriteInfo info) {
+    return null;
+  }
+
+  @Override
+  public void commit(long epochId, WriterCommitMessage[] messages) {}
+
+  @Override
+  public void abort(long epochId, WriterCommitMessage[] messages) {}
+}


### PR DESCRIPTION
### One-line summary for changelog:

Spark: emit catalog-aware output datasets for relation-backed structured-streaming writes on Spark 3.2+.

### Meaningful description

Structured Streaming V2 writes currently emit output datasets only for the exact Kafka `StreamingWrite` class. Iceberg exposes `SparkWrite$StreamingAppend`, so OpenLineage reports an unsupported implementation and emits no output even though Spark 3.2+ exposes the target relation on `WriteToDataSourceV2`.

This PR adds a Spark 3.2+ output builder that:

- handles non-Kafka `MicroBatchWrite` plans when Spark provides a target relation
- delegates to the existing relation output builder so connector extension outputs remain authoritative and ordinary relations fall back to `DataSourceV2RelationDatasetExtractor`
- preserves catalog, storage, schema, symlink, and version facets without extracting ordinary relations twice
- preserves the existing Kafka handling and the Spark 3.1 unsupported-warning path
- returns no fabricated output when the relation is absent

The builder is registered for Spark 3.2, 3.3, 3.4, 3.5, and 4.x. This is a focused implementation of the Iceberg sink portion discussed in #4401 without connector-specific reflection.

Validation completed:

- extension-routing coverage verifies that all connector-provided outputs are preserved and generic extraction is skipped
- generic-routing coverage verifies that ordinary relations are extracted exactly once
- Spark3 tests on Scala 2.12 and focused coverage on Scala 2.13, including Kafka exclusion and empty relations
- functional Iceberg streaming regression on Spark 3.2.4, 3.3.4, and 3.5.6
- Spark 4.1, Iceberg 1.11, and Polaris REST lab run produced exactly one Iceberg output per matching raw COMPLETE event with catalog, schema, symlink, storage, and version facets
- full pre-commit suite, Spark PMD, and Spotless checks

The DataHub-oriented aggregate assertions in the Polaris lab cover lifecycle coalescing and downstream naming outside this upstream extraction change.

Related: #3431

### Checklist
- [x] AI was used in creating this PR