### PR TITLE
spark: cache application and catalog metadata

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -23,6 +23,7 @@ import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.client.OpenLineage.RunFacets;
 import io.openlineage.client.OpenLineage.RunFacetsBuilder;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageUtils;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
 import io.openlineage.spark.agent.util.DatasetReducerUtils;
@@ -196,18 +197,24 @@ class OpenLineageRunEventBuilder {
     OpenLineage openLineage = openLineageContext.getOpenLineage();
     List<Object> nodes = context.loadNodes(stageMap, jobMap);
     UUID runId = context.getOverwriteRunId().orElse(openLineageContext.getRunUuid());
+    CatalogUtils.EventCache catalogEventCache = CatalogUtils.newEventCache();
 
     OpenLineage.JobFacets jobFacets =
         timeouter.timeoutJobFacets(
-            () -> buildJobFacets(nodes, jobFacetBuilders, context.getJobFacetsBuilder()));
+            () ->
+                catalogEventCache.call(
+                    () -> buildJobFacets(nodes, jobFacetBuilders, context.getJobFacetsBuilder())));
     List<InputDataset> inputDatasets =
-        timeouter.timeoutInputDatasets(() -> buildInputDatasets(nodes));
+        timeouter.timeoutInputDatasets(
+            () -> catalogEventCache.call(() -> buildInputDatasets(nodes)));
     openLineageContext.getLineageRunStatus().capturedInputs(inputDatasets.size());
     List<OutputDataset> outputDatasets =
-        timeouter.timeoutOutputDatasets(() -> buildOutputDatasets(nodes));
+        timeouter.timeoutOutputDatasets(
+            () -> catalogEventCache.call(() -> buildOutputDatasets(nodes)));
     openLineageContext.getLineageRunStatus().capturedOutputs(outputDatasets.size());
     RunFacets runFacets =
-        timeouter.timeoutRunFacets(() -> buildRunFacets(context, nodes), openLineage);
+        timeouter.timeoutRunFacets(
+            () -> catalogEventCache.call(() -> buildRunFacets(context, nodes)), openLineage);
 
     OpenLineage.RunBuilder runBuilder = openLineage.newRunBuilder().runId(runId).facets(runFacets);
     context

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/catalog/CatalogUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/catalog/CatalogUtils.java
@@ -12,20 +12,35 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 public class CatalogUtils {
 
   private static List<RelationHandler> relationHandlers = getRelationHandlers();
+  private static final ThreadLocal<EventCache> ACTIVE_EVENT_CACHE = new ThreadLocal<>();
 
   private static List<CatalogHandler> getHandlers(OpenLineageContext context) {
-    return context.getDatasetBuilderFactory().getCatalogHandlers(context).stream()
-        .filter(CatalogHandler::hasClasses)
-        .collect(Collectors.toList());
+    Supplier<List<CatalogHandler>> loader =
+        () ->
+            context.getDatasetBuilderFactory().getCatalogHandlers(context).stream()
+                .filter(CatalogHandler::hasClasses)
+                .collect(Collectors.toList());
+    EventCache cache = ACTIVE_EVENT_CACHE.get();
+    return cache == null ? loader.get() : cache.getHandlers(context, loader);
   }
 
   private static List<RelationHandler> getRelationHandlers() {
@@ -66,7 +81,32 @@ public class CatalogUtils {
 
   public static Optional<CatalogHandler> getCatalogHandler(
       OpenLineageContext context, TableCatalog catalog) {
-    return getHandlers(context).stream().filter(handler -> handler.isClass(catalog)).findAny();
+    EventCache cache = ACTIVE_EVENT_CACHE.get();
+    Supplier<Optional<CatalogHandler>> loader =
+        () -> getHandlers(context).stream().filter(handler -> handler.isClass(catalog)).findAny();
+    return cache == null ? loader.get() : cache.getCatalogHandler(context, catalog, loader);
+  }
+
+  /** Returns a new cache whose lifetime must be limited to one OpenLineage event build. */
+  public static EventCache newEventCache() {
+    return new EventCache();
+  }
+
+  /** Loads a Spark table at most once for the active event. */
+  public static Table loadTable(TableCatalog catalog, Identifier identifier)
+      throws NoSuchTableException {
+    return loadTable(catalog, identifier, "spark-table", () -> catalog.loadTable(identifier));
+  }
+
+  /**
+   * Loads an arbitrary catalog representation at most once for the active event. The operation name
+   * distinguishes multiple representations of the same table, such as Spark and Iceberg tables.
+   */
+  @SneakyThrows
+  public static <T> T loadTable(
+      TableCatalog catalog, Identifier identifier, String operation, Callable<T> loader) {
+    EventCache cache = ACTIVE_EVENT_CACHE.get();
+    return cache == null ? loader.call() : cache.load(catalog, identifier, operation, loader);
   }
 
   public static DatasetIdentifier getDatasetIdentifierFromRelation(DataSourceV2Relation relation) {
@@ -129,5 +169,142 @@ public class CatalogUtils {
     return catalogHandler.isPresent()
         ? catalogHandler.get().getDatasetVersion(catalog, identifier, properties)
         : Optional.empty();
+  }
+
+  /** Per-event handler and loaded-table cache. */
+  public static final class EventCache {
+    private final Map<IdentityKey<OpenLineageContext>, List<CatalogHandler>> handlers =
+        new ConcurrentHashMap<>();
+    private final Map<HandlerKey, Optional<CatalogHandler>> catalogHandlers =
+        new ConcurrentHashMap<>();
+    private final Map<TableLoadKey, Future<Object>> loadedTables = new ConcurrentHashMap<>();
+
+    /** Executes one event-build phase with this cache active on the calling thread. */
+    @SneakyThrows
+    public <T> T call(Callable<T> callable) {
+      EventCache previous = ACTIVE_EVENT_CACHE.get();
+      ACTIVE_EVENT_CACHE.set(this);
+      try {
+        return callable.call();
+      } finally {
+        if (previous == null) {
+          ACTIVE_EVENT_CACHE.remove();
+        } else {
+          ACTIVE_EVENT_CACHE.set(previous);
+        }
+      }
+    }
+
+    private List<CatalogHandler> getHandlers(
+        OpenLineageContext context, Supplier<List<CatalogHandler>> loader) {
+      return handlers.computeIfAbsent(new IdentityKey<>(context), ignored -> loader.get());
+    }
+
+    private Optional<CatalogHandler> getCatalogHandler(
+        OpenLineageContext context,
+        TableCatalog catalog,
+        Supplier<Optional<CatalogHandler>> loader) {
+      return catalogHandlers.computeIfAbsent(
+          new HandlerKey(context, catalog), ignored -> loader.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    @SneakyThrows
+    private <T> T load(
+        TableCatalog catalog, Identifier identifier, String operation, Callable<T> loader) {
+      TableLoadKey key = new TableLoadKey(catalog, identifier, operation);
+      Future<Object> future = loadedTables.get(key);
+      if (future == null) {
+        FutureTask<Object> newFuture = new FutureTask<>(loader::call);
+        future = loadedTables.putIfAbsent(key, newFuture);
+        if (future == null) {
+          future = newFuture;
+          newFuture.run();
+        }
+      }
+
+      try {
+        return (T) future.get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw e;
+      } catch (ExecutionException e) {
+        throw e.getCause();
+      }
+    }
+  }
+
+  private static final class IdentityKey<T> {
+    private final T value;
+
+    private IdentityKey(T value) {
+      this.value = value;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals") // cache keys intentionally use identity
+    public boolean equals(Object other) {
+      return other instanceof IdentityKey && value == ((IdentityKey<?>) other).value;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(value);
+    }
+  }
+
+  private static final class HandlerKey {
+    private final OpenLineageContext context;
+    private final TableCatalog catalog;
+
+    private HandlerKey(OpenLineageContext context, TableCatalog catalog) {
+      this.context = context;
+      this.catalog = catalog;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals") // cache keys intentionally use identity
+    public boolean equals(Object other) {
+      if (!(other instanceof HandlerKey)) {
+        return false;
+      }
+      HandlerKey that = (HandlerKey) other;
+      return context == that.context && catalog == that.catalog;
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * System.identityHashCode(context) + System.identityHashCode(catalog);
+    }
+  }
+
+  private static final class TableLoadKey {
+    private final TableCatalog catalog;
+    private final String identifier;
+    private final String operation;
+
+    private TableLoadKey(TableCatalog catalog, Identifier identifier, String operation) {
+      this.catalog = catalog;
+      this.identifier =
+          String.join("\u0000", identifier.namespace()) + "\u0000" + identifier.name();
+      this.operation = operation;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals") // cache keys intentionally use identity
+    public boolean equals(Object other) {
+      if (!(other instanceof TableLoadKey)) {
+        return false;
+      }
+      TableLoadKey that = (TableLoadKey) other;
+      return catalog == that.catalog
+          && identifier.equals(that.identifier)
+          && operation.equals(that.operation);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(System.identityHashCode(catalog), identifier, operation);
+    }
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ApplicationMetadataCache.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ApplicationMetadataCache.java
@@ -1,0 +1,142 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import lombok.SneakyThrows;
+import org.apache.spark.SparkContext;
+
+/**
+ * Stores metadata that is stable for the lifetime of one Spark application.
+ *
+ * <p>The registry is keyed by {@link SparkContext}, rather than globally by cloud provider, so
+ * sequential Spark applications in the same JVM cannot reuse one another's cloud identity. Weak
+ * keys allow stopped contexts to be collected; cached values must therefore not retain the Spark
+ * context itself.
+ */
+public final class ApplicationMetadataCache {
+
+  private static final Map<SparkContext, ApplicationMetadataCache> APPLICATION_CACHES =
+      new WeakHashMap<>();
+
+  private final Map<String, CacheEntry> values = new ConcurrentHashMap<>();
+
+  public static ApplicationMetadataCache forSparkContext(SparkContext sparkContext) {
+    Objects.requireNonNull(sparkContext, "sparkContext");
+    synchronized (APPLICATION_CACHES) {
+      return APPLICATION_CACHES.computeIfAbsent(
+          sparkContext, ignored -> new ApplicationMetadataCache());
+    }
+  }
+
+  /** Removes an application's cached metadata immediately, primarily for deterministic teardown. */
+  public static void invalidate(SparkContext sparkContext) {
+    synchronized (APPLICATION_CACHES) {
+      APPLICATION_CACHES.remove(sparkContext);
+    }
+  }
+
+  /**
+   * Returns the cached value or computes it once. Values such as {@code Optional.empty()} are
+   * cached, allowing callers to represent a definitive negative lookup without retrying it for
+   * every event.
+   */
+  @SuppressWarnings("unchecked")
+  @SneakyThrows
+  public <T> T get(String key, Supplier<T> loader) {
+    return get(key, loader, value -> Long.MAX_VALUE);
+  }
+
+  /**
+   * Caches a present value for the application lifetime and an unavailable value for a bounded
+   * interval. This avoids retrying transient cloud-service failures for every event without making
+   * a temporary failure permanent.
+   */
+  public <T> Optional<T> getOptional(
+      String key, Supplier<Optional<T>> loader, Duration negativeTtl) {
+    Objects.requireNonNull(negativeTtl, "negativeTtl");
+    return get(
+        key,
+        loader,
+        value ->
+            ((Optional<?>) value).isPresent()
+                ? Long.MAX_VALUE
+                : System.nanoTime() + Math.max(0L, negativeTtl.toNanos()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @SneakyThrows
+  private <T> T get(String key, Supplier<T> loader, ToLongFunction<Object> expiration) {
+    Objects.requireNonNull(key, "key");
+    Objects.requireNonNull(loader, "loader");
+
+    CacheEntry entry;
+    boolean retry;
+    do {
+      retry = false;
+      entry = values.get(key);
+      if (entry != null && entry.isExpired()) {
+        values.remove(key, entry);
+        retry = true;
+      } else if (entry == null) {
+        CacheEntry newEntry = new CacheEntry(loader, expiration);
+        entry = values.putIfAbsent(key, newEntry);
+        if (entry == null) {
+          entry = newEntry;
+          newEntry.run();
+        } else if (entry.isExpired()) {
+          retry = true;
+        }
+      }
+    } while (retry);
+
+    try {
+      return (T) entry.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw e;
+    } catch (ExecutionException e) {
+      values.remove(key, entry);
+      throw e.getCause();
+    }
+  }
+
+  private static final class CacheEntry {
+    private final FutureTask<Object> future;
+    private volatile long expiresAt = Long.MAX_VALUE;
+
+    private <T> CacheEntry(Supplier<T> loader, ToLongFunction<Object> expiration) {
+      future =
+          new FutureTask<>(
+              () -> {
+                T value = loader.get();
+                expiresAt = expiration.applyAsLong(value);
+                return value;
+              });
+    }
+
+    private void run() {
+      future.run();
+    }
+
+    private Object get() throws InterruptedException, ExecutionException {
+      return future.get();
+    }
+
+    private boolean isExpired() {
+      return future.isDone() && System.nanoTime() >= expiresAt;
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsAccountIdFetcher.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsAccountIdFetcher.java
@@ -5,8 +5,11 @@
 
 package io.openlineage.spark.agent.util;
 
+import java.time.Duration;
+import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
@@ -20,21 +23,42 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 @Slf4j
 @UtilityClass
 public class AwsAccountIdFetcher {
-  private static String accountId;
+  private static final String ACCOUNT_ID_CACHE_KEY = "aws.sts.account-id";
+  private static final Duration NEGATIVE_CACHE_TTL = Duration.ofMinutes(1);
+  private static final ApplicationMetadataCache PROCESS_CACHE = new ApplicationMetadataCache();
 
   public static String getAccountId() {
-    if (accountId == null) {
-      log.info("Building STS client.");
-      try (StsClient stsClient =
-          StsClient.builder().httpClient(UrlConnectionHttpClient.builder().build()).build()) {
-        GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
-        GetCallerIdentityResponse response = stsClient.getCallerIdentity(request);
-        accountId = response.account();
-        log.info("Retrieved account ID [{}].", accountId);
-      }
-    } else {
-      log.debug("Using cached account ID [{}].", accountId);
+    return PROCESS_CACHE.get(ACCOUNT_ID_CACHE_KEY, AwsAccountIdFetcher::fetchAccountId);
+  }
+
+  public static String getAccountId(SparkContext sparkContext) {
+    return getAccountIdOptional(sparkContext).orElse(null);
+  }
+
+  public static Optional<String> getAccountIdOptional(SparkContext sparkContext) {
+    return ApplicationMetadataCache.forSparkContext(sparkContext)
+        .getOptional(
+            ACCOUNT_ID_CACHE_KEY,
+            () -> {
+              try {
+                return Optional.ofNullable(fetchAccountId());
+              } catch (Exception e) {
+                log.warn("Unable to retrieve AWS account ID.", e);
+                return Optional.empty();
+              }
+            },
+            NEGATIVE_CACHE_TTL);
+  }
+
+  private static String fetchAccountId() {
+    log.info("Building STS client.");
+    try (StsClient stsClient =
+        StsClient.builder().httpClient(UrlConnectionHttpClient.builder().build()).build()) {
+      GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+      GetCallerIdentityResponse response = stsClient.getCallerIdentity(request);
+      String accountId = response.account();
+      log.info("Retrieved account ID [{}].", accountId);
+      return accountId;
     }
-    return accountId;
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
@@ -9,12 +9,15 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.jetbrains.annotations.NotNull;
 
 @Slf4j
@@ -28,13 +31,47 @@ public class AwsUtils {
   private static final String HIVE_METASTORE_GLUE_CATALOG_ID_KEY = "hive.metastore.glue.catalogid";
   private static final String SPARK_SQL_CATALOG_PREFIX = "spark.sql.catalog.";
   private static final String GLUE_CATALOG_SUFFIX = "GlueCatalog";
+  private static final String AWS_REGION_CACHE_KEY = "aws.imds.region";
+  private static final String GLUE_ARN_CACHE_KEY = "aws.glue.catalog-arn";
+  private static final Duration NEGATIVE_CACHE_TTL = Duration.ofMinutes(1);
 
   public static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
+    return getGlueArn(
+        sparkConf,
+        hadoopConf,
+        AwsUtils::awsRegion,
+        () -> Optional.ofNullable(AwsAccountIdFetcher.getAccountId()));
+  }
+
+  public static Optional<String> getGlueArn(SparkContext sparkContext) {
+    SparkConf sparkConf = sparkContext.getConf();
+    Configuration hadoopConf = sparkContext.hadoopConfiguration();
+    if (!isHiveUsingGlue(sparkConf, hadoopConf) && !isIcebergUsingGlue(sparkConf)) {
+      return Optional.empty();
+    }
+    return ApplicationMetadataCache.forSparkContext(sparkContext)
+        .getOptional(
+            GLUE_ARN_CACHE_KEY,
+            () ->
+                getGlueArn(
+                    sparkConf,
+                    hadoopConf,
+                    () -> awsRegion(sparkContext),
+                    () -> AwsAccountIdFetcher.getAccountIdOptional(sparkContext)),
+            NEGATIVE_CACHE_TTL);
+  }
+
+  private static Optional<String> getGlueArn(
+      SparkConf sparkConf,
+      Configuration hadoopConf,
+      Supplier<Optional<String>> regionSupplier,
+      Supplier<Optional<String>> accountIdSupplier) {
     if (isHiveUsingGlue(sparkConf, hadoopConf) || isIcebergUsingGlue(sparkConf)) {
-      return awsRegion()
+      return regionSupplier
+          .get()
           .flatMap(
               region ->
-                  getGlueCatalogId(sparkConf, hadoopConf)
+                  getGlueCatalogId(sparkConf, hadoopConf, accountIdSupplier)
                       .map(glueCatalogId -> "arn:aws:glue:" + region + ":" + glueCatalogId));
     } else {
       return Optional.empty();
@@ -48,7 +85,7 @@ public class AwsUtils {
    * where the application is running and optional, extra configuration.
    */
   private static @NotNull Optional<String> getGlueCatalogId(
-      SparkConf sparkConf, Configuration hadoopConf) {
+      SparkConf sparkConf, Configuration hadoopConf, Supplier<Optional<String>> accountIdSupplier) {
     /*
     The ID of the Glue catalog can be specified explicitly. If it is not, then the account ID of the current account
     is used.
@@ -75,7 +112,7 @@ public class AwsUtils {
     } else {
       log.debug("Fetching current account ID to use as the catalog ID.");
       try {
-        return Optional.ofNullable(AwsAccountIdFetcher.getAccountId());
+        return accountIdSupplier.get();
       } catch (Exception e) {
         log.warn("Unable to retrieve AWS account ID to build Glue catalog ARN.", e);
         return Optional.empty();
@@ -131,6 +168,11 @@ public class AwsUtils {
       log.debug("Failed to get region from EC2 metadata service", e);
       return Optional.empty();
     }
+  }
+
+  public static @NotNull Optional<String> awsRegion(SparkContext sparkContext) {
+    return ApplicationMetadataCache.forSparkContext(sparkContext)
+        .getOptional(AWS_REGION_CACHE_KEY, AwsUtils::awsRegion, NEGATIVE_CACHE_TTL);
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -81,7 +81,7 @@ public class PathUtils {
     Configuration hadoopConf = sparkContext.hadoopConfiguration();
 
     Optional<URI> metastoreUri = getMetastoreUri(sparkContext);
-    Optional<String> glueArn = AwsUtils.getGlueArn(sparkConf, hadoopConf);
+    Optional<String> glueArn = AwsUtils.getGlueArn(sparkContext);
     if (glueArn.isPresent()) {
       // Even if glue catalog is used, it will have a hive metastore URI
       // Use ARN format 'arn:aws:glue:{region}:{account_id}:table/{database}/{table}'

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/S3TablesUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/S3TablesUtils.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.agent.util;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.Value;
@@ -15,6 +16,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 
 /**
  * Utilities for detecting and building dataset identifiers for AWS S3 Tables. S3 Tables can be
@@ -109,7 +111,23 @@ public class S3TablesUtils {
   public static String buildS3TablesArnFromCatalogConf(
       SparkConf sparkConf, Configuration hadoopConf, Map<String, String> catalogConf) {
     Optional<BucketInfo> info = extractBucketFromCatalogConf(catalogConf);
-    return composeArn(sparkConf, hadoopConf, info);
+    return composeArn(
+        sparkConf,
+        hadoopConf,
+        info,
+        AwsUtils::awsRegion,
+        () -> Optional.ofNullable(AwsAccountIdFetcher.getAccountId()));
+  }
+
+  public static String buildS3TablesArnFromCatalogConf(
+      SparkContext sparkContext, Map<String, String> catalogConf) {
+    Optional<BucketInfo> info = extractBucketFromCatalogConf(catalogConf);
+    return composeArn(
+        sparkContext.getConf(),
+        sparkContext.hadoopConfiguration(),
+        info,
+        () -> AwsUtils.awsRegion(sparkContext),
+        () -> AwsAccountIdFetcher.getAccountIdOptional(sparkContext));
   }
 
   // ----- internals -----
@@ -135,10 +153,14 @@ public class S3TablesUtils {
   }
 
   private static String composeArn(
-      SparkConf sparkConf, Configuration hadoopConf, Optional<BucketInfo> info) {
+      SparkConf sparkConf,
+      Configuration hadoopConf,
+      Optional<BucketInfo> info,
+      Supplier<Optional<String>> regionSupplier,
+      Supplier<Optional<String>> accountIdSupplier) {
     Optional<String> resolvedRegion = info.flatMap(b -> b.region);
     if (!resolvedRegion.isPresent()) {
-      resolvedRegion = AwsUtils.awsRegion();
+      resolvedRegion = regionSupplier.get();
     }
     if (!resolvedRegion.isPresent()) {
       log.warn("Unable to resolve AWS region for S3 Tables namespace; using 'unknown'.");
@@ -146,7 +168,7 @@ public class S3TablesUtils {
 
     Optional<String> resolvedAccount = info.flatMap(b -> b.account);
     if (!resolvedAccount.isPresent()) {
-      resolvedAccount = resolveAccountId(sparkConf, hadoopConf);
+      resolvedAccount = resolveAccountId(sparkConf, hadoopConf, accountIdSupplier);
     }
     if (!resolvedAccount.isPresent()) {
       log.warn("Unable to resolve AWS account ID for S3 Tables namespace; using 'unknown'.");
@@ -160,7 +182,8 @@ public class S3TablesUtils {
     return info.map(b -> prefix + ":bucket/" + b.bucketName).orElse(prefix);
   }
 
-  private static Optional<String> resolveAccountId(SparkConf sparkConf, Configuration hadoopConf) {
+  private static Optional<String> resolveAccountId(
+      SparkConf sparkConf, Configuration hadoopConf, Supplier<Optional<String>> accountIdSupplier) {
     // Mirror the order AwsUtils.getGlueCatalogId uses: explicit catalog id wins, then EMR/Glue job
     // account, then STS. Keeps behavior consistent across V1/V2 paths and avoids a network call in
     // test environments that set the account explicitly.
@@ -184,7 +207,7 @@ public class S3TablesUtils {
       }
     }
     try {
-      return Optional.ofNullable(AwsAccountIdFetcher.getAccountId());
+      return accountIdSupplier.get();
     } catch (Exception e) {
       log.debug("Could not retrieve AWS account ID", e);
       return Optional.empty();

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilderTest.java
@@ -9,17 +9,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.JobFacetsBuilder;
+import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunFacetsBuilder;
 import io.openlineage.client.circuitBreaker.TimeoutCircuitBreakerConfig;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.facets.DebugRunFacet;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
@@ -32,6 +36,9 @@ import java.util.UUID;
 import lombok.SneakyThrows;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -141,5 +148,53 @@ class OpenLineageRunEventBuilderTest {
 
     // test that the debug facet contains the timeout message
     assertThat(facet.getLogs().get(0)).startsWith("Incomplete lineage:");
+  }
+
+  @Test
+  void testCatalogLoadsAreSharedWithinEachEventAndRefreshedBetweenEvents() throws Exception {
+    TableCatalog catalog = mock(TableCatalog.class);
+    Identifier identifier = Identifier.of(new String[] {"namespace"}, "table");
+    Table table = mock(Table.class);
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    PartialFunction<Object, List<InputDataset>> inputBuilder =
+        new PartialFunction<Object, List<InputDataset>>() {
+          @Override
+          @SneakyThrows
+          public List<InputDataset> apply(Object ignored) {
+            CatalogUtils.loadTable(catalog, identifier);
+            return Collections.emptyList();
+          }
+
+          @Override
+          public boolean isDefinedAt(Object ignored) {
+            return true;
+          }
+        };
+    PartialFunction<Object, List<OutputDataset>> outputBuilder =
+        new PartialFunction<Object, List<OutputDataset>>() {
+          @Override
+          @SneakyThrows
+          public List<OutputDataset> apply(Object ignored) {
+            CatalogUtils.loadTable(catalog, identifier);
+            return Collections.emptyList();
+          }
+
+          @Override
+          public boolean isDefinedAt(Object ignored) {
+            return true;
+          }
+        };
+    when(openLineageEventHandlerFactory.createInputDatasetBuilder(openLineageContext))
+        .thenReturn(Collections.singletonList(inputBuilder));
+    when(openLineageEventHandlerFactory.createOutputDatasetBuilder(openLineageContext))
+        .thenReturn(Collections.singletonList(outputBuilder));
+
+    OpenLineageRunEventBuilder builder =
+        new OpenLineageRunEventBuilder(openLineageContext, openLineageEventHandlerFactory);
+    builder.buildRun(runEventContext);
+    builder.buildRun(runEventContext);
+
+    verify(catalog, times(2)).loadTable(identifier);
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/catalog/CatalogUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/catalog/CatalogUtilsTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.Test;
 import scala.PartialFunction;
@@ -158,5 +161,43 @@ class CatalogUtilsTest {
                 mock(Identifier.class),
                 new HashMap<>(),
                 Arrays.asList(catalogHandler)));
+  }
+
+  @Test
+  void testEventCacheResolvesHandlerAndLoadsTableOncePerEvent() throws Exception {
+    CatalogHandler handler = mock(CatalogHandler.class);
+    when(handler.hasClasses()).thenReturn(true);
+    when(handler.isClass(any())).thenReturn(true);
+    OpenLineageContext context = contextWithHandlers(handler);
+    TableCatalog catalog = mock(TableCatalog.class);
+    Identifier identifier = Identifier.of(new String[] {"namespace"}, "table");
+    Table table = mock(Table.class);
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    CatalogUtils.EventCache firstEvent = CatalogUtils.newEventCache();
+    firstEvent.call(
+        () -> {
+          assertEquals(handler, CatalogUtils.getCatalogHandler(context, catalog).get());
+          assertEquals(handler, CatalogUtils.getCatalogHandler(context, catalog).get());
+          assertEquals(table, CatalogUtils.loadTable(catalog, identifier));
+          assertEquals(table, CatalogUtils.loadTable(catalog, identifier));
+          return null;
+        });
+
+    verify(handler, times(1)).hasClasses();
+    verify(handler, times(1)).isClass(catalog);
+    verify(catalog, times(1)).loadTable(identifier);
+
+    CatalogUtils.newEventCache()
+        .call(
+            () -> {
+              assertEquals(handler, CatalogUtils.getCatalogHandler(context, catalog).get());
+              assertEquals(table, CatalogUtils.loadTable(catalog, identifier));
+              return null;
+            });
+
+    verify(handler, times(2)).hasClasses();
+    verify(handler, times(2)).isClass(catalog);
+    verify(catalog, times(2)).loadTable(identifier);
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/ApplicationMetadataCacheTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/ApplicationMetadataCacheTest.java
@@ -1,0 +1,123 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.spark.SparkContext;
+import org.junit.jupiter.api.Test;
+
+class ApplicationMetadataCacheTest {
+  private static final String POSITIVE = "positive";
+  private static final String NEGATIVE = "negative";
+  private static final String VALUE_PREFIX = "value-";
+  private static final String FIRST_VALUE = "value-1";
+
+  @Test
+  void cachesPositiveAndNegativeValuesPerSparkApplication() {
+    SparkContext firstContext = mock(SparkContext.class);
+    SparkContext secondContext = mock(SparkContext.class);
+    AtomicInteger positiveLoads = new AtomicInteger();
+    AtomicInteger negativeLoads = new AtomicInteger();
+
+    ApplicationMetadataCache first = ApplicationMetadataCache.forSparkContext(firstContext);
+    assertThat(first.get(POSITIVE, () -> VALUE_PREFIX + positiveLoads.incrementAndGet()))
+        .isEqualTo(FIRST_VALUE);
+    assertThat(first.get(POSITIVE, () -> VALUE_PREFIX + positiveLoads.incrementAndGet()))
+        .isEqualTo(FIRST_VALUE);
+    assertThat(first.get(NEGATIVE, () -> negativeValue(negativeLoads))).isEmpty();
+    assertThat(first.get(NEGATIVE, () -> negativeValue(negativeLoads))).isEmpty();
+
+    ApplicationMetadataCache second = ApplicationMetadataCache.forSparkContext(secondContext);
+    assertThat(second.get(POSITIVE, () -> VALUE_PREFIX + positiveLoads.incrementAndGet()))
+        .isEqualTo("value-2");
+
+    assertThat(positiveLoads).hasValue(2);
+    assertThat(negativeLoads).hasValue(1);
+  }
+
+  @Test
+  void computesAValueOnceWhenReadersAreConcurrent() throws Exception {
+    SparkContext sparkContext = mock(SparkContext.class);
+    ApplicationMetadataCache cache = ApplicationMetadataCache.forSparkContext(sparkContext);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch loaderStarted = new CountDownLatch(1);
+    CountDownLatch releaseLoader = new CountDownLatch(1);
+    AtomicInteger loads = new AtomicInteger();
+
+    try {
+      Future<String> first =
+          executor.submit(
+              () ->
+                  cache.get(
+                      "concurrent",
+                      () -> {
+                        loads.incrementAndGet();
+                        loaderStarted.countDown();
+                        await(releaseLoader);
+                        return "value";
+                      }));
+      loaderStarted.await();
+      Future<String> second = executor.submit(() -> cache.get("concurrent", () -> "other"));
+      releaseLoader.countDown();
+
+      assertThat(first.get()).isEqualTo("value");
+      assertThat(second.get()).isEqualTo("value");
+      assertThat(loads).hasValue(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void expiresOnlyNegativeOptionalValues() {
+    ApplicationMetadataCache cache = new ApplicationMetadataCache();
+    AtomicInteger negativeLoads = new AtomicInteger();
+    AtomicInteger positiveLoads = new AtomicInteger();
+
+    assertThat(cache.getOptional(NEGATIVE, () -> negativeValue(negativeLoads), Duration.ZERO))
+        .isEmpty();
+    assertThat(cache.getOptional(NEGATIVE, () -> negativeValue(negativeLoads), Duration.ZERO))
+        .isEmpty();
+    assertThat(
+            cache.getOptional(
+                POSITIVE,
+                () -> Optional.of(VALUE_PREFIX + positiveLoads.incrementAndGet()),
+                Duration.ZERO))
+        .contains(FIRST_VALUE);
+    assertThat(
+            cache.getOptional(
+                POSITIVE,
+                () -> Optional.of(VALUE_PREFIX + positiveLoads.incrementAndGet()),
+                Duration.ZERO))
+        .contains(FIRST_VALUE);
+
+    assertThat(negativeLoads).hasValue(2);
+    assertThat(positiveLoads).hasValue(1);
+  }
+
+  private static Optional<String> negativeValue(AtomicInteger loads) {
+    loads.incrementAndGet();
+    return Optional.empty();
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/AwsUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/AwsUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.mockito.MockedStatic;
+
+class AwsUtilsTest {
+
+  private SparkContext sparkContext;
+
+  @AfterEach
+  void tearDown() {
+    if (sparkContext != null) {
+      ApplicationMetadataCache.invalidate(sparkContext);
+    }
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void cachesGlueCatalogIdentityForTheApplication() {
+    sparkContext = glueSparkContext();
+
+    try (MockedStatic<AwsAccountIdFetcher> accountIdFetcher =
+        mockStatic(AwsAccountIdFetcher.class)) {
+      accountIdFetcher
+          .when(() -> AwsAccountIdFetcher.getAccountIdOptional(sparkContext))
+          .thenReturn(Optional.of("123456789012"));
+
+      assertThat(AwsUtils.getGlueArn(sparkContext))
+          .contains("arn:aws:glue:eu-central-1:123456789012");
+      assertThat(AwsUtils.getGlueArn(sparkContext))
+          .contains("arn:aws:glue:eu-central-1:123456789012");
+
+      accountIdFetcher.verify(
+          () -> AwsAccountIdFetcher.getAccountIdOptional(sparkContext), times(1));
+    }
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void cachesUnavailableGlueCatalogIdentityForTheApplication() {
+    sparkContext = glueSparkContext();
+
+    try (MockedStatic<AwsAccountIdFetcher> accountIdFetcher =
+        mockStatic(AwsAccountIdFetcher.class)) {
+      accountIdFetcher
+          .when(() -> AwsAccountIdFetcher.getAccountIdOptional(sparkContext))
+          .thenReturn(Optional.empty());
+
+      assertThat(AwsUtils.getGlueArn(sparkContext)).isEmpty();
+      assertThat(AwsUtils.getGlueArn(sparkContext)).isEmpty();
+
+      accountIdFetcher.verify(
+          () -> AwsAccountIdFetcher.getAccountIdOptional(sparkContext), times(1));
+    }
+  }
+
+  private static SparkContext glueSparkContext() {
+    SparkConf sparkConf = new SparkConf();
+    Configuration hadoopConf = new Configuration();
+    hadoopConf.set(
+        AwsUtils.HIVE_METASTORE_CLIENT_FACTORY_CLASS, AwsUtils.AWS_GLUE_HIVE_FACTORY_CLASS);
+    SparkContext context = mock(SparkContext.class);
+    when(context.getConf()).thenReturn(sparkConf);
+    when(context.hadoopConfiguration()).thenReturn(hadoopConf);
+    return context;
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
@@ -7,6 +7,7 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -91,7 +92,7 @@ public abstract class AbstractDatabricksHandler implements CatalogHandler {
     if (!location.isPresent()) {
       try {
         location =
-            Optional.ofNullable(tableCatalog.loadTable(identifier))
+            Optional.ofNullable(CatalogUtils.loadTable(tableCatalog, identifier))
                 .map(t -> t.properties())
                 .filter(p -> p.containsKey("location"))
                 .map(p -> p.get("location"));

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -9,6 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -56,6 +57,7 @@ public class DeltaHandler implements CatalogHandler {
   }
 
   @Override
+  @SneakyThrows
   public DatasetIdentifier getDatasetIdentifier(
       SparkSession session,
       TableCatalog tableCatalog,
@@ -63,7 +65,7 @@ public class DeltaHandler implements CatalogHandler {
       Map<String, String> properties) {
     DeltaCatalog catalog = (DeltaCatalog) tableCatalog;
 
-    Table table = catalog.loadTable(identifier);
+    Table table = CatalogUtils.loadTable(catalog, identifier);
     if (catalog.isPathIdentifier(identifier)) {
       // no information in metastore, only path
       Path path = new Path(identifier.name());
@@ -127,7 +129,7 @@ public class DeltaHandler implements CatalogHandler {
   public Optional<String> getDatasetVersion(
       TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
     DeltaCatalog deltaCatalog = (DeltaCatalog) tableCatalog;
-    return DeltaVersionUtils.getDatasetVersion(deltaCatalog.loadTable(identifier));
+    return DeltaVersionUtils.getDatasetVersion(CatalogUtils.loadTable(deltaCatalog, identifier));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,7 +86,7 @@ abstract class BaseCatalogTypeHandler {
       if (tableCatalog instanceof SparkCatalog) {
         SparkCatalog sparkCatalog = (SparkCatalog) tableCatalog;
         org.apache.spark.sql.connector.catalog.Table loadedTable =
-            sparkCatalog.loadTable(identifier);
+            CatalogUtils.loadTable(sparkCatalog, identifier);
 
         // Handle different table implementations safely
         if (loadedTable instanceof SparkTable) {
@@ -119,7 +120,12 @@ abstract class BaseCatalogTypeHandler {
       } else if (tableCatalog instanceof SparkSessionCatalog) {
         TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
         SparkSessionCatalog sparkCatalog = (SparkSessionCatalog) tableCatalog;
-        return Optional.ofNullable(sparkCatalog.icebergCatalog().loadTable(tableIdentifier));
+        return Optional.ofNullable(
+            CatalogUtils.loadTable(
+                tableCatalog,
+                identifier,
+                "iceberg-table",
+                () -> sparkCatalog.icebergCatalog().loadTable(tableIdentifier)));
       } else {
         log.warn(
             "Unknown catalog type: {} for identifier: {}. Expected SparkCatalog or SparkSessionCatalog.",

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
@@ -48,8 +48,7 @@ class GlueCatalogTypeHandler extends BaseCatalogTypeHandler {
   Optional<DatasetIdentifier.Symlink> getSymlinkIdentifiers(
       SparkSession session, Map<String, String> catalogConf, String table) {
     SparkContext sparkContext = session.sparkContext();
-    Optional<String> arn =
-        AwsUtils.getGlueArn(sparkContext.getConf(), sparkContext.hadoopConfiguration());
+    Optional<String> arn = AwsUtils.getGlueArn(sparkContext);
     if (!arn.isPresent()) {
       log.warn("Glue catalog ARN is unavailable; omitting Glue table symlink for table {}.", table);
     }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/S3TablesCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/S3TablesCatalogTypeHandler.java
@@ -55,9 +55,7 @@ class S3TablesCatalogTypeHandler extends BaseCatalogTypeHandler {
     nameBuilder.append('.').append(identifier.name());
 
     SparkContext ctx = session.sparkContext();
-    String ns =
-        S3TablesUtils.buildS3TablesArnFromCatalogConf(
-            ctx.getConf(), ctx.hadoopConfiguration(), catalogConf);
+    String ns = S3TablesUtils.buildS3TablesArnFromCatalogConf(ctx, catalogConf);
     DatasetIdentifier di = new DatasetIdentifier(nameBuilder.toString(), ns);
     getTableLocation(identifier, tableCatalog)
         .ifPresent(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/UnityCatalogTableDatasetUtils.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.utils;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.agent.util.SparkSessionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -69,7 +70,7 @@ public final class UnityCatalogTableDatasetUtils {
     TableCatalog tableCatalog = (TableCatalog) catalogPlugin.get();
     Identifier v2Identifier = Identifier.of(new String[] {schema}, table);
     try {
-      Table loadedTable = tableCatalog.loadTable(v2Identifier);
+      Table loadedTable = CatalogUtils.loadTable(tableCatalog, v2Identifier);
       Map<String, String> properties = loadedTable.properties();
       Optional<DatasetIdentifier> datasetIdentifier =
           datasetIdentifier(context, tableCatalog, v2Identifier, properties);

--- a/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -64,7 +64,7 @@ public class AlterTableCommandDatasetBuilder
     Table table;
     try {
       // resolvedTable has only old metadata (before alter)
-      table = resolvedTable.catalog().loadTable(resolvedTable.identifier());
+      table = CatalogUtils.loadTable(resolvedTable.catalog(), resolvedTable.identifier());
     } catch (NoSuchTableException e) {
       return Collections.emptyList();
     }

--- a/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/catalog/UnityCatalogHandler.java
+++ b/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/catalog/UnityCatalogHandler.java
@@ -9,6 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogHandler;
+import io.openlineage.spark.agent.lifecycle.plan.catalog.CatalogUtils;
 import io.openlineage.spark.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -73,7 +74,7 @@ public class UnityCatalogHandler implements CatalogHandler {
 
     Table table;
     try {
-      table = tableCatalog.loadTable(identifier);
+      table = CatalogUtils.loadTable(tableCatalog, identifier);
     } catch (NoSuchTableException e) {
       log.error("Failed to get dataset identifier because table {} doesn't exist", identifier, e);
       throw new RuntimeException(e);
@@ -158,7 +159,7 @@ public class UnityCatalogHandler implements CatalogHandler {
   @Override
   public Optional<String> getDatasetVersion(
       TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
-    Table table = tableCatalog.loadTable(identifier);
+    Table table = CatalogUtils.loadTable(tableCatalog, identifier);
     if (table instanceof DeltaTableV2) {
       return DeltaVersionUtils.getDatasetVersion(table);
     } else {

--- a/integration/spark/spark40/src/test/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
+++ b/integration/spark/spark40/src/test/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
@@ -122,6 +122,7 @@ class AlterTableCommandDatasetBuilderTest {
     when(tableCatalog.loadTable(identifier)).thenReturn(table);
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       try (MockedStatic mockCatalog = mockStatic(CatalogUtils.class)) {
+        when(CatalogUtils.loadTable(tableCatalog, identifier)).thenReturn(table);
         when(CatalogUtils.getDatasetVersion(
                 openLineageContext, tableCatalog, identifier, tableProperties))
             .thenReturn(Optional.of("v2"));

--- a/integration/spark/vendor/gcp/src/main/java/io/openlineage/spark/agent/vendor/gcp/util/GCPUtils.java
+++ b/integration/spark/vendor/gcp/src/main/java/io/openlineage/spark/agent/vendor/gcp/util/GCPUtils.java
@@ -8,10 +8,12 @@ package io.openlineage.spark.agent.vendor.gcp.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.openlineage.client.Environment;
+import io.openlineage.spark.agent.util.ApplicationMetadataCache;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.naming.NameNormalizer;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +57,7 @@ public class GCPUtils {
   private static final String METADATA_FLAVOUR = "Metadata-Flavor";
   private static final String GOOGLE = "Google";
   private static final String SPARK_DIST_CLASSPATH = "SPARK_DIST_CLASSPATH";
+  private static final String DATAPROC_METADATA_CACHE_KEY = "gcp.dataproc.application-metadata";
 
   enum ResourceType {
     CLUSTER,
@@ -87,8 +90,39 @@ public class GCPUtils {
   // Remove suppression after PMD is updated to >=7.0.0
   @SuppressWarnings("PMD.SwitchStmtsShouldHaveDefault")
   public static Map<String, Object> getDataprocRunFacetMap(SparkContext context) {
+    return new HashMap<>(getDataprocApplicationMetadata(context).getRunFacetProperties());
+  }
+
+  public static Map<String, Object> getOriginFacetMap(SparkContext sparkContext) {
+    return new HashMap<>(getDataprocApplicationMetadata(sparkContext).getOriginProperties());
+  }
+
+  private static DataprocApplicationMetadata getDataprocApplicationMetadata(SparkContext context) {
+    return ApplicationMetadataCache.forSparkContext(context)
+        .get(DATAPROC_METADATA_CACHE_KEY, () -> loadDataprocApplicationMetadata(context));
+  }
+
+  // Remove suppression after PMD is updated to >=7.0.0
+  @SuppressWarnings("PMD.SwitchStmtsShouldHaveDefault")
+  private static DataprocApplicationMetadata loadDataprocApplicationMetadata(SparkContext context) {
+    Optional<String> batchId = Optional.empty();
+    Optional<String> sessionId = Optional.empty();
+    ResourceType resource;
+    if ("yarn".equals(context.getConf().get(SPARK_MASTER, ""))) {
+      resource = ResourceType.CLUSTER;
+    } else {
+      batchId = getDataprocBatchID(context);
+      if (batchId.isPresent()) {
+        resource = ResourceType.BATCH;
+      } else {
+        sessionId = getDataprocSessionID(context);
+        resource = sessionId.isPresent() ? ResourceType.INTERACTIVE : ResourceType.UNKNOWN;
+      }
+    }
+
+    Optional<String> projectId = getGCPProjectId(context);
+    Optional<String> region = getDataprocRegion(context);
     Map<String, Object> dataprocProperties = new HashMap<>();
-    ResourceType resource = identifyResource(context);
 
     switch (resource) {
       case CLUSTER:
@@ -99,12 +133,12 @@ public class GCPUtils {
         dataprocProperties.put("jobType", "dataproc_job");
         break;
       case BATCH:
-        getDataprocBatchID(context).ifPresent(p -> dataprocProperties.put("batchId", p));
+        batchId.ifPresent(p -> dataprocProperties.put("batchId", p));
         getDataprocBatchUUID(context).ifPresent(p -> dataprocProperties.put("batchUuid", p));
         dataprocProperties.put("jobType", "batch");
         break;
       case INTERACTIVE:
-        getDataprocSessionID(context).ifPresent(p -> dataprocProperties.put("sessionId", p));
+        sessionId.ifPresent(p -> dataprocProperties.put("sessionId", p));
         getDataprocSessionUUID(context).ifPresent(p -> dataprocProperties.put("sessionUuid", p));
         dataprocProperties.put("jobType", "session");
         break;
@@ -112,14 +146,35 @@ public class GCPUtils {
         // do nothing
         break;
     }
-    getGCPProjectId(context).ifPresent(p -> dataprocProperties.put("projectId", p));
+    projectId.ifPresent(p -> dataprocProperties.put("projectId", p));
     getSparkAppId(context).ifPresent(p -> dataprocProperties.put("appId", p));
     getSparkAppName(context).ifPresent(p -> dataprocProperties.put("appName", p));
-    return dataprocProperties;
-  }
 
-  public static Map<String, Object> getOriginFacetMap(SparkContext sparkContext) {
-    return createDataprocOriginMap(sparkContext);
+    Map<String, Object> originProperties = new HashMap<>();
+    String nameFormat = "";
+    String resourceId = "";
+    switch (resource) {
+      case CLUSTER:
+        nameFormat = "projects/%s/regions/%s/clusters/%s";
+        resourceId = getClusterName(context).orElse("");
+        break;
+      case BATCH:
+        nameFormat = "projects/%s/locations/%s/batches/%s";
+        resourceId = batchId.orElse("");
+        break;
+      case INTERACTIVE:
+        nameFormat = "projects/%s/locations/%s/sessions/%s";
+        resourceId = sessionId.orElse("");
+        break;
+      case UNKNOWN:
+        nameFormat = "projects/%s/regions/%s/unknown/%s";
+        break;
+    }
+    originProperties.put(
+        "name", String.format(nameFormat, projectId.orElse(""), region.orElse(""), resourceId));
+    originProperties.put("sourceType", "DATAPROC");
+
+    return new DataprocApplicationMetadata(dataprocProperties, originProperties);
   }
 
   public static Optional<String> getSparkQueryExecutionNodeName(OpenLineageContext context) {
@@ -128,14 +183,6 @@ public class GCPUtils {
     SparkPlan node = context.getQueryExecution().get().executedPlan();
     if (node instanceof WholeStageCodegenExec) node = ((WholeStageCodegenExec) node).child();
     return Optional.of(NameNormalizer.normalize(node.nodeName()));
-  }
-
-  private static ResourceType identifyResource(SparkContext context) {
-    if ("yarn".equals(context.getConf().get(SPARK_MASTER, ""))) return ResourceType.CLUSTER;
-    if (getDataprocBatchID(context).isPresent()) return ResourceType.BATCH;
-    if (getDataprocSessionID(context).isPresent()) return ResourceType.INTERACTIVE;
-
-    return ResourceType.UNKNOWN;
   }
 
   private static Optional<String> getDriverHost(SparkContext context) {
@@ -195,38 +242,6 @@ public class GCPUtils {
     return fetchGCPMetadata(CLUSTER_UUID_ENDPOINT, context);
   }
 
-  // Remove suppression after PMD is updated to >=7.0.0
-  @SuppressWarnings("PMD.SwitchStmtsShouldHaveDefault")
-  private static Map<String, Object> createDataprocOriginMap(SparkContext context) {
-    Map<String, Object> originProperties = new HashMap<>();
-    String nameFormat = "";
-    String resourceID = "";
-    String regionName = getDataprocRegion(context).orElse("");
-    String projectID = getGCPProjectId(context).orElse("");
-
-    switch (identifyResource(context)) {
-      case CLUSTER:
-        nameFormat = "projects/%s/regions/%s/clusters/%s";
-        resourceID = getClusterName(context).orElse("");
-        break;
-      case BATCH:
-        nameFormat = "projects/%s/locations/%s/batches/%s";
-        resourceID = getDataprocBatchID(context).orElse("");
-        break;
-      case INTERACTIVE:
-        nameFormat = "projects/%s/locations/%s/sessions/%s";
-        resourceID = getDataprocSessionID(context).orElse("");
-        break;
-      case UNKNOWN:
-        nameFormat = "projects/%s/regions/%s/unknown/%s";
-        break;
-    }
-    String dataprocResource = String.format(nameFormat, projectID, regionName, resourceID);
-    originProperties.put("name", dataprocResource);
-    originProperties.put("sourceType", "DATAPROC");
-    return originProperties;
-  }
-
   private static Optional<String> getPropertyFromYarnTag(SparkContext context, String tagPrefix) {
     String yarnTag = context.getConf().get(SPARK_YARN_TAGS, null);
     if (yarnTag == null) {
@@ -275,5 +290,24 @@ public class GCPUtils {
             "code: %d, response: %s",
             statusCode, EntityUtils.toString(response.getEntity(), UTF_8));
     throw new IOException(message);
+  }
+
+  private static final class DataprocApplicationMetadata {
+    private final Map<String, Object> runFacetProperties;
+    private final Map<String, Object> originProperties;
+
+    private DataprocApplicationMetadata(
+        Map<String, Object> runFacetProperties, Map<String, Object> originProperties) {
+      this.runFacetProperties = Collections.unmodifiableMap(new HashMap<>(runFacetProperties));
+      this.originProperties = Collections.unmodifiableMap(new HashMap<>(originProperties));
+    }
+
+    private Map<String, Object> getRunFacetProperties() {
+      return runFacetProperties;
+    }
+
+    private Map<String, Object> getOriginProperties() {
+      return originProperties;
+    }
   }
 }

--- a/integration/spark/vendor/gcp/src/test/java/io/openlineage/spark/agent/vendor/gcp/util/GCPUtilsTest.java
+++ b/integration/spark/vendor/gcp/src/test/java/io/openlineage/spark/agent/vendor/gcp/util/GCPUtilsTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import io.openlineage.spark.agent.util.ApplicationMetadataCache;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.mockserver.configuration.Configuration;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.verify.VerificationTimes;
 import org.slf4j.event.Level;
 import scala.Tuple2;
 
@@ -75,6 +77,7 @@ class GCPUtilsTest {
 
   @AfterEach
   public void afterEach() {
+    ApplicationMetadataCache.invalidate(sparkContext);
     mockServer.reset();
 
     Tuple2<String, String>[] configuration = sparkConf.getAll();
@@ -113,6 +116,11 @@ class GCPUtilsTest {
 
     Map<String, Object> dataprocRunFacet = GCPUtils.getDataprocRunFacetMap(sparkContext);
     assertThat(dataprocRunFacet).isEqualTo(EXPECTED_FACET_DATAPROC_CLUSTER);
+    verifyRequestedOnce(GCPUtils.PROJECT_ID_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.DATAPROC_REGION_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.CLUSTER_UUID_ENDPOINT);
+    verifyNotRequested(GCPUtils.BATCH_ID_ENDPOINT);
+    verifyNotRequested(GCPUtils.SESSION_ID_ENDPOINT);
   }
 
   @Test
@@ -134,6 +142,11 @@ class GCPUtilsTest {
 
     Map<String, Object> dataprocRunFacet = GCPUtils.getDataprocRunFacetMap(sparkContext);
     assertThat(dataprocRunFacet).isEqualTo(EXPECTED_FACET_DATAPROC_BATCH);
+    verifyRequestedOnce(GCPUtils.PROJECT_ID_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.DATAPROC_REGION_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.BATCH_ID_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.BATCH_UUID_ENDPOINT);
+    verifyNotRequested(GCPUtils.SESSION_ID_ENDPOINT);
   }
 
   @Test
@@ -155,6 +168,19 @@ class GCPUtilsTest {
 
     Map<String, Object> dataprocRunFacet = GCPUtils.getDataprocRunFacetMap(sparkContext);
     assertThat(dataprocRunFacet).isEqualTo(EXPECTED_FACET_DATAPROC_SESSION);
+    verifyRequestedOnce(GCPUtils.PROJECT_ID_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.DATAPROC_REGION_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.BATCH_ID_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.SESSION_ID_ENDPOINT);
+    verifyRequestedOnce(GCPUtils.SESSION_UUID_ENDPOINT);
+  }
+
+  private static void verifyRequestedOnce(String endpoint) {
+    mockServer.verify(request(endpoint).withHeader(METADATA_HEADER), VerificationTimes.exactly(1));
+  }
+
+  private static void verifyNotRequested(String endpoint) {
+    mockServer.verify(request(endpoint).withHeader(METADATA_HEADER), VerificationTimes.exactly(0));
   }
 
   static {


### PR DESCRIPTION
This change adds two caching layers to the Spark integration so that lineage emission performs fewer cloud lookups and table loads. `ApplicationMetadataCache` stores metadata that stays stable for the lifetime of one Spark application. It keys entries by `SparkContext` in a `WeakHashMap`. The cache keeps successful values for the application lifetime and negative results for a bounded interval, so a transient cloud failure is retried later instead of on every event. `CatalogUtils.EventCache` is a thread-local cache scoped to one event build; it resolves catalog handlers and loads Spark and Iceberg tables at most once per event.

The cache is wired into the AWS and GCP lookup paths. `AwsAccountIdFetcher`, `AwsUtils`, and `S3TablesUtils` now resolve the STS account ID, EC2 instance-metadata region, and Glue and S3 Tables ARNs per `SparkContext` instead of through process-global statics. `GCPUtils` computes the Dataproc run and origin facet metadata in one pass and caches it per application. Catalog handlers for Delta, Iceberg, Glue, S3 Tables, and Unity Catalog use the SparkContext-aware helpers. Together these changes stop cloud identity from leaking between applications that share a JVM and reduce repeated STS and IMDS calls and table loads. Unit tests cover the cache semantics, the negative-cache TTL, and the AWS and GCP lookup paths.

### Checklist
- [x] AI was used in creating this PR
