### PR TITLE
go: accept any 2xx response in the HTTP transport

### DIFF
--- a/client/go/pkg/transport/http.go
+++ b/client/go/pkg/transport/http.go
@@ -157,7 +157,7 @@ func (h *httpTransport) Emit(ctx context.Context, event any) (map[string]string,
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		respBody, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("server responded with status %v: %s", resp.StatusCode, respBody)
 	}

--- a/client/go/pkg/transport/http_test.go
+++ b/client/go/pkg/transport/http_test.go
@@ -105,6 +105,34 @@ func TestHTTPTransport_Emit_CreatedStatusAccepted(t *testing.T) {
 	}
 }
 
+// TestHTTPTransport_Emit_AcceptedStatusAccepted verifies that a 202 Accepted
+// response is treated as success, as consumers that queue events answer with it.
+func TestHTTPTransport_Emit_AcceptedStatusAccepted(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t, http.StatusAccepted)
+	tr := newHTTPTransport(t, HTTPConfig{URL: srv.URL})
+
+	_, err := tr.Emit(context.Background(), map[string]string{"k": "v"})
+	if err != nil {
+		t.Errorf("Emit() with 202 Accepted should not return error, got: %v", err)
+	}
+}
+
+// TestHTTPTransport_Emit_ClientErrorStatus verifies that a 4xx response is still
+// reported as an error.
+func TestHTTPTransport_Emit_ClientErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := testServer(t, http.StatusUnauthorized)
+	tr := newHTTPTransport(t, HTTPConfig{URL: srv.URL})
+
+	_, err := tr.Emit(context.Background(), map[string]string{"k": "v"})
+	if err == nil {
+		t.Error("Emit() with 401 Unauthorized should return an error")
+	}
+}
+
 // TestHTTPTransport_Emit_ServerError verifies that a 5xx response from the server
 // is surfaced as an error from Emit.
 func TestHTTPTransport_Emit_ServerError(t *testing.T) {


### PR DESCRIPTION
closes: #4938

### One-line summary for changelog:
Go client: treat any 2xx response as success in the HTTP transport, so `202 Accepted` no longer reports a failure.

### Meaningful description
The Go HTTP transport accepted only `200 OK` and `201 Created`, so a consumer that queues events and answers `202 Accepted` made every `Emit` return an error even though the event had been accepted:

```
server responded with status 202: Event received
```

The Python client raises only for 4xx and 5xx (`response.raise_for_status()`), and the Java client does the same (`HttpTransport.throwOnHttpError` throws when `code >= 400 && code < 600`). This change brings the Go client in line by treating any 2xx as success.

Two tests are added: `202 Accepted` succeeds, and a 4xx is still reported as an error. Verified against a real consumer that answers `202`.

Marked draft only because I raised it unprompted alongside #4938; happy to mark it ready whenever you would like it reviewed.

### Checklist
- [x] AI was used in creating this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBfMWG5AG33JMqGGQgAV6v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP requests now succeed for all 2xx response statuses, including `202 Accepted`.
  - Non-2xx responses, such as `401 Unauthorized`, continue to return an error with status and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->