### PR TITLE
sql: expand wildcards over derived tables, and respect wildcard modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.53.0...HEAD)
 
+### Fixed
+
+* **SQL: Expand wildcards over derived tables, and respect wildcard modifiers** [`#4941`](https://github.com/OpenLineage/OpenLineage/pull/4941) [@lhadhazy](https://github.com/lhadhazy) with [@simonjobs](https://github.com/simonjobs)
+  *Emits column lineage for `SELECT * FROM (SELECT ...)`, and stops reporting columns that `EXCLUDE`, `EXCEPT` or `RENAME` removed or renamed from the output.*
+
 ## [1.53.0](https://github.com/OpenLineage/OpenLineage/compare/1.52.0...1.53.0)
 
 ### Added

--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -81,6 +81,9 @@ pub struct Context<'a> {
     dialect: &'a dyn CanonicalDialect,
     // Used to generate unique names for unaliased columns created from compound expressions
     column_id: u32,
+    // Registry of known column names for CTE tables, keyed by qualified_name().
+    // Populated during With::visit(), consumed during wildcard expansion in Select::visit().
+    cte_column_registry: HashMap<String, Vec<String>>,
 }
 
 impl<'a> Context<'a> {
@@ -94,6 +97,7 @@ impl<'a> Context<'a> {
             default_database: None,
             dialect: &SnowflakeDialect,
             column_id: 0,
+            cte_column_registry: HashMap::new(),
         }
     }
 
@@ -110,6 +114,7 @@ impl<'a> Context<'a> {
             default_database,
             dialect,
             column_id: 0,
+            cte_column_registry: HashMap::new(),
         }
     }
 
@@ -578,6 +583,25 @@ impl<'a> Context<'a> {
             for (alias, t) in old.aliases.tables() {
                 frame.aliases.add_table_alias(t.clone(), alias.clone());
             }
+        }
+    }
+
+    // --- CTE Column Registry ---
+
+    pub fn register_cte_columns(&mut self, table_qualified_name: String, columns: Vec<String>) {
+        self.cte_column_registry
+            .insert(table_qualified_name, columns);
+    }
+
+    pub fn cte_columns(&self, table_qualified_name: &str) -> Option<&Vec<String>> {
+        self.cte_column_registry.get(table_qualified_name)
+    }
+
+    pub fn resolve_table_qualified_name(&self, table: &DbTableMeta) -> String {
+        if let Some(frame) = self.frames.last() {
+            frame.aliases.resolve_table(table).qualified_name()
+        } else {
+            table.qualified_name()
         }
     }
 

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -6,12 +6,12 @@ use crate::lineage::*;
 
 use anyhow::{anyhow, Result};
 use sqlparser::ast::{
-    AccessExpr, AlterTableOperation, CopyIntoSnowflakeKind, CreateTableLikeKind, Expr, FromTable,
-    Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, Join, JoinConstraint,
-    JoinOperator, ObjectName, ObjectNamePart, Query, RenameTableNameKind, Select, SelectItem,
-    SelectItemQualifiedWildcardKind, SetExpr, Statement, Subscript, Table, TableFactor,
-    TableFunctionArgs, TableObject, UpdateTableFromKind, Use, Value, ValueWithSpan, WindowSpec,
-    WindowType, With,
+    AccessExpr, AlterTableOperation, CopyIntoSnowflakeKind, CreateTableLikeKind, ExcludeSelectItem,
+    Expr, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, Join,
+    JoinConstraint, JoinOperator, ObjectName, ObjectNamePart, Query, RenameSelectItem,
+    RenameTableNameKind, Select, SelectItem, SelectItemQualifiedWildcardKind, SetExpr, Statement,
+    Subscript, Table, TableFactor, TableFunctionArgs, TableObject, UpdateTableFromKind, Use, Value,
+    ValueWithSpan, WildcardAdditionalOptions, WindowSpec, WindowType, With,
 };
 use sqlparser::dialect::{DatabricksDialect, MsSqlDialect, SnowflakeDialect};
 
@@ -118,6 +118,16 @@ impl Visit for TableFactor {
                 subquery.visit(context)?;
                 let frame = context.pop_frame().unwrap();
 
+                // Register the subquery's output columns so a wildcard over
+                // this table can be expanded, the same way a CTE's are. The
+                // FROM clause is visited before the projection, so the entry
+                // is in place by the time the wildcard is reached.
+                let col_names: Vec<String> = frame
+                    .column_ancestry
+                    .keys()
+                    .map(|cm| cm.name.clone())
+                    .collect();
+
                 if let Some(alias) = alias {
                     let table = DbTableMeta::new(
                         vec![alias.clone().name],
@@ -125,8 +135,13 @@ impl Visit for TableFactor {
                         context.default_schema().clone(),
                         context.default_database().clone(),
                     );
+                    context.register_cte_columns(table.qualified_name(), col_names);
                     context.collect_with_table(frame, table);
                 } else {
+                    // No alias means no name to key on, so the subquery's own
+                    // text stands in. It is stable within one statement, which
+                    // is all the lookup needs.
+                    context.register_cte_columns(anonymous_derived_key(subquery), col_names);
                     context.collect(frame);
                 }
 
@@ -588,28 +603,40 @@ impl Visit for Select {
                     context.set_column_context(Some(ColumnMeta::new(alias.value.clone(), None)));
                     expr.visit(context)?;
                 }
-                SelectItem::Wildcard(_) => {
+                SelectItem::Wildcard(options) => {
+                    let filter = WildcardFilter::from_options(options);
                     for table_with_joins in &self.from {
                         expand_wildcard_for_table_factor(
                             &table_with_joins.relation,
+                            &filter,
                             context,
                         );
                         for join in &table_with_joins.joins {
-                            expand_wildcard_for_table_factor(&join.relation, context);
+                            expand_wildcard_for_table_factor(&join.relation, &filter, context);
                         }
                     }
                 }
-                SelectItem::QualifiedWildcard(kind, _) => {
-                    if let SelectItemQualifiedWildcardKind::ObjectName(name) = kind {
-                        let table = DbTableMeta::new(
-                            convert_to_idents(name),
-                            context.dialect(),
-                            context.default_schema().clone(),
-                            context.default_database().clone(),
-                        );
-                        expand_wildcard_for_cte_table(&table, context);
-                    }
+                SelectItem::QualifiedWildcard(
+                    SelectItemQualifiedWildcardKind::ObjectName(name),
+                    options,
+                ) => {
+                    let table = DbTableMeta::new(
+                        convert_to_idents(name),
+                        context.dialect(),
+                        context.default_schema().clone(),
+                        context.default_database().clone(),
+                    );
+                    expand_wildcard_for_known_table(
+                        &table,
+                        &WildcardFilter::from_options(options),
+                        context,
+                    );
                 }
+                // Deliberately not exhaustive. sqlparser adds SelectItem
+                // variants between releases — ExprWithAliases arrived in one —
+                // and a bare match here turns an upstream bump into a compile
+                // error in this file rather than a missing case to fill in.
+                _ => {}
             }
         }
 
@@ -1070,19 +1097,162 @@ fn convert_to_idents(object_name: &ObjectName) -> Vec<Ident> {
         .collect()
 }
 
-fn expand_wildcard_for_table_factor(relation: &TableFactor, context: &mut Context) {
-    if let TableFactor::Table { name, .. } = relation {
-        let table = DbTableMeta::new(
-            convert_to_idents(name),
-            context.dialect(),
-            context.default_schema().clone(),
-            context.default_database().clone(),
-        );
-        expand_wildcard_for_cte_table(&table, context);
+/// The modifiers a wildcard can carry, reduced to what expansion needs.
+///
+/// `SELECT *` is rarely bare in practice. Dropping these silently is worse
+/// than reporting no lineage at all: `EXCLUDE (secret)` would otherwise emit
+/// an ordinary-looking edge for a column that is not in the output, and
+/// `RENAME (x AS y)` would report the input name rather than the one a
+/// consumer sees.
+#[derive(Default)]
+struct WildcardFilter {
+    excluded: Vec<String>,
+    renamed: Vec<(String, String)>,
+}
+
+/// The column an `ObjectName` refers to, which is its last part — `secret` in
+/// both `secret` and `t.secret`.
+fn column_name_of(name: &ObjectName) -> Option<String> {
+    convert_to_idents(name).last().map(|i| i.value.clone())
+}
+
+impl WildcardFilter {
+    fn from_options(options: &WildcardAdditionalOptions) -> Self {
+        let mut filter = Self::default();
+
+        if let Some(exclude) = &options.opt_exclude {
+            // These are ObjectNames rather than bare idents, so a qualified
+            // form like EXCLUDE (t.secret) is possible; the column is the
+            // final part either way.
+            match exclude {
+                ExcludeSelectItem::Single(name) => {
+                    filter.excluded.extend(column_name_of(name));
+                }
+                ExcludeSelectItem::Multiple(names) => {
+                    filter
+                        .excluded
+                        .extend(names.iter().filter_map(column_name_of));
+                }
+            }
+        }
+
+        // EXCEPT is the same idea; Snowflake spells it EXCLUDE and BigQuery
+        // and DuckDB spell it EXCEPT.
+        if let Some(except) = &options.opt_except {
+            filter.excluded.push(except.first_element.value.clone());
+            filter
+                .excluded
+                .extend(except.additional_elements.iter().map(|i| i.value.clone()));
+        }
+
+        if let Some(rename) = &options.opt_rename {
+            let pairs = match rename {
+                RenameSelectItem::Single(item) => std::slice::from_ref(item),
+                RenameSelectItem::Multiple(items) => items.as_slice(),
+            };
+            filter.renamed.extend(
+                pairs
+                    .iter()
+                    .map(|p| (p.ident.value.clone(), p.alias.value.clone())),
+            );
+        }
+
+        filter
+    }
+
+    /// The name this column appears under in the output, or `None` if it does
+    /// not appear at all.
+    fn apply(&self, column: &str) -> Option<String> {
+        if self.excluded.iter().any(|e| e == column) {
+            return None;
+        }
+        Some(
+            self.renamed
+                .iter()
+                .find(|(from, _)| from == column)
+                .map(|(_, to)| to.clone())
+                .unwrap_or_else(|| column.to_string()),
+        )
     }
 }
 
-fn expand_wildcard_for_cte_table(table: &DbTableMeta, context: &mut Context) {
+fn expand_wildcard_for_table_factor(
+    relation: &TableFactor,
+    filter: &WildcardFilter,
+    context: &mut Context,
+) {
+    match relation {
+        TableFactor::Table { name, .. } => {
+            let table = DbTableMeta::new(
+                convert_to_idents(name),
+                context.dialect(),
+                context.default_schema().clone(),
+                context.default_database().clone(),
+            );
+            expand_wildcard_for_known_table(&table, filter, context);
+        }
+        // An inline derived table. Its projection is known inside the query
+        // exactly as a CTE's is, so the same uplift applies. An aliased one is
+        // registered under its alias; an unaliased one has no name to key on,
+        // so it is registered under the subquery text instead.
+        TableFactor::Derived {
+            subquery, alias, ..
+        } => {
+            let table = match alias {
+                Some(alias) => DbTableMeta::new(
+                    vec![alias.name.clone()],
+                    context.dialect(),
+                    context.default_schema().clone(),
+                    context.default_database().clone(),
+                ),
+                None => {
+                    expand_wildcard_for_anonymous_derived(subquery, filter, context);
+                    return;
+                }
+            };
+            expand_wildcard_for_known_table(&table, filter, context);
+        }
+        _ => {}
+    }
+}
+
+/// Expand a wildcard over a derived table that has no alias. The columns were
+/// registered under the subquery's own text, which is the only stable handle
+/// available in both places.
+fn expand_wildcard_for_anonymous_derived(
+    subquery: &Query,
+    filter: &WildcardFilter,
+    context: &mut Context,
+) {
+    let key = anonymous_derived_key(subquery);
+    let Some(columns) = context.cte_columns(&key).cloned() else {
+        return;
+    };
+    for column in columns {
+        let Some(output_name) = filter.apply(&column) else {
+            continue;
+        };
+        // No table to attribute to, so the ancestor keeps the subquery's own
+        // resolution, which the frame already carries.
+        context.set_column_context(Some(ColumnMeta::new(output_name.clone(), None)));
+        context.add_column_ancestors(
+            ColumnMeta::new(output_name, None),
+            vec![ColumnMeta::new(column, None)],
+        );
+    }
+}
+
+pub(crate) fn anonymous_derived_key(subquery: &Query) -> String {
+    format!("<derived>{subquery}")
+}
+
+/// Expand a wildcard over a table whose columns are already registered — a
+/// CTE, or a derived table with an alias.
+fn expand_wildcard_for_known_table(
+    table: &DbTableMeta,
+    filter: &WildcardFilter,
+    context: &mut Context,
+) {
     let qn = table.qualified_name();
     let resolved_qn = context.resolve_table_qualified_name(table);
 
@@ -1097,9 +1267,12 @@ fn expand_wildcard_for_cte_table(table: &DbTableMeta, context: &mut Context) {
     };
 
     for col_name in columns {
-        context.set_column_context(Some(ColumnMeta::new(col_name.clone(), None)));
+        let Some(output_name) = filter.apply(&col_name) else {
+            continue;
+        };
+        context.set_column_context(Some(ColumnMeta::new(output_name.clone(), None)));
         context.add_column_ancestors(
-            ColumnMeta::new(col_name.clone(), None),
+            ColumnMeta::new(output_name, None),
             vec![ColumnMeta::new(col_name, Some(table.clone()))],
         );
     }

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -9,8 +9,9 @@ use sqlparser::ast::{
     AccessExpr, AlterTableOperation, CopyIntoSnowflakeKind, CreateTableLikeKind, Expr, FromTable,
     Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, Join, JoinConstraint,
     JoinOperator, ObjectName, ObjectNamePart, Query, RenameTableNameKind, Select, SelectItem,
-    SetExpr, Statement, Subscript, Table, TableFactor, TableFunctionArgs, TableObject,
-    UpdateTableFromKind, Use, Value, ValueWithSpan, WindowSpec, WindowType, With,
+    SelectItemQualifiedWildcardKind, SetExpr, Statement, Subscript, Table, TableFactor,
+    TableFunctionArgs, TableObject, UpdateTableFromKind, Use, Value, ValueWithSpan, WindowSpec,
+    WindowType, With,
 };
 use sqlparser::dialect::{DatabricksDialect, MsSqlDialect, SnowflakeDialect};
 
@@ -36,6 +37,9 @@ impl Visit for With {
                     context.default_schema().clone(),
                     context.default_database().clone(),
                 );
+                let col_names: Vec<String> =
+                    f.column_ancestry.keys().map(|cm| cm.name.clone()).collect();
+                context.register_cte_columns(table.qualified_name(), col_names);
                 context.collect_with_table(f, table);
             }
 
@@ -584,7 +588,28 @@ impl Visit for Select {
                     context.set_column_context(Some(ColumnMeta::new(alias.value.clone(), None)));
                     expr.visit(context)?;
                 }
-                _ => {}
+                SelectItem::Wildcard(_) => {
+                    for table_with_joins in &self.from {
+                        expand_wildcard_for_table_factor(
+                            &table_with_joins.relation,
+                            context,
+                        );
+                        for join in &table_with_joins.joins {
+                            expand_wildcard_for_table_factor(&join.relation, context);
+                        }
+                    }
+                }
+                SelectItem::QualifiedWildcard(kind, _) => {
+                    if let SelectItemQualifiedWildcardKind::ObjectName(name) = kind {
+                        let table = DbTableMeta::new(
+                            convert_to_idents(name),
+                            context.dialect(),
+                            context.default_schema().clone(),
+                            context.default_database().clone(),
+                        );
+                        expand_wildcard_for_cte_table(&table, context);
+                    }
+                }
             }
         }
 
@@ -1043,6 +1068,41 @@ fn convert_to_idents(object_name: &ObjectName) -> Vec<Ident> {
             ObjectNamePart::Function(f) => f.name.clone(),
         })
         .collect()
+}
+
+fn expand_wildcard_for_table_factor(relation: &TableFactor, context: &mut Context) {
+    if let TableFactor::Table { name, .. } = relation {
+        let table = DbTableMeta::new(
+            convert_to_idents(name),
+            context.dialect(),
+            context.default_schema().clone(),
+            context.default_database().clone(),
+        );
+        expand_wildcard_for_cte_table(&table, context);
+    }
+}
+
+fn expand_wildcard_for_cte_table(table: &DbTableMeta, context: &mut Context) {
+    let qn = table.qualified_name();
+    let resolved_qn = context.resolve_table_qualified_name(table);
+
+    let columns = context
+        .cte_columns(&resolved_qn)
+        .or_else(|| context.cte_columns(&qn))
+        .cloned();
+
+    let columns = match columns {
+        Some(cols) => cols,
+        None => return,
+    };
+
+    for col_name in columns {
+        context.set_column_context(Some(ColumnMeta::new(col_name.clone(), None)));
+        context.add_column_ancestors(
+            ColumnMeta::new(col_name.clone(), None),
+            vec![ColumnMeta::new(col_name, Some(table.clone()))],
+        );
+    }
 }
 
 pub fn extract_up_to_two_ident_values(

--- a/integration/sql/impl/tests/column_lineage/mod.rs
+++ b/integration/sql/impl/tests/column_lineage/mod.rs
@@ -5,3 +5,4 @@ pub mod tests_aliases;
 pub mod tests_cte;
 pub mod tests_select;
 pub mod tests_simple;
+pub mod tests_wildcard;

--- a/integration/sql/impl/tests/column_lineage/tests_cte.rs
+++ b/integration/sql/impl/tests/column_lineage/tests_cte.rs
@@ -39,3 +39,233 @@ fn test_simple_cte() {
         ]
     );
 }
+
+#[test]
+fn test_cte_select_star() {
+    let output = test_sql(
+        "WITH data AS (SELECT x.a, x.b, x.c FROM tbl x)
+         SELECT * FROM data",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "a".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "a".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "b".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "b".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "c".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "c".to_string()
+                }]
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_cte_qualified_wildcard() {
+    let output = test_sql(
+        "WITH data AS (SELECT a, b FROM tbl)
+         SELECT data.* FROM data",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "a".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "a".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "b".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "b".to_string()
+                }]
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_cte_wildcard_with_alias() {
+    let output = test_sql(
+        "WITH data AS (SELECT a, b FROM tbl)
+         SELECT d.* FROM data AS d",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "a".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "a".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "b".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("tbl")),
+                    name: "b".to_string()
+                }]
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_chained_cte_wildcard() {
+    let output = test_sql(
+        "WITH
+           d1 AS (SELECT a, b FROM t1),
+           d2 AS (SELECT * FROM d1)
+         SELECT * FROM d2",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "a".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("t1")),
+                    name: "a".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "b".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("t1")),
+                    name: "b".to_string()
+                }]
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_multi_cte_join_wildcard() {
+    let output = test_sql(
+        "WITH
+           d1 AS (SELECT a FROM t1),
+           d2 AS (SELECT b FROM t2)
+         SELECT * FROM d1 JOIN d2 ON d1.a = d2.b",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "a".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("t1")),
+                    name: "a".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "b".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("t2")),
+                    name: "b".to_string()
+                }]
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_cte_mixed_wildcard_and_explicit() {
+    let output = test_sql(
+        "WITH
+           d1 AS (SELECT a FROM t1),
+           d2 AS (SELECT b FROM t2)
+         SELECT d1.*, d2.b FROM d1 JOIN d2 ON d1.a = d2.b",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "a".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("t1")),
+                    name: "a".to_string()
+                }]
+            },
+            ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "b".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("t2")),
+                    name: "b".to_string()
+                }]
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_cte_inner_star_no_lineage() {
+    let output = test_sql(
+        "WITH data AS (SELECT * FROM physical_table)
+         SELECT * FROM data",
+    )
+    .unwrap();
+    assert_eq!(output.column_lineage, vec![]);
+}

--- a/integration/sql/impl/tests/column_lineage/tests_wildcard.rs
+++ b/integration/sql/impl/tests/column_lineage/tests_wildcard.rs
@@ -1,0 +1,125 @@
+// Copyright 2018-2026 contributors to the OpenLineage project
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wildcard expansion beyond the CTE case.
+//!
+//! The CTE form — `WITH d AS (...) SELECT * FROM d` — is handled by the column
+//! registry these tests build on. Two things are not.
+//!
+//! The first is the form issue #3809 actually reports: a wildcard over an
+//! inline derived table, `SELECT * FROM (SELECT a, b, c FROM t)`. The columns
+//! are known inside the query exactly as they are for a CTE, so the same
+//! uplift applies.
+//!
+//! The second is that the modifiers attached to a wildcard are ignored.
+//! `SELECT * EXCLUDE (secret)` reports `secret`, which is worse than reporting
+//! nothing: a consumer sees an ordinary lineage edge for a column that is not
+//! in the output.
+
+use crate::test_utils::{table, test_sql, test_sql_dialect};
+use openlineage_sql::{ColumnLineage, ColumnMeta};
+
+/// `descendant <- origin.source`, in the order the parser emits them.
+fn edge(descendant: &str, origin: &str, source: &str) -> ColumnLineage {
+    ColumnLineage {
+        descendant: ColumnMeta {
+            origin: None,
+            name: descendant.to_string(),
+        },
+        lineage: vec![ColumnMeta {
+            origin: Some(table(origin)),
+            name: source.to_string(),
+        }],
+    }
+}
+
+#[test]
+fn test_derived_table_wildcard() {
+    // The example in the issue. Identical in meaning to
+    // `INSERT INTO t1 SELECT a, b, c FROM t2`, which already works.
+    let output = test_sql("INSERT INTO t1 SELECT * FROM (SELECT a, b, c FROM t2)").unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            edge("a", "t2", "a"),
+            edge("b", "t2", "b"),
+            edge("c", "t2", "c"),
+        ]
+    );
+}
+
+#[test]
+fn test_derived_table_qualified_wildcard() {
+    // The second form in the issue: the derived table is aliased and the
+    // wildcard is qualified by that alias.
+    let output = test_sql("INSERT INTO t1 SELECT tbl.* FROM (SELECT a, b, c FROM t2) tbl").unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            edge("a", "t2", "a"),
+            edge("b", "t2", "b"),
+            edge("c", "t2", "c"),
+        ]
+    );
+}
+
+#[test]
+fn test_derived_table_wildcard_with_extra_column() {
+    // A wildcard alongside an explicit projection: both must survive.
+    let output = test_sql("SELECT *, x AS x2 FROM (SELECT id, x FROM t)").unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![
+            edge("id", "t", "id"),
+            edge("x", "t", "x"),
+            edge("x2", "t", "x"),
+        ]
+    );
+}
+
+#[test]
+fn test_derived_table_inner_star_has_no_lineage() {
+    // The boundary. `SELECT *` over a physical table has no column list to
+    // uplift, and the parser has no schema, so it must stay silent rather than
+    // guess. This mirrors the CTE case's own negative test.
+    let output = test_sql("SELECT * FROM (SELECT * FROM physical_table)").unwrap();
+    assert_eq!(output.column_lineage, vec![]);
+}
+
+#[test]
+fn test_wildcard_exclude_omits_the_excluded_column() {
+    // Snowflake's EXCLUDE. `secret` is not in the output, so reporting lineage
+    // for it is a wrong edge rather than a missing one.
+    let output = test_sql_dialect(
+        "WITH d AS (SELECT id, secret FROM t) SELECT * EXCLUDE (secret) FROM d",
+        "snowflake",
+    )
+    .unwrap();
+    assert_eq!(output.column_lineage, vec![edge("id", "t", "id")]);
+}
+
+#[test]
+fn test_wildcard_except_omits_the_excluded_column() {
+    // The same idea spelled EXCEPT, which is what BigQuery and DuckDB use.
+    let output = test_sql_dialect(
+        "WITH d AS (SELECT id, secret FROM t) SELECT * EXCEPT (secret) FROM d",
+        "bigquery",
+    )
+    .unwrap();
+    assert_eq!(output.column_lineage, vec![edge("id", "t", "id")]);
+}
+
+#[test]
+fn test_wildcard_rename_uses_the_new_name() {
+    // RENAME changes the output column's name. The lineage should follow the
+    // name a consumer will actually see.
+    let output = test_sql_dialect(
+        "WITH d AS (SELECT id, x FROM t) SELECT * RENAME (x AS y) FROM d",
+        "snowflake",
+    )
+    .unwrap();
+    assert_eq!(
+        output.column_lineage,
+        vec![edge("id", "t", "id"), edge("y", "t", "x")]
+    );
+}


### PR DESCRIPTION
closes: #3809

### One-line summary for changelog:

Expand wildcards over derived tables, and stop discarding the modifiers attached to a wildcard.

### Meaningful description

**This PR carries two commits, and the first is not mine.** `sql: add cte column registry for wildcard expansion` is @simonjobs' work from his fork, rebased onto current `main`. He offered it for anyone to continue and it had never been opened here, so it is included rather than reimplemented — the CTE case it solves is what the derived-table case builds on, and separating them would mean either rewriting his code as mine or submitting something that does not compile. His authorship is preserved in the commit.

#### The problem

The parser produces no column lineage for the form this issue reports:

```sql
INSERT INTO t1 SELECT * FROM (SELECT a, b, c FROM t2)
```

which is identical in meaning to `INSERT INTO t1 SELECT a, b, c FROM t2`, and that already works. The projection is known inside the query, so there is nothing to guess at.

A second problem turned up while testing the CTE branch. The match arm bound `SelectItem::Wildcard(_)`, discarding `WildcardAdditionalOptions`, so every modifier attached to a wildcard was ignored:

| SQL | Reported | Correct |
|---|---|---|
| `SELECT * EXCLUDE (secret)` | `id`, `secret` | `secret` is not in the output |
| `SELECT * EXCEPT (secret)` | `id`, `secret` | same, BigQuery spelling |
| `SELECT * RENAME (x AS y)` | `id`, `x` | the output column is `y` |

That is a **wrong edge rather than a missing one**, which seems worse: a missing facet is visibly absent, whereas these look like ordinary lineage. It matters for anything treating lineage as evidence rather than as a browsing aid.

#### The solution

A derived table registers its output columns when it is visited, keyed on its alias, or on the subquery's own text when it has none. The FROM clause is visited before the projection, so the entry is in place by the time a wildcard reaches it. This reuses the registry the first commit introduces rather than adding a second mechanism.

`WildcardFilter` reduces `WildcardAdditionalOptions` to the exclusions and renames expansion needs. EXCLUDE and EXCEPT collapse together, being the Snowflake and BigQuery spellings of one idea.

`expand_wildcard_for_cte_table` becomes `expand_wildcard_for_known_table`, since it now serves CTEs and aliased derived tables both.

#### The boundary is unchanged

A wildcard over a physical table still yields nothing. The parser has no schema there, so guessing would be worse than silence — @tnazarew's point when this issue was opened, and the reason the fix is scoped to projections that are knowable from the query text. There is a test pinning it, alongside the equivalent one for the CTE case.

#### One thing I changed in the first commit

I restored the `_ => {}` arm on the `SelectItem` match. Enumerating every variant turned a `sqlparser` bump into a compile error in this file, and that is not hypothetical: rebasing onto current `main` broke on `SelectItem::ExprWithAliases`, which did not exist when the branch was written. The same rebase needed two other fixes — `ExcludeSelectItem` now carries `ObjectName` rather than `Ident`, and a newer clippy flags the `if let` inside the `QualifiedWildcard` arm.

#### Alternatives considered

Implementing derived-table expansion separately from the CTE registry, which would have duplicated the lookup for no benefit. And keying unaliased derived tables on a counter rather than on the subquery text, which is cheaper but breaks if the visit order ever changes.

#### Tests

Seven added in `tests_wildcard.rs`, six of which fail without this change. **163 pass, none regressed**, including the eight CTE tests from the commit this builds on. Verified with the same three commands CI runs, from the workspace root: `cargo test --no-default-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt -- --check`.

### Checklist
- [x] AI was used in creating this PR


---

#### A note on the sign-off, since it is unusual

The first commit is authored by @simonjobs and **signed off by me rather than by him**. He never opened a PR here, so it carried no sign-off and the DCO check failed on it.

I signed it under DCO clause (b): the work is covered by this project's own Apache-2.0 licence, and it is submitted here with modifications under the same licence. The author field is untouched — GitHub still shows him as the author of that commit, and the commit message records what changed during the rebase.

If you would rather have his own sign-off on it, I am happy to wait for him, or to squash the two commits into one authored by me with a `Co-authored-by` trailer. Whichever you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL column lineage for wildcard selections from CTEs and derived tables.
  - Added support for qualified wildcards, including aliased and nested queries.
  - Correctly applies positional column aliases and preserves projection order.
  - Honors `EXCLUDE`/`EXCEPT` and `RENAME` modifiers with appropriate identifier matching.
  - Preserves source mappings across chained CTEs, joins, and mixed wildcard projections.

- **Tests**
  - Added coverage for wildcard lineage, CTEs, derived tables, nested queries, column aliases, and dialect-specific modifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->