### PR TITLE
spark: cancel facet task on interruption

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventTimeoutExecutor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventTimeoutExecutor.java
@@ -235,7 +235,11 @@ public class OpenLineageRunEventTimeoutExecutor {
         T result = callableExecutor.get(timeout, MILLISECONDS);
         timeSpent = (int) (System.currentTimeMillis() - startTime);
         return result;
-      } catch (InterruptedException | ExecutionException ex) {
+      } catch (InterruptedException ex) {
+        callableExecutor.cancel(true);
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(ex);
+      } catch (ExecutionException ex) {
         throw new RuntimeException(ex);
       } catch (TimeoutException timeoutException) {
         callableExecutor.cancel(true);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventTimeoutExecutorTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventTimeoutExecutorTest.java
@@ -5,6 +5,7 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -235,6 +239,52 @@ class OpenLineageRunEventTimeoutExecutorTest {
 
     // timeout should be applied
     assertThat(executor.timeoutJobFacets(jobFacetsCallableWithTimeout)).isNull();
+  }
+
+  @Test
+  void testInterruptedEventHandlerCancelsJobFacetsTask() throws InterruptedException {
+    when(circuitBreakerConfig.getTimeout()).thenReturn(Optional.of(Duration.ofSeconds(30)));
+    when(timeoutConfig.getFacetsBuildingTimePercentage()).thenReturn(100);
+    executor = new OpenLineageRunEventTimeoutExecutor(openLineageContext);
+
+    CountDownLatch facetTaskStarted = new CountDownLatch(1);
+    CountDownLatch facetTaskInterrupted = new CountDownLatch(1);
+    CountDownLatch callerReturned = new CountDownLatch(1);
+    AtomicBoolean callerInterruptRestored = new AtomicBoolean();
+    AtomicReference<RuntimeException> callerFailure = new AtomicReference<>();
+
+    Thread outerEventHandler =
+        new Thread(
+            () -> {
+              try {
+                executor.timeoutJobFacets(
+                    () -> {
+                      facetTaskStarted.countDown();
+                      try {
+                        new CountDownLatch(1).await();
+                      } catch (InterruptedException ex) {
+                        facetTaskInterrupted.countDown();
+                        throw ex;
+                      }
+                      return jobFacets;
+                    });
+              } catch (RuntimeException ex) {
+                callerFailure.set(ex);
+                callerInterruptRestored.set(Thread.currentThread().isInterrupted());
+              } finally {
+                callerReturned.countDown();
+              }
+            });
+
+    outerEventHandler.start();
+    assertThat(facetTaskStarted.await(5, SECONDS)).isTrue();
+
+    outerEventHandler.interrupt();
+
+    assertThat(callerReturned.await(5, SECONDS)).isTrue();
+    assertThat(facetTaskInterrupted.await(5, SECONDS)).isTrue();
+    assertThat(callerFailure.get()).hasCauseInstanceOf(InterruptedException.class);
+    assertThat(callerInterruptRestored).isTrue();
   }
 
   @Test


### PR DESCRIPTION
OpenLineage can run event processing under an outer circuit breaker while submitting dataset or facet-building work as a separate task. If the circuit breaker triggers, it interrupts the event-processing thread, which may be waiting for that inner task. In `OpenLineageRunEventTimeoutExecutor`, a timeout cancels the inner future, but an `InterruptedException` only causes the waiting thread to throw. The inner task therefore keeps running even though the event handler has returned and the listener may have removed the job or SQL execution context.

The running task can still hold references to the event builder, event nodes, and `QueryExecution`, preventing garbage collection until it finishes. Slow or blocked tasks can therefore prolong substantial memory retention and occupy executor threads; this is not necessarily a permanent leak if the work eventually completes. I reproduced the missing cancellation with an interruptible worker: the waiting thread returned, but the worker remained running and received no interrupt. The fix is to cancel the inner future when the wait is interrupted, restore the waiting thread’s interrupt flag, and propagate cancellation.