### PR TITLE
Support Unix Domain Socket URLs (unix://) in the Java HTTP transport

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -83,11 +83,6 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     compileOnly 'org.apache.kafka:kafka-clients:4.3.1'
-    // Unix Domain Socket support for HttpTransport (e.g. sending lineage to a socket endpoint,
-    // such as one exposed on a Kubernetes node). Optional: only required when a unix:// url is
-    // configured, so it is compileOnly here (like kafka-clients) and must be added to the
-    // classpath by consumers that use it. Kept out of shaded downstream jars. Java 8 compatible.
-    compileOnly 'com.github.jnr:jnr-unixsocket:0.38.25'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "io.micrometer:micrometer-registry-statsd:${micrometerVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -77,15 +77,17 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-blackbird:${jacksonVersion}"
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.6.4'
-    // Unix Domain Socket support for HttpTransport (e.g. sending lineage to a socket endpoint,
-    // such as one exposed on a Kubernetes node). Java 8 compatible.
-    implementation 'com.github.jnr:jnr-unixsocket:0.38.25'
     implementation 'commons-logging:commons-logging:1.4.0'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation "io.micrometer:micrometer-core:${micrometerVersion}"
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     compileOnly 'org.apache.kafka:kafka-clients:4.3.1'
+    // Unix Domain Socket support for HttpTransport (e.g. sending lineage to a socket endpoint,
+    // such as one exposed on a Kubernetes node). Optional: only required when a unix:// url is
+    // configured, so it is compileOnly here (like kafka-clients) and must be added to the
+    // classpath by consumers that use it. Kept out of shaded downstream jars. Java 8 compatible.
+    compileOnly 'com.github.jnr:jnr-unixsocket:0.38.25'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "io.micrometer:micrometer-registry-statsd:${micrometerVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-blackbird:${jacksonVersion}"
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.6.4'
+    // Unix Domain Socket support for HttpTransport (e.g. sending lineage to a socket endpoint,
+    // such as one exposed on a Kubernetes node). Java 8 compatible.
+    implementation 'com.github.jnr:jnr-unixsocket:0.38.25'
     implementation 'commons-logging:commons-logging:1.4.0'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation "io.micrometer:micrometer-core:${micrometerVersion}"

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -139,7 +139,24 @@ public final class HttpTransport extends Transport {
     return httpConfig.getUrl() != null && "unix".equalsIgnoreCase(httpConfig.getUrl().getScheme());
   }
 
+  /**
+   * Unix Domain Socket support relies on jnr-unixsocket, which is an optional (compileOnly)
+   * dependency. Fail with an actionable message instead of a NoClassDefFoundError when a unix://
+   * url is configured but the dependency is missing from the classpath.
+   */
+  private static void ensureUnixSocketSupport() {
+    try {
+      Class.forName("jnr.unixsocket.UnixSocketChannel");
+    } catch (ClassNotFoundException e) {
+      throw new OpenLineageClientException(
+          "A unix:// transport url requires the jnr-unixsocket dependency on the classpath "
+              + "(e.g. com.github.jnr:jnr-unixsocket). Add it to enable Unix Domain Socket support.",
+          e);
+    }
+  }
+
   private static CloseableHttpClient withUnixSocket(HttpConfig httpConfig, Timeout timeout) {
+    ensureUnixSocketSupport();
     // url.getPath() of unix:///path/to/agent.socket -> /path/to/agent.socket
     File socketPath = new File(httpConfig.getUrl().getPath());
 

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -29,21 +29,32 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import jnr.unixsocket.UnixSocketChannel;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.SystemDefaultDnsResolver;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
+import org.apache.hc.client5.http.impl.DefaultSchemePortResolver;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator;
+import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.DetachedSocketFactory;
+import org.apache.hc.client5.http.io.HttpClientConnectionOperator;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -80,6 +91,14 @@ public final class HttpTransport extends Transport {
     }
     Timeout timeout = Timeout.ofMilliseconds(timeoutMs);
 
+    // A unix:// URL means the target is a Unix Domain Socket endpoint (e.g. one exposed on a
+    // Kubernetes node). Apache HttpClient can't dial a UDS directly, so build a client whose
+    // connection socket factory tunnels over the socket; the request itself uses a placeholder
+    // http://localhost URL (see getUri).
+    if (isUnixSocket(httpConfig)) {
+      return withUnixSocket(httpConfig, timeout);
+    }
+
     PoolingHttpClientConnectionManagerBuilder connectionManagerBuilder =
         PoolingHttpClientConnectionManagerBuilder.create()
             .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeout).build())
@@ -113,6 +132,57 @@ public final class HttpTransport extends Transport {
         .setDefaultRequestConfig(requestConfig)
         .setConnectionManager(connectionManagerBuilder.build())
         .setDefaultRequestConfig(requestConfig)
+        .build();
+  }
+
+  private static boolean isUnixSocket(HttpConfig httpConfig) {
+    return httpConfig.getUrl() != null && "unix".equalsIgnoreCase(httpConfig.getUrl().getScheme());
+  }
+
+  private static CloseableHttpClient withUnixSocket(HttpConfig httpConfig, Timeout timeout) {
+    // url.getPath() of unix:///path/to/agent.socket -> /path/to/agent.socket
+    File socketPath = new File(httpConfig.getUrl().getPath());
+
+    // httpclient5 5.x drives socket creation through DetachedSocketFactory (the legacy
+    // ConnectionSocketFactory registry is not consulted by the blocking connection operator).
+    // Return a socket that ignores the placeholder TCP address and dials the UDS path instead.
+    DetachedSocketFactory socketFactory =
+        proxy -> new TunnelingUnixSocket(socketPath, UnixSocketChannel.create());
+    // No TLS over the local socket, so an empty TLS strategy lookup is fine.
+    Registry<TlsSocketStrategy> tlsStrategyRegistry =
+        RegistryBuilder.<TlsSocketStrategy>create().build();
+    HttpClientConnectionOperator connectionOperator =
+        new DefaultHttpClientConnectionOperator(
+            socketFactory,
+            DefaultSchemePortResolver.INSTANCE,
+            SystemDefaultDnsResolver.INSTANCE,
+            tlsStrategyRegistry);
+
+    PoolingHttpClientConnectionManager connectionManager =
+        new PoolingHttpClientConnectionManager(
+            connectionOperator,
+            PoolConcurrencyPolicy.STRICT,
+            PoolReusePolicy.LIFO,
+            timeout,
+            ManagedHttpClientConnectionFactory.INSTANCE);
+    connectionManager.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeout).build());
+    connectionManager.setDefaultConnectionConfig(
+        ConnectionConfig.custom()
+            .setSocketTimeout(timeout)
+            .setConnectTimeout(timeout)
+            .setTimeToLive(timeout)
+            .build());
+
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setConnectionRequestTimeout(timeout)
+            .setResponseTimeout(timeout)
+            .build();
+
+    log.info("Using Unix Domain Socket transport for OpenLineage at {}", socketPath);
+    return HttpClientBuilder.create()
+        .setDefaultRequestConfig(requestConfig)
+        .setConnectionManager(connectionManager)
         .build();
   }
 
@@ -159,6 +229,27 @@ public final class HttpTransport extends Transport {
     if (url == null) {
       throw new OpenLineageClientException(
           "url can't be null, try setting transport.url in config");
+    }
+    // For a unix:// URL the path is the socket file, not the HTTP path — target a placeholder
+    // http://localhost/<endpoint>; UnixDomainSocketConnectionSocketFactory tunnels it to the
+    // socket.
+    if (isUnixSocket(httpConfig)) {
+      String endpoint =
+          StringUtils.isNotBlank(httpConfig.getEndpoint())
+              ? httpConfig.getEndpoint()
+              : API_V1 + "/lineage";
+      URIBuilder socketBuilder =
+          new URIBuilder()
+              .setScheme("http")
+              .setHost("localhost")
+              .setPath(endpoint.startsWith("/") ? endpoint : "/" + endpoint);
+      if (httpConfig.getUrlParams() != null) {
+        httpConfig.getUrlParams().entrySet().stream()
+            .forEach(
+                e ->
+                    socketBuilder.addParameter(e.getKey().replace("url.param.", ""), e.getValue()));
+      }
+      return socketBuilder.build();
     }
     URIBuilder builder = new URIBuilder(url);
     if (StringUtils.isNotBlank(url.getPath())) {

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
-import jnr.unixsocket.UnixSocketChannel;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.experimental.Delegate;
@@ -69,6 +68,9 @@ import org.apache.hc.core5.util.Timeout;
 @ToString
 public final class HttpTransport extends Transport {
   private static final String API_V1 = "/api/v1";
+
+  /** Minimum Java version providing native Unix Domain Socket support (JEP 380). */
+  private static final int MIN_JAVA_VERSION_FOR_UNIX_SOCKET = 16;
 
   private final CloseableHttpClient http;
   private final URI uri;
@@ -140,18 +142,38 @@ public final class HttpTransport extends Transport {
   }
 
   /**
-   * Unix Domain Socket support relies on jnr-unixsocket, which is an optional (compileOnly)
-   * dependency. Fail with an actionable message instead of a NoClassDefFoundError when a unix://
-   * url is configured but the dependency is missing from the classpath.
+   * Unix Domain Socket support uses the JDK-native UDS APIs added in Java 16 (JEP 380). Fail fast
+   * with an actionable message on older runtimes instead of a {@link NoClassDefFoundError} that
+   * would otherwise be thrown when the isolated {@link TunnelingUnixSocket} class (which references
+   * Java 16+ types) is loaded.
    */
   private static void ensureUnixSocketSupport() {
-    try {
-      Class.forName("jnr.unixsocket.UnixSocketChannel");
-    } catch (ClassNotFoundException e) {
+    if (javaMajorVersion() < MIN_JAVA_VERSION_FOR_UNIX_SOCKET) {
       throw new OpenLineageClientException(
-          "A unix:// transport url requires the jnr-unixsocket dependency on the classpath "
-              + "(e.g. com.github.jnr:jnr-unixsocket). Add it to enable Unix Domain Socket support.",
-          e);
+          "A unix:// transport url requires Java 16 or later; it uses the JDK-native Unix Domain "
+              + "Socket support (JEP 380). Detected Java "
+              + System.getProperty("java.specification.version")
+              + ". Use an http(s):// url or run on Java 16+.");
+    }
+  }
+
+  private static int javaMajorVersion() {
+    String spec = System.getProperty("java.specification.version");
+    if (spec == null) {
+      return 0;
+    }
+    // "1.8" -> 8 (Java 8 and earlier), "11"/"16"/"17" -> as-is (Java 9+).
+    if (spec.startsWith("1.")) {
+      spec = spec.substring(2);
+    }
+    int dot = spec.indexOf('.');
+    if (dot >= 0) {
+      spec = spec.substring(0, dot);
+    }
+    try {
+      return Integer.parseInt(spec);
+    } catch (NumberFormatException e) {
+      return 0;
     }
   }
 
@@ -163,8 +185,7 @@ public final class HttpTransport extends Transport {
     // httpclient5 5.x drives socket creation through DetachedSocketFactory (the legacy
     // ConnectionSocketFactory registry is not consulted by the blocking connection operator).
     // Return a socket that ignores the placeholder TCP address and dials the UDS path instead.
-    DetachedSocketFactory socketFactory =
-        proxy -> new TunnelingUnixSocket(socketPath, UnixSocketChannel.create());
+    DetachedSocketFactory socketFactory = proxy -> new TunnelingUnixSocket(socketPath);
     // No TLS over the local socket, so an empty TLS strategy lookup is fine.
     Registry<TlsSocketStrategy> tlsStrategyRegistry =
         RegistryBuilder.<TlsSocketStrategy>create().build();

--- a/client/java/src/main/java/io/openlineage/client/transports/TunnelingUnixSocket.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TunnelingUnixSocket.java
@@ -7,34 +7,145 @@ package io.openlineage.client.transports;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.SocketAddress;
-import jnr.unixsocket.UnixSocket;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
 
 /**
  * A {@link java.net.Socket} that ignores the TCP endpoint it is asked to connect to and instead
- * dials a Unix Domain Socket at a fixed path. This lets an HTTP client that only knows how to talk
- * to {@code host:port} tunnel its requests over a UDS, e.g. a socket endpoint exposed on a
- * Kubernetes node.
+ * dials a Unix Domain Socket at a fixed path. This lets the blocking Apache HttpClient, which only
+ * knows how to talk to {@code host:port}, tunnel its requests over a UDS, e.g. a socket endpoint
+ * exposed on a Kubernetes node.
  *
- * <p>Adapted from OkHttp's unix-domain-sockets sample. Uses jnr-unixsocket so it works on Java 8+.
+ * <p>Backed by the JDK-native Unix Domain Socket support introduced in Java 16 (JEP 380) rather
+ * than a third-party library, so it adds no dependencies. It references Java 16+ types directly, so
+ * {@link HttpTransport} guards construction with a runtime version check: this class may be loaded
+ * on an older JVM (the Java 16+ types it names are only symbolic references, resolved lazily), but
+ * its methods must never execute there — the version check ensures they don't, avoiding a {@link
+ * NoClassDefFoundError} on the Java 16+ types. The client is compiled with {@code source/target 8}
+ * against a JDK 17 toolchain, so this compiles to Java 8 bytecode while still referencing the newer
+ * APIs.
+ *
+ * <p>Because the HTTP exchange runs over channel-backed streams, {@code SO_TIMEOUT} and other TCP
+ * socket options do not apply and are accepted as no-ops. Read/write operations block; the local
+ * socket makes this acceptable for best-effort lineage emission.
  */
-final class TunnelingUnixSocket extends UnixSocket {
-  private final File path;
+final class TunnelingUnixSocket extends java.net.Socket {
+  private final UnixDomainSocketAddress address;
+  private final SocketChannel channel;
+  private int soTimeout;
 
-  TunnelingUnixSocket(File path, UnixSocketChannel channel) {
-    super(channel);
-    this.path = path;
+  TunnelingUnixSocket(File path) throws IOException {
+    this.address = UnixDomainSocketAddress.of(path.toPath());
+    this.channel = SocketChannel.open(StandardProtocolFamily.UNIX);
   }
 
   @Override
   public void connect(SocketAddress endpoint) throws IOException {
-    super.connect(new UnixSocketAddress(path), 0);
+    channel.connect(address);
   }
 
   @Override
   public void connect(SocketAddress endpoint, int timeout) throws IOException {
-    super.connect(new UnixSocketAddress(path), timeout);
+    // The channel is in blocking mode; connecting to a local UDS returns as soon as the peer
+    // accepts, so the (TCP-oriented) connect timeout does not apply.
+    channel.connect(address);
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return Channels.newInputStream(channel);
+  }
+
+  @Override
+  public OutputStream getOutputStream() throws IOException {
+    return Channels.newOutputStream(channel);
+  }
+
+  @Override
+  public boolean isConnected() {
+    return channel.isConnected();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return !channel.isOpen();
+  }
+
+  @Override
+  public void close() throws IOException {
+    channel.close();
+  }
+
+  @Override
+  public void shutdownInput() throws IOException {
+    channel.shutdownInput();
+  }
+
+  @Override
+  public void shutdownOutput() throws IOException {
+    channel.shutdownOutput();
+  }
+
+  @Override
+  public SocketAddress getRemoteSocketAddress() {
+    return address;
+  }
+
+  // The remaining overrides make the TCP-oriented socket options HttpClient sets during connection
+  // setup into no-ops (or harmless getters); the underlying default Socket impl is never used, so
+  // touching it would otherwise throw because this socket is never truly "created".
+  @Override
+  public void setSoTimeout(int timeout) {
+    this.soTimeout = timeout;
+  }
+
+  @Override
+  public int getSoTimeout() {
+    return soTimeout;
+  }
+
+  @Override
+  public void setTcpNoDelay(boolean on) {
+    // no-op: not applicable to a Unix Domain Socket
+  }
+
+  @Override
+  public boolean getTcpNoDelay() {
+    return true;
+  }
+
+  @Override
+  public void setKeepAlive(boolean on) {
+    // no-op: not applicable to a Unix Domain Socket
+  }
+
+  @Override
+  public boolean getKeepAlive() {
+    return false;
+  }
+
+  @Override
+  public void setReuseAddress(boolean on) {
+    // no-op: not applicable to a Unix Domain Socket
+  }
+
+  @Override
+  public boolean getReuseAddress() {
+    return false;
+  }
+
+  @Override
+  public void setSoLinger(boolean on, int linger) {
+    // no-op: not applicable to a Unix Domain Socket
+  }
+
+  @Override
+  public int getSoLinger() {
+    return -1;
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/TunnelingUnixSocket.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TunnelingUnixSocket.java
@@ -1,0 +1,40 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.SocketAddress;
+import jnr.unixsocket.UnixSocket;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+/**
+ * A {@link java.net.Socket} that ignores the TCP endpoint it is asked to connect to and instead
+ * dials a Unix Domain Socket at a fixed path. This lets an HTTP client that only knows how to talk
+ * to {@code host:port} tunnel its requests over a UDS, e.g. a socket endpoint exposed on a
+ * Kubernetes node.
+ *
+ * <p>Adapted from OkHttp's unix-domain-sockets sample. Uses jnr-unixsocket so it works on Java 8+.
+ */
+final class TunnelingUnixSocket extends UnixSocket {
+  private final File path;
+
+  TunnelingUnixSocket(File path, UnixSocketChannel channel) {
+    super(channel);
+    this.path = path;
+  }
+
+  @Override
+  public void connect(SocketAddress endpoint) throws IOException {
+    super.connect(new UnixSocketAddress(path), 0);
+  }
+
+  @Override
+  public void connect(SocketAddress endpoint, int timeout) throws IOException {
+    super.connect(new UnixSocketAddress(path), timeout);
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -32,9 +32,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.net.StandardProtocolFamily;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnixDomainSocketAddress;
 import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,9 +50,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
-import jnr.unixsocket.UnixServerSocketChannel;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 import lombok.SneakyThrows;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -60,6 +61,8 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.mockito.ArgumentCaptor;
 
 @SuppressWarnings("unchecked")
@@ -88,6 +91,7 @@ class HttpTransportTest {
 
   @Test
   @SneakyThrows
+  @EnabledForJreRange(min = JRE.JAVA_16)
   @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   void transportCreatedWithUnixSocketUrl() {
     // A unix:// url targets a Unix Domain Socket; the request is issued against a
@@ -105,6 +109,7 @@ class HttpTransportTest {
 
   @Test
   @SneakyThrows
+  @EnabledForJreRange(min = JRE.JAVA_16)
   @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   void transportUnixSocketUsesDefaultEndpoint() {
     HttpConfig httpConfig = new HttpConfig();
@@ -118,10 +123,12 @@ class HttpTransportTest {
 
   @Test
   @SneakyThrows
+  @EnabledForJreRange(min = JRE.JAVA_16)
   void httpTransportEmitsOverUnixSocket() {
     // End-to-end check that a unix:// url really tunnels the request over a Unix
-    // Domain Socket: bind a real UDS server, emit an event through HttpTransport,
-    // and assert the bytes the server read back match the serialized event.
+    // Domain Socket: bind a real UDS server (JDK-native, JEP 380), emit an event
+    // through HttpTransport, and assert the bytes the server read back match the
+    // serialized event.
     //
     // Keep the socket path in /tmp and short — AF_UNIX paths are capped around 104
     // characters, and the default temp dir on macOS is long enough to overflow it.
@@ -130,15 +137,15 @@ class HttpTransportTest {
 
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
-      UnixServerSocketChannel serverChannel = UnixServerSocketChannel.open();
-      serverChannel.socket().bind(new UnixSocketAddress(socketFile));
+      ServerSocketChannel serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+      serverChannel.bind(UnixDomainSocketAddress.of(socketFile.toPath()));
 
       // The server accepts one connection, reads the full HTTP request, replies 200,
       // and returns the request body it received.
       Future<String> received =
           executor.submit(
               () -> {
-                try (UnixSocketChannel channel = serverChannel.accept()) {
+                try (SocketChannel channel = serverChannel.accept()) {
                   InputStream in = Channels.newInputStream(channel);
                   OutputStream out = Channels.newOutputStream(channel);
 

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -65,6 +65,8 @@ import org.mockito.ArgumentCaptor;
 @SuppressWarnings("unchecked")
 class HttpTransportTest {
 
+  private static final String HEADER_TERMINATOR = "\r\n\r\n";
+
   @Test
   @SuppressWarnings("PMD")
   void transportCreatedWithHttpConfig()
@@ -86,6 +88,7 @@ class HttpTransportTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   void transportCreatedWithUnixSocketUrl() {
     // A unix:// url targets a Unix Domain Socket; the request is issued against a
     // placeholder http://localhost/<endpoint> and tunneled over the socket.
@@ -102,6 +105,7 @@ class HttpTransportTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   void transportUnixSocketUsesDefaultEndpoint() {
     HttpConfig httpConfig = new HttpConfig();
     httpConfig.setUrl(new URI("unix:///var/run/some.socket"));
@@ -140,13 +144,13 @@ class HttpTransportTest {
 
                   // Read headers up to the blank line terminating them.
                   StringBuilder headers = new StringBuilder();
-                  int b;
-                  while ((b = in.read()) != -1) {
+                  int b = in.read();
+                  while (b != -1) {
                     headers.append((char) b);
-                    int len = headers.length();
-                    if (len >= 4 && "\r\n\r\n".equals(headers.substring(len - 4))) {
+                    if (headers.toString().endsWith(HEADER_TERMINATOR)) {
                       break;
                     }
+                    b = in.read();
                   }
 
                   int contentLength = 0;

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -71,6 +71,34 @@ class HttpTransportTest {
   }
 
   @Test
+  @SneakyThrows
+  void transportCreatedWithUnixSocketUrl() {
+    // A unix:// url targets a Unix Domain Socket; the request is issued against a
+    // placeholder http://localhost/<endpoint> and tunneled over the socket.
+    HttpConfig httpConfig = new HttpConfig();
+    httpConfig.setUrl(new URI("unix:///var/run/some.socket"));
+    httpConfig.setEndpoint("/api/v1/lineage");
+    httpConfig.setUrlParams(singletonMap("param", "value"));
+    HttpTransport httpTransport = new HttpTransport(httpConfig);
+    Field uri = httpTransport.getClass().getDeclaredField("uri");
+    uri.setAccessible(true);
+    String target = uri.get(httpTransport).toString();
+    assertEquals("http://localhost/api/v1/lineage?param=value", target);
+  }
+
+  @Test
+  @SneakyThrows
+  void transportUnixSocketUsesDefaultEndpoint() {
+    HttpConfig httpConfig = new HttpConfig();
+    httpConfig.setUrl(new URI("unix:///var/run/some.socket"));
+    HttpTransport httpTransport = new HttpTransport(httpConfig);
+    Field uri = httpTransport.getClass().getDeclaredField("uri");
+    uri.setAccessible(true);
+    String target = uri.get(httpTransport).toString();
+    assertEquals("http://localhost/api/v1/lineage", target);
+  }
+
+  @Test
   void clientEmitsHttpTransport() throws IOException {
     CloseableHttpClient http = mock(CloseableHttpClient.class);
     HttpConfig config = new HttpConfig();

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -24,17 +24,31 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.OpenLineageClientUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
+import jnr.unixsocket.UnixServerSocketChannel;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
 import lombok.SneakyThrows;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -96,6 +110,87 @@ class HttpTransportTest {
     uri.setAccessible(true);
     String target = uri.get(httpTransport).toString();
     assertEquals("http://localhost/api/v1/lineage", target);
+  }
+
+  @Test
+  @SneakyThrows
+  void httpTransportEmitsOverUnixSocket() {
+    // End-to-end check that a unix:// url really tunnels the request over a Unix
+    // Domain Socket: bind a real UDS server, emit an event through HttpTransport,
+    // and assert the bytes the server read back match the serialized event.
+    //
+    // Keep the socket path in /tmp and short — AF_UNIX paths are capped around 104
+    // characters, and the default temp dir on macOS is long enough to overflow it.
+    File socketFile = new File("/tmp/ol-uds-test-" + System.nanoTime() + ".sock");
+    socketFile.deleteOnExit();
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      UnixServerSocketChannel serverChannel = UnixServerSocketChannel.open();
+      serverChannel.socket().bind(new UnixSocketAddress(socketFile));
+
+      // The server accepts one connection, reads the full HTTP request, replies 200,
+      // and returns the request body it received.
+      Future<String> received =
+          executor.submit(
+              () -> {
+                try (UnixSocketChannel channel = serverChannel.accept()) {
+                  InputStream in = Channels.newInputStream(channel);
+                  OutputStream out = Channels.newOutputStream(channel);
+
+                  // Read headers up to the blank line terminating them.
+                  StringBuilder headers = new StringBuilder();
+                  int b;
+                  while ((b = in.read()) != -1) {
+                    headers.append((char) b);
+                    int len = headers.length();
+                    if (len >= 4 && "\r\n\r\n".equals(headers.substring(len - 4))) {
+                      break;
+                    }
+                  }
+
+                  int contentLength = 0;
+                  for (String line : headers.toString().split("\r\n")) {
+                    if (line.toLowerCase(Locale.ROOT).startsWith("content-length:")) {
+                      contentLength =
+                          Integer.parseInt(line.substring(line.indexOf(':') + 1).trim());
+                    }
+                  }
+
+                  byte[] body = new byte[contentLength];
+                  int read = 0;
+                  while (read < contentLength) {
+                    int r = in.read(body, read, contentLength - read);
+                    if (r == -1) {
+                      break;
+                    }
+                    read += r;
+                  }
+
+                  out.write(
+                      "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+                          .getBytes(StandardCharsets.UTF_8));
+                  out.flush();
+
+                  return new String(body, StandardCharsets.UTF_8);
+                }
+              });
+
+      HttpConfig config = new HttpConfig();
+      config.setUrl(new URI("unix://" + socketFile.getAbsolutePath()));
+      Transport transport = new HttpTransport(config);
+      OpenLineageClient client = new OpenLineageClient(transport);
+
+      client.emit(runEvent());
+
+      String body = received.get(10, TimeUnit.SECONDS);
+      serverChannel.close();
+
+      assertThat(body).isEqualTo(OpenLineageClientUtils.toJson(runEvent()));
+    } finally {
+      executor.shutdownNow();
+      socketFile.delete();
+    }
   }
 
   @Test

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -39,7 +39,10 @@ and tunneled over the socket, so `endpoint`, `headers`, `auth`, `compression`, `
 `timeoutInMillis` behave exactly as they do for a regular `http(s)` url. TLS is not applied over
 the local socket.
 
-This relies on `jnr-unixsocket` and works on Java 8+.
+Unix Domain Socket support relies on [`jnr-unixsocket`](https://github.com/jnr/jnr-unixsocket),
+which is an optional dependency of the client. When you configure a `unix://` url, add it to your
+classpath (for example `com.github.jnr:jnr-unixsocket`); otherwise the transport fails fast with an
+error telling you the dependency is missing. It works on Java 8+.
 
 #### Examples
 

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -10,7 +10,7 @@ Allows sending events to HTTP endpoint, using [ApacheHTTPClient](https://hc.apac
 #### Configuration
 
 - `type` - string, must be `"http"`. Required.
-- `url` - string, base url for HTTP requests. Required. A `unix://` url (e.g. `unix:///var/run/some.socket`) sends events over a Unix Domain Socket instead of TCP — see [Unix Domain Socket](#unix-domain-socket) below.
+- `url` - string, base url for HTTP requests. Required. A `unix://` url (e.g. `unix:///var/run/some.socket`) sends events over a Unix Domain Socket instead of TCP (**requires Java 16 or later**) — see [Unix Domain Socket](#unix-domain-socket) below.
 - `endpoint` - string specifying the endpoint to which events are sent, appended to `url`. Optional, default: `/api/v1/lineage`.
 - `urlParams` - dictionary specifying query parameters send in HTTP requests. Optional.
 - `timeoutInMillis` - integer specifying timeout (in milliseconds) value used while connecting to server. Optional, default: `5000`.
@@ -28,6 +28,12 @@ Events are serialized to JSON, and then are send as HTTP POST request with `Cont
 
 #### Unix Domain Socket
 
+:::info Requires Java 16 or later
+Unix Domain Socket support uses the JDK-native UDS APIs introduced in Java 16 ([JEP 380](https://openjdk.org/jeps/380)).
+It is available only when running on **Java 16 or later**. On an older JVM, configuring a `unix://`
+url fails fast with a clear error, while `http(s)://` urls keep working on every supported Java version.
+:::
+
 When `url` uses the `unix://` scheme, the transport sends events over a Unix Domain Socket
 instead of a TCP connection. This is useful when the collector is reachable only through a
 local socket — for example a sidecar or daemon exposing an HTTP endpoint over a socket on a
@@ -39,10 +45,7 @@ and tunneled over the socket, so `endpoint`, `headers`, `auth`, `compression`, `
 `timeoutInMillis` behave exactly as they do for a regular `http(s)` url. TLS is not applied over
 the local socket.
 
-Unix Domain Socket support relies on [`jnr-unixsocket`](https://github.com/jnr/jnr-unixsocket),
-which is an optional dependency of the client. When you configure a `unix://` url, add it to your
-classpath (for example `com.github.jnr:jnr-unixsocket`); otherwise the transport fails fast with an
-error telling you the dependency is missing. It works on Java 8+.
+Because it builds on the JDK-native UDS support, this feature needs no extra dependencies.
 
 #### Examples
 

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -10,7 +10,7 @@ Allows sending events to HTTP endpoint, using [ApacheHTTPClient](https://hc.apac
 #### Configuration
 
 - `type` - string, must be `"http"`. Required.
-- `url` - string, base url for HTTP requests. Required.
+- `url` - string, base url for HTTP requests. Required. A `unix://` url (e.g. `unix:///var/run/some.socket`) sends events over a Unix Domain Socket instead of TCP — see [Unix Domain Socket](#unix-domain-socket) below.
 - `endpoint` - string specifying the endpoint to which events are sent, appended to `url`. Optional, default: `/api/v1/lineage`.
 - `urlParams` - dictionary specifying query parameters send in HTTP requests. Optional.
 - `timeoutInMillis` - integer specifying timeout (in milliseconds) value used while connecting to server. Optional, default: `5000`.
@@ -26,6 +26,21 @@ Allows sending events to HTTP endpoint, using [ApacheHTTPClient](https://hc.apac
 
 Events are serialized to JSON, and then are send as HTTP POST request with `Content-Type: application/json`.
 
+#### Unix Domain Socket
+
+When `url` uses the `unix://` scheme, the transport sends events over a Unix Domain Socket
+instead of a TCP connection. This is useful when the collector is reachable only through a
+local socket — for example a sidecar or daemon exposing an HTTP endpoint over a socket on a
+Kubernetes node.
+
+The path component of the URL is the socket path (`unix:///var/run/some.socket` →
+`/var/run/some.socket`). The request is issued against a placeholder `http://localhost/<endpoint>`
+and tunneled over the socket, so `endpoint`, `headers`, `auth`, `compression`, `urlParams` and
+`timeoutInMillis` behave exactly as they do for a regular `http(s)` url. TLS is not applied over
+the local socket.
+
+This relies on `jnr-unixsocket` and works on Java 8+.
+
 #### Examples
 
 <Tabs groupId="integrations">
@@ -37,6 +52,15 @@ Anonymous connection:
 transport:
   type: http
   url: http://localhost:5000
+```
+
+Unix Domain Socket connection:
+
+```yaml
+transport:
+  type: http
+  url: unix:///var/run/some.socket
+  endpoint: /api/v1/lineage
 ```
 
 With authorization:
@@ -77,6 +101,14 @@ Anonymous connection:
 ```ini
 spark.openlineage.transport.type=http
 spark.openlineage.transport.url=http://localhost:5000
+```
+
+Unix Domain Socket connection:
+
+```ini
+spark.openlineage.transport.type=http
+spark.openlineage.transport.url=unix:///var/run/some.socket
+spark.openlineage.transport.endpoint=/api/v1/lineage
 ```
 
 With authorization:


### PR DESCRIPTION
### One-line summary for changelog:

Support Unix Domain Socket URLs (`unix://`) in the Java HTTP transport (JDK-native, no extra dependency).

### Meaningful description

**Problem**

The Java HTTP transport can only reach a collector over a TCP `host:port`. In some deployments the collector is exposed *only* over a local Unix Domain Socket — for example a sidecar or daemon reachable via a socket path on a Kubernetes node, rather than a TCP endpoint. There is currently no way to point `HttpTransport` at such a socket, so lineage can't be delivered in those environments.

**Solution**

Allow the transport URL to use the `unix://` scheme, e.g.:

```yaml
transport:
  type: http
  url: unix:///path/to/collector.socket
```

When the URL scheme is `unix`, `HttpTransport` builds an Apache HttpClient 5 connection operator whose sockets dial the socket path instead of a TCP address, and issues the request against a placeholder `http://localhost/<endpoint>`. The socket path is taken from the URL path; the endpoint defaults to `/api/v1/lineage` and can be overridden as usual.

All existing behavior for `http(s)` URLs is unchanged — endpoint, headers, auth, gzip compression, and timeouts all work identically. The change is additive and gated entirely on the `unix` scheme.

**Implementation notes**

- Uses the **JDK-native Unix Domain Socket support** introduced in Java 16 ([JEP 380](https://openjdk.org/jeps/380)) — **no third-party dependency is added**, and nothing extra has to ship on the classpath (including in downstream shaded jars).
- New `TunnelingUnixSocket` extends `java.net.Socket` and dials a `java.net.UnixDomainSocketAddress` over a `SocketChannel`, ignoring the placeholder TCP endpoint. The HTTP exchange runs over channel-backed streams.
- `HttpTransport` plugs this socket into hc5 via a `DetachedSocketFactory` + a custom `DefaultHttpClientConnectionOperator` / `PoolingHttpClientConnectionManager` (the `DetachedSocketFactory` is the seam hc5 actually uses; the legacy `ConnectionSocketFactory` registry is bypassed by the blocking connection operator).
- **Runtime requirement:** `unix://` URLs require **Java 16+**. The client still compiles to Java 8 bytecode (source/target 8 on a JDK 17 toolchain) and references the Java 16 UDS types only symbolically; `HttpTransport` guards the `unix://` path with a runtime version check and fails fast with a clear message on older JVMs. `http(s)://` URLs are unaffected on every supported Java version.

**Tests**

- Unit tests for `unix://` target-URL handling (explicit endpoint + query params, and the default endpoint).
- An end-to-end round-trip test (gated to Java 16+) that binds a real Unix Domain Socket server via the JDK-native APIs, emits an event through `HttpTransport`, and asserts the bytes the server reads back match the serialized event — exercising the socket-tunneling path, not just URL parsing.

**Docs**

- `website/docs/client/java/partials/java_transport.md` documents the `unix://` URL support (including the Java 16+ requirement) with YAML and Spark-config examples.

**Alternatives considered**

- *A separate `socket`/`unix` transport type.* Rejected in favor of extending `HttpTransport`, since the request semantics (endpoint, auth, headers, gzip, error handling) are identical to HTTP — only the underlying socket differs. This keeps configuration simple (just change the URL scheme) and avoids duplicating the transport's request logic.
- *A third-party UDS library (e.g. `jnr-unixsocket`).* Rejected to avoid adding a dependency (and its native binaries) that would be bundled into downstream shaded jars; the JDK-native APIs cover the need on Java 16+.

### Checklist
- [x] AI was used in creating this PR
