### PR TITLE
sql: include QUALIFY subquery inputs in lineage

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -604,6 +604,13 @@ impl Visit for Select {
             context.collect_aliases(&frame);
         }
 
+        if let Some(qualify) = &self.qualify {
+            context.push_frame();
+            qualify.visit(context)?;
+            let frame = context.pop_frame().unwrap();
+            context.collect_aliases(&frame);
+        }
+
         if let Some(into) = &self.into {
             context.add_output(convert_to_idents(&into.name))
         }

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -46,6 +46,24 @@ fn select_having_exists_subquery() {
 }
 
 #[test]
+fn select_qualify_exists_subquery() {
+    assert_eq!(
+        test_sql_dialect(
+            "SELECT row_number() OVER (ORDER BY id)
+             FROM orders
+             QUALIFY EXISTS (SELECT 1 FROM customers);",
+            "snowflake",
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["customers", "orders"]),
+            out_tables: vec![]
+        }
+    )
+}
+
+#[test]
 fn select_aggregate_filter_subquery() {
     assert_eq!(
         test_sql(


### PR DESCRIPTION
### One-line summary for changelog:

Include tables referenced only by `QUALIFY` subqueries in SQL table lineage.

### Meaningful description

Closes: #4914

The SQL parser accepts `QUALIFY` expressions, but the `Select` visitor did not traverse them. As a result, a table used only by a nested `QUALIFY` subquery was silently absent from `inTables` even though equivalent `WHERE` and `HAVING` subqueries were handled correctly.

This change visits `Select.qualify` with the existing expression-frame pattern used for `WHERE` and `HAVING`. A focused Snowflake regression test proves that both the outer table and the table used only by the `QUALIFY` subquery are collected.

There are no public API, dependency, generated-file, specification, or documentation changes.

### Validation

- `cargo test` — 158 passed, 3 ignored across the SQL workspace (8 unit, 149 table/column-lineage integration, 1 Python conversion)
- `cargo fmt --all -- --check`
- Java binding `./script/compile.sh && ./script/build.sh` — 13 tests, publication/package tasks, and smoke test passed
- Python binding `RUN_TESTS=true ./iface-py/script/build-macos.sh` — tests, Clippy with warnings denied, formatting, universal2 wheel build/install, and import smoke passed
- Repository pre-commit suite — every non-Docker hook passed; the Docker hooks could not mount this checkout from an external volume containing a space, so the same pinned checks were rerun directly: ShellCheck v0.10.0 passed on all tracked shell scripts and golangci-lint v2.10.1 reported 0 issues

### Checklist

- [x] AI was used in creating this PR
