### PR TITLE
spark: prevent late task metrics retention

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsCleanupIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/JobMetricsCleanupIntegrationTest.java
@@ -91,14 +91,19 @@ class JobMetricsCleanupIntegrationTest {
   private void assertNoRetainedMetrics(int completedJobs) throws ReflectiveOperationException {
     assertThat(retainedMetricsState())
         .as("retained metrics state after %d completed Spark jobs", completedJobs)
-        .containsOnly(entry("jobStages", 0), entry("stageMetrics", 0), entry("jobMetrics", 0));
+        .containsOnly(
+            entry("jobStages", 0),
+            entry("stageOwners", 0),
+            entry("stageMetrics", 0),
+            entry("jobMetrics", 0));
   }
 
   @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   private Map<String, Integer> retainedMetricsState() throws ReflectiveOperationException {
     Map<String, Integer> retainedState = new LinkedHashMap<>();
     JobMetricsHolder holder = JobMetricsHolder.getInstance();
-    for (String fieldName : new String[] {"jobStages", "stageMetrics", "jobMetrics"}) {
+    for (String fieldName :
+        new String[] {"jobStages", "stageOwners", "stageMetrics", "jobMetrics"}) {
       Field field = JobMetricsHolder.class.getDeclaredField(fieldName);
       field.setAccessible(true);
       retainedState.put(fieldName, ((Map<?, ?>) field.get(holder)).size());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -255,6 +255,29 @@ class OpenLineageSparkListenerTest {
   }
 
   @Test
+  void testTaskEndAfterJobEndDoesNotRecreateStageMetrics() {
+    ContextFactory contextFactory = mock(ContextFactory.class);
+    when(contextFactory.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
+    listener.skipInitializationForTests(contextFactory);
+    SparkListenerJobEnd jobEnd = mock(SparkListenerJobEnd.class);
+    when(jobEnd.jobId()).thenReturn(64);
+    SparkListenerTaskEnd taskEnd = mock(SparkListenerTaskEnd.class);
+    when(taskEnd.stageId()).thenReturn(640);
+    when(taskEnd.taskMetrics()).thenReturn(new TaskMetrics());
+    JobMetricsHolder holder = JobMetricsHolder.getInstance();
+    holder.addJobStages(64, Collections.singleton(640));
+
+    listener.onJobEnd(jobEnd);
+    listener.onTaskEnd(taskEnd);
+
+    assertThat(holder.getJobStagesSize()).isZero();
+    assertThat(holder.getStageOwners()).isEmpty();
+    assertThat(holder.getStageMetricsSize()).isZero();
+    assertThat(holder.getJobMetricsSize()).isZero();
+  }
+
+  @Test
   @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void testRetainedStateGaugesTrackContextsAndMetrics() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
@@ -40,6 +40,7 @@ public class JobMetricsHolder {
       "openlineage.spark.state.job_metrics.completed_jobs";
 
   private final Map<Integer, Set<Integer>> jobStages = new ConcurrentHashMap<>();
+  private final Map<Integer, Set<Integer>> stageOwners = new ConcurrentHashMap<>();
   private final Map<Integer, TaskMetricsAggregate> stageMetrics = new ConcurrentHashMap<>();
 
   /**
@@ -51,18 +52,27 @@ public class JobMetricsHolder {
   // Use singleton instance
   JobMetricsHolder() {}
 
-  public void addJobStages(int jobId, Set<Integer> stages) {
+  public synchronized void addJobStages(int jobId, Set<Integer> stages) {
     if (log.isDebugEnabled()) {
       log.debug(
           "JobMetricsHolder addStage for jobId {} stages {}", jobId, StringUtils.join(stages, ","));
     }
     if (stages != null) {
-      jobStages.put(jobId, stages);
+      Set<Integer> newStages = new HashSet<>(stages);
+      Set<Integer> previousStages = jobStages.put(jobId, newStages);
+      if (previousStages != null) {
+        previousStages.stream()
+            .filter(stage -> !newStages.contains(stage))
+            .forEach(stage -> removeStageOwner(jobId, stage));
+      }
+      newStages.forEach(
+          stage -> stageOwners.computeIfAbsent(stage, ignored -> new HashSet<>()).add(jobId));
     }
   }
 
-  public void addMetrics(int stage, TaskMetrics taskMetrics) {
-    if (taskMetrics != null) {
+  /** Adds task metrics only while at least one active job owns the stage. */
+  public synchronized void addMetrics(int stage, TaskMetrics taskMetrics) {
+    if (taskMetrics != null && stageOwners.containsKey(stage)) {
       if (stageMetrics.containsKey(stage)) {
         stageMetrics.get(stage).add(taskMetrics);
       } else {
@@ -74,7 +84,7 @@ public class JobMetricsHolder {
   /**
    * Aggregates a job's stage metrics and keeps the result available until {@link #cleanUp(int)}.
    */
-  public Map<Metric, Number> pollMetrics(int jobId) {
+  public synchronized Map<Metric, Number> pollMetrics(int jobId) {
     return completeJob(jobId);
   }
 
@@ -82,7 +92,7 @@ public class JobMetricsHolder {
    * Marks a job complete by releasing its stage state and retaining only its compact aggregate.
    * This supports the Spark ordering where JobEnd is followed by the final SQLExecutionEnd event.
    */
-  public Map<Metric, Number> completeJob(int jobId) {
+  public synchronized Map<Metric, Number> completeJob(int jobId) {
     Map<Metric, Number> completedMetrics =
         jobMetrics.computeIfAbsent(
             jobId,
@@ -112,27 +122,44 @@ public class JobMetricsHolder {
   private Map<Metric, Number> computeJobMetricsAndClearTemporaryResults(int jobId) {
     return Optional.ofNullable(jobStages.remove(jobId))
         .map(
-            stages ->
-                stages.stream()
-                    .map(stageMetrics::remove)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList()))
+            stages -> {
+              List<TaskMetricsAggregate> metrics =
+                  stages.stream()
+                      .map(stageMetrics::get)
+                      .filter(Objects::nonNull)
+                      .collect(Collectors.toList());
+              stages.forEach(stage -> removeStageOwner(jobId, stage));
+              return metrics;
+            })
         .filter(l -> !l.isEmpty())
         .map(this::mapMetrics)
         .orElse(Collections.emptyMap());
   }
 
-  public void cleanUp(int jobId) {
+  public synchronized void cleanUp(int jobId) {
     jobMetrics.remove(jobId);
     Set<Integer> stages = jobStages.remove(jobId);
     stages = stages == null ? Collections.emptySet() : stages;
-    stages.forEach(stageMetrics::remove);
+    stages.forEach(stage -> removeStageOwner(jobId, stage));
   }
 
-  public void cleanUpAll() {
+  public synchronized void cleanUpAll() {
     jobMetrics.clear();
     jobStages.clear();
+    stageOwners.clear();
     stageMetrics.clear();
+  }
+
+  private void removeStageOwner(int jobId, int stage) {
+    Set<Integer> owners = stageOwners.get(stage);
+    if (owners == null) {
+      return;
+    }
+    owners.remove(jobId);
+    if (owners.isEmpty()) {
+      stageOwners.remove(stage);
+      stageMetrics.remove(stage);
+    }
   }
 
   /** Registers low-cardinality gauges for every retained metrics map. */
@@ -199,6 +226,13 @@ public class JobMetricsHolder {
   @VisibleForTesting
   Map<Integer, Set<Integer>> getJobStages() {
     return jobStages.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> new HashSet<>(e.getValue())));
+  }
+
+  /** Visible for testing. Creates a deep copy of the active stage owners map. */
+  @VisibleForTesting
+  synchronized Map<Integer, Set<Integer>> getStageOwners() {
+    return stageOwners.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> new HashSet<>(e.getValue())));
   }
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
@@ -168,6 +168,53 @@ class JobMetricsHolderTest {
   }
 
   @Test
+  void testCancelledJobsRejectTaskMetricsArrivingAfterJobCompletion() {
+    for (int jobId = 0; jobId < 1_000; jobId++) {
+      int stageId = jobId;
+      underTest.addJobStages(jobId, Collections.singleton(stageId));
+
+      // A cancelled Spark job can emit JobEnd before TaskEnd.
+      underTest.completeJob(jobId);
+      underTest.addMetrics(stageId, taskMetrics(100, 10, 100, 10));
+
+      assertThat(underTest.getJobStagesSize()).isZero();
+      assertThat(underTest.getStageOwners()).isEmpty();
+      assertThat(underTest.getStageMetricsSize()).isZero();
+      assertThat(underTest.getJobMetricsSize()).isZero();
+    }
+  }
+
+  @Test
+  void testLateSpeculativeTaskDoesNotRecreateCompletedStageMetrics() {
+    underTest.addJobStages(1, Collections.singleton(100));
+    underTest.addMetrics(100, taskMetrics(100, 10, 100, 10));
+
+    Map<Metric, Number> completedMetrics = underTest.completeJob(1);
+    underTest.addMetrics(100, taskMetrics(100, 10, 100, 10));
+
+    assertThat(completedMetrics.get(Metric.WRITE_RECORDS)).isEqualTo(10L);
+    assertThat(underTest.getStageOwners()).isEmpty();
+    assertThat(underTest.getStageMetrics()).isEmpty();
+    assertThat(underTest.completeJob(1).get(Metric.WRITE_RECORDS)).isEqualTo(10L);
+  }
+
+  @Test
+  void testSharedStageAcceptsMetricsUntilItsLastJobCompletes() {
+    underTest.addJobStages(1, Collections.singleton(100));
+    underTest.addJobStages(2, Collections.singleton(100));
+    underTest.addMetrics(100, taskMetrics(100, 10, 100, 10));
+
+    Map<Metric, Number> firstJobMetrics = underTest.completeJob(1);
+    underTest.addMetrics(100, taskMetrics(10, 1, 10, 1));
+    Map<Metric, Number> secondJobMetrics = underTest.completeJob(2);
+
+    assertThat(firstJobMetrics.get(Metric.WRITE_RECORDS)).isEqualTo(10L);
+    assertThat(secondJobMetrics.get(Metric.WRITE_RECORDS)).isEqualTo(11L);
+    assertThat(underTest.getStageOwners()).isEmpty();
+    assertThat(underTest.getStageMetrics()).isEmpty();
+  }
+
+  @Test
   void testContainsMetrics() {
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
     underTest.addMetrics(1, taskMetrics(0, 0, 0, 0));


### PR DESCRIPTION
Spark can deliver `TaskEnd` after `JobEnd`, for example when a job is cancelled while a task is still running. OpenLineage processes `JobEnd` by removing the job-to-stage mapping and clearing its stage metrics. When the late `TaskEnd` arrives, `OpenLineageSparkListener.onTaskEnd()` passes its metrics to `JobMetricsHolder.addMetrics()`, which recreates the stage entry without checking whether any active job still owns it. Subsequent job cleanup cannot find that entry because the job-to-stage mapping is already gone.

These orphaned entries remain in the singleton `JobMetricsHolder.stageMetrics` map until application cleanup. Each retains only a compact metrics aggregate, not an RDD or query plan, but repeated cancellations can cause unbounded growth in a long-running driver. I reproduced this with a real Spark 3.3.4 cancellation: after all events were processed, one stage entry remained despite there being no tracked jobs. The fix is to track active stage ownership, account for stages shared between jobs, and ignore late task metrics once no active job owns the stage.

Checklist
- [x] AI was used in creating this PR